### PR TITLE
perf: speed up monetizationstart

### DIFF
--- a/packages/coil-extension/src/background/services/Stream.ts
+++ b/packages/coil-extension/src/background/services/Stream.ts
@@ -331,7 +331,8 @@ class StreamAttempt {
 
     return new Promise((resolve, reject) => {
       const onMoney = (sentAmount: string) => {
-        this.onMoney(sentAmount)
+        // Wait until `nextTick` so that `connection.totalDelivered` has been updated.
+        process.nextTick(this.onMoney.bind(this), sentAmount)
       }
 
       const onPluginDisconnect = async () => {

--- a/packages/coil-extension/src/background/services/Stream.ts
+++ b/packages/coil-extension/src/background/services/Stream.ts
@@ -331,8 +331,8 @@ class StreamAttempt {
 
     return new Promise((resolve, reject) => {
       const onMoney = (sentAmount: string) => {
-        // Wait until `nextTick` so that `connection.totalDelivered` has been updated.
-        process.nextTick(this.onMoney.bind(this), sentAmount)
+        // Wait until `setImmediate` so that `connection.totalDelivered` has been updated.
+        setImmediate(this.onMoney.bind(this), sentAmount)
       }
 
       const onPluginDisconnect = async () => {

--- a/packages/coil-oauth-scripts/src/Stream.ts
+++ b/packages/coil-oauth-scripts/src/Stream.ts
@@ -173,7 +173,9 @@ export class Stream {
       stream.setSendMax(initialSendMaxAmount)
 
       await new Promise((resolve, reject) => {
-        const boundOutgoingMoney = this.onOutgoingMoney.bind(this, connection)
+        const boundOutgoingMoney = (sentAmount: string) => {
+          setImmediate(this.onOutgoingMoney.bind(this), connection)
+        }
         const onPluginDisconnect = async () => {
           cleanUp()
           stream.destroy()

--- a/packages/coil-oauth-scripts/src/Stream.ts
+++ b/packages/coil-oauth-scripts/src/Stream.ts
@@ -174,7 +174,7 @@ export class Stream {
 
       await new Promise((resolve, reject) => {
         const boundOutgoingMoney = (sentAmount: string) => {
-          setImmediate(this.onOutgoingMoney.bind(this), connection)
+          setImmediate(this.onOutgoingMoney.bind(this), connection, sentAmount)
         }
         const onPluginDisconnect = async () => {
           cleanUp()


### PR DESCRIPTION
In ilp-protocol-stream, `Stream`s emit `"outgoing_money"` events before `connection.totalDelivered` is updated. This resulted in the extension ignoring the first `outgoing_money` event, since it mistakenly assumed that no money was delivered.

In my tests, this shortened the time-to-`monetizationstart` from 2500-2800ms down to 500-700ms.