### PR TITLE
feat(coil-extension): use stricter regex for youtube urls

### DIFF
--- a/packages/coil-extension/src/content/util/getAdaptedSite.ts
+++ b/packages/coil-extension/src/content/util/getAdaptedSite.ts
@@ -1,6 +1,6 @@
 export const ADAPTED_REGEX: Record<string, RegExp> = {
   twitch: /https?:\/\/(www\.)?twitch\.tv(\/.*)?/i,
-  youtube: /https?:\/\/(www\.)?youtube\.com(\/.*)?/i
+  youtube: /https?:\/\/(www\.)?youtube\.com\/(watch|channel)(.*)/i
 }
 
 const ADAPTED_SITES = Object.keys(ADAPTED_REGEX)


### PR DESCRIPTION
Ensures that the extension will only query on video and channel pages, and not on pages like Youtube's homepage or search results pages. Part of [coilhq/coil#2939](https://github.com/coilhq/coil/issues/2939).