### PR TITLE
feat(coil-extension): fix #175, ignore popup not exist errors

### DIFF
--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -110,7 +110,10 @@ export class BackgroundScript {
         const message: ClosePopup = {
           command: 'closePopup'
         }
-        this.api.runtime.sendMessage(message)
+        this.api.runtime.sendMessage(message, () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const ignored = chrome.runtime.lastError
+        })
 
         this.api.tabs.query({ active: true, currentWindow: true }, tabs => {
           if (tabs.length === 0 || tabs[0].id == null) return

--- a/packages/coil-extension/src/background/services/BackgroundStorageService.ts
+++ b/packages/coil-extension/src/background/services/BackgroundStorageService.ts
@@ -15,7 +15,10 @@ export class BackgroundStorageService extends StorageService {
         command: 'localStorageUpdate',
         key
       }
-      this.api.runtime.sendMessage(message)
+      this.api.runtime.sendMessage(message, () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const ignored = this.api.runtime.lastError
+      })
     })
   }
 }


### PR DESCRIPTION
Simply by accessing `chrome.runtime.lastError` we can avoid the console being littered with errors where messages are sent but no popup is open:

![image](https://user-images.githubusercontent.com/525211/72659633-4ecc3d00-39f5-11ea-9236-75951a8c1a08.png)

This aligns the behavior of Firefox with Chrome which silently ignores these errors.

