### PR TITLE
fix(coil-extension): fix clock skew

### DIFF
--- a/packages/coil-extension/package.json
+++ b/packages/coil-extension/package.json
@@ -53,7 +53,7 @@
     "@web-monetization/wext": "^0.0.0",
     "debug": "^4.1.1",
     "ilp-plugin-btp": "1.4.2",
-    "ilp-protocol-stream": "2.2.1",
+    "ilp-protocol-stream": "2.3.0",
     "inversify": "^5.0.1",
     "inversify-logger-middleware": "^3.1.0",
     "jsonwebtoken": "^8.5.1",

--- a/packages/coil-extension/src/background/services/Stream.ts
+++ b/packages/coil-extension/src/background/services/Stream.ts
@@ -325,7 +325,8 @@ class StreamAttempt {
       plugin,
       slippage: 1.0,
       exchangeRate: 1.0,
-      maximumPacketAmount: '10000000'
+      maximumPacketAmount: '10000000',
+      getExpiry
     })
 
     if (!this._active) return
@@ -487,4 +488,14 @@ class StreamAttempt {
       }
     }
   }
+}
+
+// Use a fixed date in the distant future (2100-01-01T00:00:00.000Z) as the
+// expiry of all outgoing packets. This ensures that payment will work even
+// if the OS's clock is skewed. It will be replaced with a more reasonable
+// expiry by the connector.
+const FAR_FUTURE_EXPIRY = new Date(4102444800000)
+
+function getExpiry(destination: string): Date {
+  return FAR_FUTURE_EXPIRY
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2496,7 +2496,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/long@^4.0.0":
+"@types/long@4.0.0", "@types/long@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
   integrity sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==
@@ -8403,6 +8403,14 @@ ilp-packet@^3.0.8, ilp-packet@^3.0.9:
     extensible-error "^1.0.2"
     oer-utils "^5.0.0"
 
+ilp-packet@^3.1.0-alpha.0:
+  version "3.1.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/ilp-packet/-/ilp-packet-3.1.0-alpha.0.tgz#13bcea0c1d23c3f5129efbbdb804f1eae820a891"
+  integrity sha512-GGzY9ftkfsPXAMlcJEwUCSzewecKKsYmw3gHLIT90YjpgQW56Xr0HDanNEHjnrMyBYkwjUf48zxEB9tHZCVkEw==
+  dependencies:
+    extensible-error "^1.0.2"
+    oer-utils "^5.1.0-alpha.0"
+
 ilp-plugin-btp@1.4.2, ilp-plugin-btp@^1.3.5:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/ilp-plugin-btp/-/ilp-plugin-btp-1.4.2.tgz#1fd975c10dce1f97a14d888ef0db24742641b150"
@@ -8443,6 +8451,15 @@ ilp-protocol-ildcp@^2.0.1, ilp-protocol-ildcp@^2.0.2:
     ilp-packet "^3.0.9"
     oer-utils "^5.0.1"
 
+ilp-protocol-ildcp@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/ilp-protocol-ildcp/-/ilp-protocol-ildcp-2.1.4.tgz#6edb5f0d99e33e7b0df9c105ca26037d229d32c8"
+  integrity sha512-+DUJlbacQTKrI+Pmnz/PH9luX78dOiRTHG+xQzm3MXD0PO0oYLt35t9d+nfzSyba0S+4QQEnAOv8eEnFZwcW0A==
+  dependencies:
+    debug "^3.1.0"
+    ilp-packet "^3.1.0-alpha.0"
+    oer-utils "^5.1.0-alpha.0"
+
 ilp-protocol-stream@2.2.1, ilp-protocol-stream@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ilp-protocol-stream/-/ilp-protocol-stream-2.2.1.tgz#8eee1626d18605f385130e8a79b6af0edeab8b7f"
@@ -8452,6 +8469,18 @@ ilp-protocol-stream@2.2.1, ilp-protocol-stream@^2.2.1:
     ilp-logger "^1.2.1"
     ilp-packet "^3.0.9"
     ilp-protocol-ildcp "^2.0.2"
+    long "^4.0.0"
+    oer-utils "^5.0.1"
+
+ilp-protocol-stream@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/ilp-protocol-stream/-/ilp-protocol-stream-2.3.0.tgz#19bb662da619490d861cc86d390372288e3bf1df"
+  integrity sha512-SpzbyGIFjMnbHI8FBRhRlGI+qNsJh2wufJX+zVMbskBH9TqPf3zbvN5dD6m+d65HDyrKRaTRowdzLW7w+9G05g==
+  dependencies:
+    "@types/node" "^10.14.22"
+    ilp-logger "^1.2.1"
+    ilp-packet "^3.0.9"
+    ilp-protocol-ildcp "^2.1.4"
     long "^4.0.0"
     oer-utils "^5.0.1"
 
@@ -11644,6 +11673,14 @@ oer-utils@^5.0.0, oer-utils@^5.0.1:
   integrity sha512-/+b8EC7RsNBkK+0weoUD55dKa5K2kUAIMM6KY62ssOtu7EyCcqi7idOesaXoUZEYezeZrvu09MOuias/RWVubw==
   dependencies:
     "@types/long" "^4.0.0"
+    long "^4.0.0"
+
+oer-utils@^5.1.0-alpha.0:
+  version "5.1.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/oer-utils/-/oer-utils-5.1.0-alpha.0.tgz#b8b99ad13030140c9b5cebe7953ce4752d4bf73f"
+  integrity sha512-PIjF1+jT6DENZe/WfAHU+F/xZ8aLes+TW6Wpalz2t0k2BoOdCQrgrTL/8z9jtOueR152kjxDox3meJXF+LRh3g==
+  dependencies:
+    "@types/long" "4.0.0"
     long "^4.0.0"
 
 on-finished@~2.3.0:


### PR DESCRIPTION
Ensure that payment succeeds in spite of a client's clock skew.

Send all Prepare packets with a fixed `expiresAt` in the far future (`2100-01-01T00:00:00.000Z`). The connector clamps that using the `maxHoldTime` (30s) before forwarding the Prepare.

Note that this includes https://github.com/interledgerjs/ilp-protocol-stream/pull/128 and https://github.com/interledgerjs/interledgerjs/pull/7.

Fixes https://github.com/coilhq/coil/issues/2903.