### PR TITLE
misc anonymous token updates

### DIFF
--- a/packages/coil-anonymous-tokens/src/index.ts
+++ b/packages/coil-anonymous-tokens/src/index.ts
@@ -2,7 +2,6 @@ import { randomBytes } from 'crypto'
 
 import { BigInteger } from 'jsbn'
 import {
-  longHash,
   hexString,
   hashAndBlindMessage,
   unblindSignature,
@@ -10,7 +9,7 @@ import {
   PublicRSAKey
 } from 'blind-signature'
 
-export function base64url(buf: Buffer) {
+export function base64url(buf: Buffer): string {
   return buf
     .toString('base64')
     .replace(/\+/g, '-')
@@ -18,9 +17,13 @@ export function base64url(buf: Buffer) {
     .replace(/=/g, '')
 }
 
+function _getRandomToken(): string {
+  return base64url(randomBytes(16))
+}
+
 export const TOKEN_PREFIX = 'anonymous_token:'
 export interface SignedToken {
-  value: string
+  message: string
   month: string
   signature: hexString
 }
@@ -37,7 +40,7 @@ export interface PublicFields extends PublicRSAKey {
 // TODO: should these be allowed to be async?
 // TODO: went for localforage-like, could chang
 export interface TokenStore {
-  getItem: (key: string) => Promise<string>
+  //getItem: (key: string) => Promise<string>
   setItem: (key: string, value: string) => Promise<string>
   removeItem: (key: string) => Promise<void>
   iterate: (
@@ -49,21 +52,66 @@ export interface TokenStore {
   ) => Promise<SignedToken | undefined>
 }
 
-export class AnonymousTokens {
-  private store: TokenStore
+export interface AnonymousTokensOptions {
+  // The `protocol://host` of the coil services.
+  redeemerUrl: string
+  signerUrl: string
+  store: TokenStore
+  debug?: typeof console.log
+}
 
-  constructor(store: TokenStore) {
+export class AnonymousTokens {
+  private redeemerUrl: string
+  private signerUrl: string
+  private store: TokenStore
+  // Maps btpToken => SignedToken.message
+  private tokenMap: Map<string, string> = new Map()
+  private debug: typeof console.log
+
+  constructor({
+    redeemerUrl,
+    signerUrl,
+    store,
+    debug
+  }: AnonymousTokensOptions) {
+    this.redeemerUrl = redeemerUrl
+    this.signerUrl = signerUrl
     this.store = store
+    this.debug = debug || function() {}
   }
 
-  async getToken(): Promise<SignedToken | undefined> {
+  async getToken(): Promise<string | undefined> {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const signedToken = await this._getSignedToken()
+      if (!signedToken) return
+      const response = await fetch(this.redeemerUrl + '/redeem', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(signedToken)
+      })
+      if (response.status === 400) {
+        // The stored token was invalid or expired (the server wouldn't verify it).
+        await this._removeSignedToken(signedToken.message)
+        continue
+      }
+      if (!response.ok) {
+        throw new Error(`failed to redeem token. code=${response.status}`)
+      }
+      const body = await response.json()
+      const btpToken = body.token
+      this.tokenMap.set(btpToken, signedToken.message)
+      return btpToken
+    }
+  }
+
+  private _getSignedToken(): Promise<SignedToken | undefined> {
     return this.store.iterate((blob: string, name: string) => {
       if (name.startsWith(TOKEN_PREFIX)) {
-        const value = name.substring(TOKEN_PREFIX.length)
+        const message = name.substring(TOKEN_PREFIX.length)
         const { signature, month } = JSON.parse(blob)
-
         return {
-          value,
+          message,
           signature,
           month
         }
@@ -71,14 +119,22 @@ export class AnonymousTokens {
     })
   }
 
-  async removeToken(token: SignedToken) {
-    await this.store.removeItem(TOKEN_PREFIX + token.value)
+  removeToken(btpToken: string): Promise<void> {
+    const anonUserId = this.tokenMap.get(btpToken)
+    this.tokenMap.delete(btpToken)
+    if (anonUserId) return this._removeSignedToken(anonUserId)
+    else return Promise.resolve()
   }
 
-  async _getKeyParams(): Promise<PublicFields> {
-    // TODO: get the actual domain/path of redeemer service
-    const paramsRes = await fetch('redeemer.coil.com/parameters')
+  private _removeSignedToken(anonUserId: string): Promise<void> {
+    this.debug('removing token anonUserId=%s', anonUserId)
+    return this.store.removeItem(TOKEN_PREFIX + anonUserId)
+  }
+
+  private async _getKeyParams(): Promise<PublicFields> {
+    const paramsRes = await fetch(this.signerUrl + '/parameters')
     if (!paramsRes.ok) {
+      this.debug('error fetching parameters status=%d', paramsRes.status)
       throw new Error('could not fetch key params from coil')
     }
 
@@ -90,62 +146,85 @@ export class AnonymousTokens {
     }
   }
 
-  async _signToken(
+  private async _signToken(
     blindedTokenHash: hexString,
-    coilAuthToken: string
+    coilAuthToken: string,
+    month: string
   ): Promise<TimestampedSignature> {
-    // TODO: pass the month in here so we don't get errors on month boundary
-    const signRes = await fetch('redeemer.coil.com/sign', {
+    const signRes = await fetch(this.signerUrl + '/sign', {
       method: 'POST',
       headers: {
         authorization: `Bearer ${coilAuthToken}`,
         'content-type': 'application/json'
       },
       body: JSON.stringify({
-        blinded_message_hash: blindedTokenHash
+        blinded_message_hash: blindedTokenHash,
+        month
       })
     })
 
     if (!signRes.ok) {
+      this.debug('token /sign failed status=%d', signRes.status)
       throw new Error(`failed to get token signature. code=${signRes.status}`)
     }
+    const body = await signRes.json()
+    if (!body.success) {
+      this.debug('token /sign failed message=%s', body.mesage)
+      throw new Error(`failed to get token signature. message=${body.message}`)
+    }
 
-    return signRes.json() as Promise<TimestampedSignature>
+    return body as TimestampedSignature
   }
 
-  _getRandomToken() {
-    return base64url(randomBytes(16))
-  }
-
-  // TODO: what's the way to get coil auth token in here?
-  async populateTokens(coilAuthToken: string, tokenCount: number) {
+  async populateTokens(
+    coilAuthToken: string,
+    tokenCount: number
+  ): Promise<void> {
     const key = await this._getKeyParams()
-
-    // TODO: handle errors in here
-    // TODO: we should generate all tokens first so you can't use the timing in
-    // between tokens to learn anything about token or blinding factor
-    for (let i = 0; i < tokenCount; ++i) {
-      const token = this._getRandomToken()
+    const tokens = []
+    // Generate all tokens first so the timing in between tokens can't be used
+    // to learn anything about the token or blinding factor.
+    for (let i = 0; i < tokenCount; i++) {
+      const token = _getRandomToken()
       const {
         blindedMessageHash: blindedTokenHash,
         blindingFactor
       } = hashAndBlindMessage(key, token)
+      tokens.push({ token, blindedTokenHash, blindingFactor })
+    }
 
-      const { month, signature: blindSignature } = await this._signToken(
-        blindedTokenHash,
-        coilAuthToken
-      )
+    let gotTokens = 0
+    for (const tokenData of tokens) {
+      const signPromise = this._signToken(
+        tokenData.blindedTokenHash,
+        coilAuthToken,
+        key.month
+      ).then(({ month, signature: blindSignature }) => {
+        const signature = unblindSignature(
+          key,
+          blindSignature,
+          tokenData.blindingFactor
+        )
+        if (!verifySignature(key, tokenData.token, signature)) {
+          // TODO: how do we handle this properly? invalid signature means the server might be trying to trick us by signing our message with a different key than advertised to try to deanonymize us
+          throw new Error('produced invalid signature!')
+        }
 
-      const signature = unblindSignature(key, blindSignature, blindingFactor)
-      if (!verifySignature(key, token, signature)) {
-        // TODO: how do we handle this properly? invalid signature means the server might be trying to trick us by signing our message with a different key than advertised to try to deanonymize us
-        throw new Error('produced invalid signature!')
-      }
+        return this.store.setItem(
+          TOKEN_PREFIX + tokenData.token,
+          JSON.stringify({ month, signature })
+        )
+      })
+      await signPromise
+        .then(() => gotTokens++)
+        .catch(err => {
+          this.debug('failed to generate token err=%s', err.message)
+        })
+    }
+    this.debug('populateTokens got=%d want=%d tokens', gotTokens, tokenCount)
 
-      await this.store.setItem(
-        TOKEN_PREFIX + token,
-        JSON.stringify({ month, signature })
-      )
+    if (gotTokens === 0) {
+      throw new Error('no anonymous tokens could be prepared')
     }
   }
 }

--- a/packages/coil-extension/package.json
+++ b/packages/coil-extension/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@abraham/reflection": "^0.7.0",
+    "@coil/anonymous-tokens": "^0.0.0",
     "@coil/polyfill-utils": "^0.0.0",
     "@coil/puppeteer-utils": "^0.0.0",
     "@dier-makr/inversify": "^0.0.0",

--- a/packages/coil-extension/src/background/background.ts
+++ b/packages/coil-extension/src/background/background.ts
@@ -5,12 +5,13 @@ import { GraphQlClient } from '@coil/client'
 import { makeLoggerMiddleware } from 'inversify-logger-middleware'
 import { HistoryDb } from '@web-monetization/wext/services'
 
-import { API, COIL_DOMAIN } from '../webpackDefines'
+import { API, COIL_DOMAIN, COIL_REDEEMER, COIL_SIGNER } from '../webpackDefines'
 import { StorageService } from '../services/storage'
 import * as tokens from '../types/tokens'
 import { ClientOptions } from '../services/ClientOptions'
 import { decorateThirdPartyClasses } from '../services/decorateThirdPartyClasses'
 
+import { AnonymousTokens } from './services/AnonymousTokens'
 import { BackgroundScript } from './services/BackgroundScript'
 import { BackgroundStorageService } from './services/BackgroundStorageService'
 import { Stream } from './services/Stream'
@@ -21,11 +22,14 @@ async function configureContainer(container: Container) {
   container.applyMiddleware(logger)
 
   container.bind(tokens.CoilDomain).toConstantValue(COIL_DOMAIN)
+  container.bind(tokens.CoilRedeemerUrl).toConstantValue(COIL_REDEEMER)
+  container.bind(tokens.CoilSignerUrl).toConstantValue(COIL_SIGNER)
   container.bind(tokens.WextApi).toConstantValue(API)
   container.bind(GraphQlClient.Options).to(ClientOptions)
   container.bind(Storage).toConstantValue(localStorage)
   container.bind(StorageService).to(BackgroundStorageService)
   container.bind(Container).toConstantValue(container)
+  container.bind(AnonymousTokens).to(AnonymousTokens)
 
   container
     .bind(Stream)

--- a/packages/coil-extension/src/background/background.ts
+++ b/packages/coil-extension/src/background/background.ts
@@ -11,7 +11,6 @@ import * as tokens from '../types/tokens'
 import { ClientOptions } from '../services/ClientOptions'
 import { decorateThirdPartyClasses } from '../services/decorateThirdPartyClasses'
 
-import { AnonymousTokens } from './services/AnonymousTokens'
 import { BackgroundScript } from './services/BackgroundScript'
 import { BackgroundStorageService } from './services/BackgroundStorageService'
 import { Stream } from './services/Stream'
@@ -29,7 +28,6 @@ async function configureContainer(container: Container) {
   container.bind(Storage).toConstantValue(localStorage)
   container.bind(StorageService).to(BackgroundStorageService)
   container.bind(Container).toConstantValue(container)
-  container.bind(AnonymousTokens).to(AnonymousTokens)
 
   container
     .bind(Stream)

--- a/packages/coil-extension/src/background/services/AnonymousTokens.ts
+++ b/packages/coil-extension/src/background/services/AnonymousTokens.ts
@@ -13,7 +13,7 @@ export class AnonymousTokens extends anonymousTokens.AnonymousTokens {
     @inject(tokens.CoilRedeemerUrl) redeemerUrl: string,
     @inject(tokens.CoilSignerUrl) signerUrl: string,
     @inject(Storage) storage: Storage,
-    @inject(tokens.Logger) debug: Logger
+    @logger('AnonymousTokens') debug: Logger
   ) {
     super({
       redeemerUrl,

--- a/packages/coil-extension/src/background/services/AnonymousTokens.ts
+++ b/packages/coil-extension/src/background/services/AnonymousTokens.ts
@@ -7,6 +7,8 @@ import { Logger, logger } from './utils'
 
 decorate(injectable(), anonymousTokens.AnonymousTokens)
 
+const ANON_TOKEN_BATCH_SIZE = 10
+
 @injectable()
 export class AnonymousTokens extends anonymousTokens.AnonymousTokens {
   constructor(
@@ -19,7 +21,8 @@ export class AnonymousTokens extends anonymousTokens.AnonymousTokens {
       redeemerUrl,
       signerUrl,
       store: new TokenStore(storage),
-      debug
+      debug,
+      batchSize: ANON_TOKEN_BATCH_SIZE
     })
   }
 }

--- a/packages/coil-extension/src/background/services/AnonymousTokens.ts
+++ b/packages/coil-extension/src/background/services/AnonymousTokens.ts
@@ -1,0 +1,61 @@
+import { Container, decorate, inject, injectable } from 'inversify'
+import * as anonymousTokens from '@coil/anonymous-tokens'
+
+import * as tokens from '../../types/tokens'
+
+import { Logger, logger } from './utils'
+
+decorate(injectable(), anonymousTokens.AnonymousTokens)
+
+@injectable()
+export class AnonymousTokens extends anonymousTokens.AnonymousTokens {
+  constructor(
+    @inject(tokens.CoilRedeemerUrl) redeemerUrl: string,
+    @inject(tokens.CoilSignerUrl) signerUrl: string,
+    @inject(Storage) storage: Storage,
+    @inject(tokens.Logger) debug: Logger
+  ) {
+    super({
+      redeemerUrl,
+      signerUrl,
+      store: new TokenStore(storage),
+      debug
+    })
+  }
+}
+
+class TokenStore {
+  private storage: Storage
+  constructor(localStorage: Storage) {
+    this.storage = localStorage
+  }
+
+  setItem(key: string, value: string): Promise<string> {
+    this.storage.setItem(key, value)
+    return Promise.resolve(value)
+  }
+
+  removeItem(key: string): Promise<void> {
+    this.storage.removeItem(key)
+    return Promise.resolve()
+  }
+
+  iterate(
+    fn: (
+      value: string,
+      key: string,
+      iterationNumber: number
+    ) => anonymousTokens.SignedToken | undefined
+  ): Promise<anonymousTokens.SignedToken | undefined> {
+    let i = 0
+    let key
+    while ((key = this.storage.key(i)) !== null) {
+      const value = this.storage.getItem(key)
+      if (value === null) continue
+      const result = fn(value, key, i)
+      if (result) return Promise.resolve(result)
+      i++
+    }
+    return Promise.resolve(undefined)
+  }
+}

--- a/packages/coil-extension/src/background/services/Stream.ts
+++ b/packages/coil-extension/src/background/services/Stream.ts
@@ -188,7 +188,13 @@ export class Stream extends EventEmitter {
           await timeout(1000)
         }
       } catch (e) {
-        if (e.message.includes('exhausted capacity.') && btpToken) {
+        const { ilpReject } = e
+        if (
+          btpToken &&
+          ilpReject &&
+          ilpReject.message === 'exhausted capacity.' &&
+          ilpReject.data.toString() === btpToken
+        ) {
           this._debug('anonymous token exhausted; retrying, err=%s', e.message)
           this._anonTokens.removeToken(btpToken)
           continue

--- a/packages/coil-extension/src/background/services/Stream.ts
+++ b/packages/coil-extension/src/background/services/Stream.ts
@@ -27,7 +27,6 @@ import { Logger, logger } from './utils'
 
 const { timeout } = asyncUtils
 
-const ANON_TOKEN_BATCH_SIZE = 10
 const UPDATE_AMOUNT_TIMEOUT = 2000
 let ATTEMPT = 0
 
@@ -170,7 +169,7 @@ export class Stream extends EventEmitter {
       let btpToken: string | undefined
       let plugin, attempt
       try {
-        btpToken = await this._getBtpToken()
+        btpToken = await this._anonTokens.getToken(this._authToken)
         plugin = await this._makePlugin(btpToken)
         const spspDetails = await this._getSPSPDetails()
         this.container
@@ -204,19 +203,6 @@ export class Stream extends EventEmitter {
 
     this._looping = false
     this._debug('aborted because stream is no longer active.')
-  }
-
-  async _getBtpToken(): Promise<string> {
-    const cachedAnonToken = await this._anonTokens.getToken()
-    if (cachedAnonToken) return cachedAnonToken
-
-    await this._anonTokens.populateTokens(
-      this._authToken,
-      ANON_TOKEN_BATCH_SIZE
-    )
-    const newAnonToken = await this._anonTokens.getToken()
-    if (newAnonToken) return newAnonToken
-    throw new Error('Unable to acquire anonymous token')
   }
 
   async _makePlugin(btpToken: string) {

--- a/packages/coil-extension/src/types/tokens.ts
+++ b/packages/coil-extension/src/types/tokens.ts
@@ -1,5 +1,7 @@
 export * from '@web-monetization/wext/tokens'
 export const CoilDomain = Symbol('CoilDomain')
+export const CoilRedeemerUrl = Symbol('CoilRedeemerUrl')
+export const CoilSignerUrl = Symbol('CoilSignerUrl')
 export const LocalStorageProxy = Symbol('LocalStorageProxy')
 export const ContentRuntime = Symbol('ContentRuntime')
 export const Logger = Symbol('Logger')

--- a/packages/coil-extension/src/webpackDefines.ts
+++ b/packages/coil-extension/src/webpackDefines.ts
@@ -2,6 +2,8 @@
 
 declare const WEBPACK_DEFINE_API: any
 declare const WEBPACK_DEFINE_COIL_DOMAIN: any
+declare const WEBPACK_DEFINE_COIL_REDEEMER: any
+declare const WEBPACK_DEFINE_COIL_SIGNER: any
 
 // This is to support opening the popup.html page in a normal browser tab
 // so that can look at it in various states. An undefined error will be thrown
@@ -16,3 +18,5 @@ try {
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 export const API: typeof window.chrome = api!
 export const COIL_DOMAIN: string = WEBPACK_DEFINE_COIL_DOMAIN
+export const COIL_REDEEMER: string = WEBPACK_DEFINE_COIL_REDEEMER
+export const COIL_SIGNER: string = WEBPACK_DEFINE_COIL_SIGNER

--- a/packages/coil-extension/tsconfig.build.json
+++ b/packages/coil-extension/tsconfig.build.json
@@ -12,6 +12,9 @@
   ],
   "references": [
     {
+      "path": "../coil-anonymous-tokens/tsconfig.build.json"
+    },
+    {
       "path": "../coil-polyfill-utils/tsconfig.build.json"
     },
     {

--- a/packages/coil-extension/webpack.dev.ts
+++ b/packages/coil-extension/webpack.dev.ts
@@ -6,7 +6,9 @@ import { config } from './webpack.common'
 module.exports = merge(config, {
   plugins: [
     new webpack.DefinePlugin({
-      WEBPACK_DEFINE_COIL_DOMAIN: JSON.stringify('http://localhost:3000')
+      WEBPACK_DEFINE_COIL_DOMAIN: JSON.stringify('http://localhost:3000'),
+      WEBPACK_DEFINE_COIL_REDEEMER: JSON.stringify('http://localhost:8081'),
+      WEBPACK_DEFINE_COIL_SIGNER: JSON.stringify('http://localhost:8080')
     })
   ]
 })

--- a/packages/coil-extension/webpack.prod.ts
+++ b/packages/coil-extension/webpack.prod.ts
@@ -6,7 +6,10 @@ import { config } from './webpack.common'
 module.exports = merge(config, {
   plugins: [
     new webpack.DefinePlugin({
-      WEBPACK_DEFINE_COIL_DOMAIN: JSON.stringify('https://coil.com')
+      WEBPACK_DEFINE_COIL_DOMAIN: JSON.stringify('https://coil.com'),
+      // TODO use the real domains
+      WEBPACK_DEFINE_COIL_REDEEMER: JSON.stringify('https://redeemer.coil.com'),
+      WEBPACK_DEFINE_COIL_SIGNER: JSON.stringify('https://signer.coil.com')
     })
   ]
 })

--- a/packages/coil-extension/webpack.staging.ts
+++ b/packages/coil-extension/webpack.staging.ts
@@ -6,7 +6,12 @@ import { config } from './webpack.common'
 module.exports = merge(config, {
   plugins: [
     new webpack.DefinePlugin({
-      WEBPACK_DEFINE_COIL_DOMAIN: JSON.stringify('https://staging.coil.com')
+      WEBPACK_DEFINE_COIL_DOMAIN: JSON.stringify('https://staging.coil.com'),
+      // TODO use the real staging domains (not localhost)
+      //WEBPACK_DEFINE_COIL_REDEEMER: JSON.stringify('https://redeemer.staging.coil.com'),
+      //WEBPACK_DEFINE_COIL_SIGNER: JSON.stringify('https://signer.staging.coil.com')
+      WEBPACK_DEFINE_COIL_REDEEMER: JSON.stringify('http://localhost:8081'),
+      WEBPACK_DEFINE_COIL_SIGNER: JSON.stringify('http://localhost:8080')
     })
   ]
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5119,7 +5119,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
+debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -5340,11 +5340,6 @@ detect-indent@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.0.0.tgz#0abd0f549f69fc6659a254fe96786186b6f528fd"
   integrity sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@3.1.0:
   version "3.1.0"
@@ -7924,7 +7919,7 @@ iconv-lite@0.4.19:
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
   integrity sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -10788,15 +10783,6 @@ ncp@~2.0.0:
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
   integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
-needle@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.0.tgz#6833e74975c444642590e15a750288c5f939b57c"
-  integrity sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -10946,22 +10932,6 @@ node-notifier@^5.4.0, node-notifier@^5.4.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.42:
   version "1.1.43"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.43.tgz#2c6ca237f88ce11d49631f11190bb01f8d0549f2"
@@ -11094,7 +11064,7 @@ npm-package-arg@^7.0.0:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.6, npm-packlist@^1.4.4, npm-packlist@^1.4.6:
+npm-packlist@^1.4.4, npm-packlist@^1.4.6:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.7.tgz#9e954365a06b80b18111ea900945af4f88ed4848"
   integrity sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==
@@ -11150,7 +11120,7 @@ npm-run-path@^3.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -12412,7 +12382,7 @@ rc-config-loader@^3.0.0:
     json5 "^2.1.1"
     require-from-string "^2.0.2"
 
-rc@^1.2.7, rc@^1.2.8, rc@~1.2.7:
+rc@^1.2.8, rc@~1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -13288,7 +13258,7 @@ semver-utils@^1.1.4:
   resolved "https://registry.yarnpkg.com/semver-utils/-/semver-utils-1.1.4.tgz#cf0405e669a57488913909fc1c3f29bf2a4871e2"
   integrity sha512-EjnoLE5OGmDAVV/8YDoN5KiajNadjzIp9BAHOhYeQHt7j0UWxjmgsx4YD48wp4Ue1Qogq38F1GNUJNqF1kKKxA==
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.0.3, semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.0.3, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -14253,7 +14223,7 @@ tar-stream@^1.5.0:
     to-buffer "^1.1.1"
     xtend "^4.0.0"
 
-tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
Note that this is a PR to `bs-anonymous-tokens`, not `master`. Some of these changes depend on https://github.com/coilhq/coil/pull/3071

Open questions:

* Right now to determine if a token is exhausted the extension checks for the substring `"exhausted capacity"` in the error message. Is that Good Enough or should a specific error code be selected (right now it uses `F00`)?
* What domains will the redeemer and signer services run on?