### PR TITLE
fix: re-enable slippage=1 and fixed exchangeRate,maxPacketAmount

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
   },
   "resolutions": {
     "@types/react": "^16.9.17",
-    "@types/webpack": "4.41.2",
-    "ilp-protocol-stream": "2.2.0"
+    "@types/webpack": "4.41.2"
   },
   "devDependencies": {
     "@babel/core": "^7.8.3",

--- a/packages/coil-extension/src/background/services/Stream.ts
+++ b/packages/coil-extension/src/background/services/Stream.ts
@@ -323,7 +323,9 @@ class StreamAttempt {
     this._connection = await createConnection({
       ...this._spspDetails,
       plugin,
-      slippage: 0.05
+      slippage: 1.0,
+      exchangeRate: 1.0,
+      maximumPacketAmount: '10000000'
     })
 
     if (!this._active) return

--- a/packages/coil-oauth-scripts/src/Stream.ts
+++ b/packages/coil-oauth-scripts/src/Stream.ts
@@ -178,7 +178,9 @@ export class Stream {
 
       const connection = await IlpStream.createConnection({
         plugin,
-        slippage: 0.05,
+        slippage: 1.0,
+        exchangeRate: 1.0,
+        maximumPacketAmount: '10000000',
         ...details
       })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8443,10 +8443,10 @@ ilp-protocol-ildcp@^2.0.1, ilp-protocol-ildcp@^2.0.2:
     ilp-packet "^3.0.9"
     oer-utils "^5.0.1"
 
-ilp-protocol-stream@2.2.0, ilp-protocol-stream@2.2.1, ilp-protocol-stream@^2.2.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/ilp-protocol-stream/-/ilp-protocol-stream-2.2.0.tgz#e1813ace8b7cbf5bdacc3c2af890946d85a12aa3"
-  integrity sha512-8LPLdG4yf3U4O/SK9RVDIXQG4YNsYs5U+YzhIirMXALgr9DbTrkeUF33GUhE1KDo3WNueziHZugS1nR+o7XC8w==
+ilp-protocol-stream@2.2.1, ilp-protocol-stream@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ilp-protocol-stream/-/ilp-protocol-stream-2.2.1.tgz#8eee1626d18605f385130e8a79b6af0edeab8b7f"
+  integrity sha512-FXbzWTpUaXJv6ETJTr6F5cYFd/heLd9pbJI5TqWekc5ifp0xiE5NX07wjGBj7tlsPFzTTb4EB78h56kjwg5+vw==
   dependencies:
     "@types/node" "^10.14.22"
     ilp-logger "^1.2.1"


### PR DESCRIPTION
The fixed exchange rate &c was reverted in 2babae5 to accommodate a GateHub race condition (see https://github.com/coilhq/coil/issues/3038) which is now fixed.

Closes https://github.com/coilhq/coil/issues/3038.

cc: @traviscrist 