### PR TITLE
feat(coil-extension): add iframes impl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   # Run Linting
   lint-all:
     docker:
-      - image: circleci/node:12.14.1-buster-browsers
+        - image: circleci/node:12.16.1-buster-browsers
     steps:
       - checkout
       # Download and cache dependencies
@@ -32,7 +32,7 @@ jobs:
 
   coil-extension-package:
     docker:
-      - image: circleci/node:12.14.1-buster-browsers
+      - image: circleci/node:12.16.1-buster-browsers
     steps:
       - checkout
       - *restore_cache
@@ -56,7 +56,7 @@ jobs:
 
   coil-extension-puppeteer:
     docker:
-      - image: circleci/node:12.14.1-buster-browsers
+      - image: circleci/node:12.16.1-buster-browsers
     steps:
       - checkout
       - *restore_cache
@@ -78,7 +78,7 @@ jobs:
 
   coil-extension-puppeteer-transpile-only:
     docker:
-      - image: circleci/node:12.14.1-buster-browsers
+      - image: circleci/node:12.16.1-buster-browsers
     steps:
       - checkout
       - *restore_cache
@@ -101,7 +101,7 @@ jobs:
 
   build-all-package-references-typescript:
     docker:
-      - image: circleci/node:12.14.1-buster-browsers
+      - image: circleci/node:12.16.1-buster-browsers
     steps:
       - checkout
       - *restore_cache
@@ -114,7 +114,7 @@ jobs:
 
   jest-all:
     docker:
-      - image: circleci/node:12.14.1-buster-browsers
+      - image: circleci/node:12.16.1-buster-browsers
     resource_class: large
     steps:
       - run:
@@ -141,7 +141,7 @@ jobs:
 
   jest-lerna-all:
     docker:
-      - image: circleci/node:12.14.1-buster-browsers
+      - image: circleci/node:12.16.1-buster-browsers
     steps:
       - checkout
       - *restore_cache
@@ -162,7 +162,7 @@ jobs:
 
   coil-oauth-scripts-build:
     docker:
-      - image: circleci/node:12.14.1-buster-browsers
+      - image: circleci/node:12.16.1-buster-browsers
     steps:
       - checkout
       - *restore_cache
@@ -177,7 +177,7 @@ jobs:
 
   yarn-format-and-upkeep-diff-check:
     docker:
-      - image: circleci/node:12.14.1-buster-browsers
+      - image: circleci/node:12.16.1-buster-browsers
     steps:
       - run:
           name: echo TESTING_ENV_VAR $TESTING_ENV_VAR should be empty

--- a/packages/coil-extension/manifest.json
+++ b/packages/coil-extension/manifest.json
@@ -31,5 +31,5 @@
       "run_at": "document_start"
     }
   ],
-  "permissions": [ "activeTab", "storage", "notifications", "tabs", "<all_urls>" ]
+  "permissions": [ "webNavigation", "activeTab", "storage", "notifications", "tabs", "<all_urls>" ]
 }

--- a/packages/coil-extension/src/background/services/BackgroundFramesService.ts
+++ b/packages/coil-extension/src/background/services/BackgroundFramesService.ts
@@ -296,6 +296,14 @@ export class BackgroundFramesService extends EventEmitter {
       makeCallback('onReferenceFragmentUpdated')
     )
 
+    // These are required otherwise there's a race between usages of getFrame()
+    // and the initial `useWebNavigationToUpdateFrames()`
+    this.api.webNavigation.onCommitted.addListener(makeCallback('onCommitted'))
+    this.api.webNavigation.onCompleted.addListener(makeCallback('onCompleted'))
+    this.api.webNavigation.onBeforeNavigate.addListener(
+      makeCallback('onBeforeNavigate')
+    )
+
     this.api.tabs.onRemoved.addListener(tabId => {
       this.log('tabs.onTabRemoved %s', tabId)
       delete this.tabs[tabId]

--- a/packages/coil-extension/src/background/services/BackgroundFramesService.ts
+++ b/packages/coil-extension/src/background/services/BackgroundFramesService.ts
@@ -46,8 +46,6 @@ interface Frame extends Record<string, any> {
    * Will be -1 for topmost iframe
    */
   parentFrameId: number
-
-  allowToken?: string
 }
 
 /**

--- a/packages/coil-extension/src/background/services/BackgroundFramesService.ts
+++ b/packages/coil-extension/src/background/services/BackgroundFramesService.ts
@@ -129,7 +129,9 @@ export class BackgroundFramesService extends EventEmitter {
     const lastUpdateTimeMS = partial.lastUpdateTimeMS ?? Date.now()
     const frame = this.getFrame({ tabId, frameId })
     if (frame && frame.lastUpdateTimeMS > lastUpdateTimeMS) {
-      this.log('ignoring frame update', { tabId, frameId, changed: partial })
+      if (this.traceLogging) {
+        this.log('ignoring frame update', { tabId, frameId, changed: partial })
+      }
       return
     }
     const update = { lastUpdateTimeMS, ...partial }

--- a/packages/coil-extension/src/background/services/BackgroundFramesService.ts
+++ b/packages/coil-extension/src/background/services/BackgroundFramesService.ts
@@ -197,7 +197,7 @@ export class BackgroundFramesService extends EventEmitter {
         if (frame) {
           resolve(frame)
         } else {
-          const spec = JSON.stringify({ tabId, frame })
+          const spec = JSON.stringify({ tabId, frameId })
           reject(new Error(`invalid_frame_spec: can not get frame for ${spec}`))
         }
       })

--- a/packages/coil-extension/src/background/services/BackgroundFramesService.ts
+++ b/packages/coil-extension/src/background/services/BackgroundFramesService.ts
@@ -1,0 +1,456 @@
+import { EventEmitter } from 'events'
+
+import { inject, injectable } from 'inversify'
+import * as tokens from '@web-monetization/wext/tokens'
+
+import { getFrameSpec } from '../../util/tabs'
+import { ToBackgroundMessage } from '../../types/commands'
+import { FrameSpec } from '../../types/FrameSpec'
+
+import { logger, Logger } from './utils'
+
+import GetFrameResultDetails = chrome.webNavigation.GetFrameResultDetails
+import MessageSender = chrome.runtime.MessageSender
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+interface Frame extends Record<string, any> {
+  // TODO: this seems useless actually
+  lastUpdateTimeMS: number
+
+  /**
+   *loading
+   *    The document is still loading.
+   * interactive
+   *    The document has finished loading and the document has been parsed but
+   *    sub-resources such as images, stylesheets and frames are still loading.
+   * complete
+   *    The document and all sub-resources have finished loading. The state
+   *    indicates that the load event is about to fire.
+   */
+  state: Document['readyState'] | null
+  /**
+   * Url kept up to date via webNavigation apis and content script
+   * readystatechange listener messages
+   */
+  href: string
+  /**
+   * Top iframe
+   */
+  top: boolean
+  /**
+   * Will be 0 for topmost iframe
+   */
+  frameId: number
+
+  /**
+   * Will be -1 for topmost iframe
+   */
+  parentFrameId: number
+
+  allowToken?: string
+}
+
+/**
+ * We don't check for state, which could be null (a transient state where
+ * it is undetermined due to webNavigation api limitations)
+ *
+ * Note that in the case where don't have the state we inject a script to send
+ * a message to the frames content script to send a message with the current
+ * document.readyState.
+ *
+ */
+const isFullFrame = (partial: Partial<Frame>): partial is Frame => {
+  return Boolean(
+    // typeof partial.state === 'string' &&
+    typeof partial.frameId === 'number' &&
+      typeof partial.parentFrameId === 'number' &&
+      typeof partial.href === 'string' &&
+      typeof partial.top === 'boolean' &&
+      typeof partial.lastUpdateTimeMS === 'number'
+  )
+}
+
+export interface FrameEvent {
+  type: string
+  from: string
+  tabId: number
+  frameId: number
+}
+
+export interface FrameEventWithFrame extends FrameEvent {
+  frame: Frame
+}
+
+export interface FrameRemovedEvent extends FrameEvent {
+  type: 'frameRemoved'
+}
+
+export interface FrameAddedEvent extends FrameEventWithFrame {
+  type: 'frameAdded'
+}
+
+export interface FrameChangedEvent extends FrameEventWithFrame {
+  type: 'frameChanged'
+  changed: Partial<Frame>
+}
+
+@injectable()
+export class BackgroundFramesService extends EventEmitter {
+  tabs: Record<number, Array<Frame>> = {}
+  traceLogging = false
+  logTabsInterval = 0
+
+  // noinspection TypeScriptFieldCanBeMadeReadonly
+  constructor(
+    @logger('BackgroundFramesService')
+    private log: Logger,
+    @inject(tokens.WextApi)
+    private api: typeof window.chrome
+  ) {
+    super()
+  }
+
+  getFrame(frame: FrameSpec): Readonly<Frame> | undefined {
+    const frames = this.getFrames(frame.tabId)
+    return frames.find(f => {
+      return f.frameId == frame.frameId
+    })
+  }
+
+  getFrames(tabId: number): Array<Readonly<Frame>> {
+    return (this.tabs[tabId] = this.tabs[tabId] ?? [])
+  }
+
+  updateOrAddFrame(
+    from: string,
+    tabId: number,
+    frameId: number,
+    partial: Readonly<Partial<Frame>>
+  ) {
+    const lastUpdateTimeMS = partial.lastUpdateTimeMS ?? Date.now()
+    const frame = this.getFrame({ tabId, frameId })
+    if (frame && frame.lastUpdateTimeMS > lastUpdateTimeMS) {
+      this.log('ignoring frame update', { tabId, frameId, changed: partial })
+      return
+    }
+    const update = { lastUpdateTimeMS, ...partial }
+    const frames = this.getFrames(tabId)
+    const changed: Partial<Frame> = {}
+    let changes = 0
+
+    if (!frame) {
+      if (isFullFrame(update)) {
+        frames.push(update)
+        const event: FrameAddedEvent = {
+          type: 'frameAdded',
+          from,
+          tabId,
+          frameId,
+          frame: update
+        }
+        const changedEvent: FrameChangedEvent = {
+          ...event,
+          type: 'frameChanged',
+          changed: update
+        }
+        this.emit(event.type, event)
+        this.emit(changedEvent.type, changedEvent)
+      } else {
+        this.log(
+          'ERROR in frameAdded from=%s update=%s',
+          from,
+          JSON.stringify(update)
+        )
+      }
+    } else if (frame) {
+      Object.entries(update).forEach(([key, val]) => {
+        if (frame[key] !== val && val != null) {
+          // Mutate the frame in place
+          ;(frame as Frame)[key] = val
+          changed[key] = val
+          if (key !== 'lastUpdateTimeMS') {
+            changes++
+          }
+        }
+      })
+      if (changes) {
+        const changedEvent: FrameChangedEvent = {
+          type: 'frameChanged',
+          from,
+          tabId,
+          frameId,
+          changed,
+          frame
+        }
+        this.emit(changedEvent.type, changedEvent)
+      }
+    }
+  }
+
+  private async getWebNavigationFrame(
+    tabId: number,
+    frameId: number
+  ): Promise<GetFrameResultDetails> {
+    return new Promise((resolve, reject) => {
+      this.api.webNavigation.getFrame({ tabId, frameId }, frame => {
+        if (frame) {
+          resolve(frame)
+        } else {
+          const spec = JSON.stringify({ tabId, frame })
+          reject(new Error(`invalid_frame_spec: can not get frame for ${spec}`))
+        }
+      })
+    })
+  }
+
+  monitor() {
+    const events = ['frameChanged', 'frameAdded', 'frameRemoved'] as const
+    events.forEach(e => {
+      this.on(e, (event: FrameEvent) => {
+        this.log(e, JSON.stringify(event, null, 2))
+      })
+    })
+
+    /**
+     * Be wary of context invalidation during extension reloading causing
+     * confusion here.
+     *
+     * This will pick up state from tabs which need reloading to refresh the
+     * context state.
+     *
+     * Perhaps should periodically prune, at least in dev mode.
+     *
+     * TODO: Is there a webNavigation (read: not content script) API for
+     *       determining window unload ?
+     *
+     * {@see Frames#sendUnloadMessage}
+     */
+    this.api.tabs.query({}, tabs => {
+      tabs.forEach(tab => {
+        if (tab.id) {
+          this.useWebNavigationToUpdateFrames(tab.id)
+        }
+      })
+    })
+
+    if (this.logTabsInterval) {
+      setInterval(() => {
+        this.logTabs()
+      }, this.logTabsInterval)
+    }
+
+    const makeCallback = (event: string) => {
+      return (details: {
+        url: string
+        tabId: number
+        frameId: number
+        parentFrameId?: number
+      }) => {
+        if (
+          !details.url.startsWith('http') ||
+          (details.parentFrameId !== 0 && details.frameId !== 0)
+        ) {
+          return
+        }
+        const frameSpec = {
+          tabId: details.tabId,
+          frameId: details.frameId
+        }
+        const frame = this.getFrame(frameSpec)
+        this.log('webNavigation.' + event)
+        if (this.traceLogging) {
+          this.log(
+            'webNavigation.%s details:%s frame=%s',
+            event,
+            JSON.stringify(details),
+            JSON.stringify({ frame })
+          )
+        }
+        const partial = {
+          href: details.url,
+          frameId: details.frameId,
+          parentFrameId: details.parentFrameId,
+          state: null,
+          top: details.frameId === 0
+        }
+        this.updateOrAddFrame(
+          `webNavigation.${event}`,
+          details.tabId,
+          details.frameId,
+          partial
+        )
+        if (this.getFrame(frameSpec)?.state == null) {
+          this.requestFrameState(frameSpec)
+        }
+      }
+    }
+
+    this.api.webNavigation.onHistoryStateUpdated.addListener(
+      makeCallback('onHistoryStateUpdated')
+    )
+    this.api.webNavigation.onReferenceFragmentUpdated.addListener(
+      makeCallback('onReferenceFragmentUpdated')
+    )
+
+    this.api.tabs.onRemoved.addListener(tabId => {
+      this.log('tabs.onTabRemoved %s', tabId)
+      delete this.tabs[tabId]
+    })
+
+    this.api.runtime.onMessage.addListener(
+      (message: ToBackgroundMessage, sender) => {
+        // Important: On Firefox, don't return a Promise directly (e.g. async
+        // function) else other listeners do not get run!!
+        // See: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage
+        void this.onMessageAsync(sender, message)
+      }
+    )
+  }
+
+  private async onMessageAsync(
+    sender: MessageSender,
+    message: ToBackgroundMessage
+  ) {
+    if (!sender.tab) {
+      this.log('onMessage, no tab', JSON.stringify({ message, sender }))
+      return
+    }
+
+    const { tabId, frameId } = getFrameSpec(sender)
+
+    if (message.command === 'unloadFrame') {
+      this.log('unloadFrame %s', frameId, message.data)
+      const frames = (this.tabs[tabId] = this.tabs[tabId] ?? [])
+      const ix = frames.findIndex(f => f.frameId === frameId)
+      if (ix !== -1) {
+        this.log('removing', ix)
+        frames.splice(ix, 1)
+        const removedEvent: FrameRemovedEvent = {
+          from: 'unloadFrame',
+          type: 'frameRemoved',
+          frameId,
+          tabId
+        }
+        this.emit(removedEvent.type, removedEvent)
+      }
+      if (frames.length === 0) {
+        delete this.tabs[tabId]
+      }
+    } else if (message.command === 'frameStateChange') {
+      if (this.traceLogging) {
+        this.log(
+          'frameStateChange, frameId=%s, tabId=%s, message=%s',
+          sender.frameId,
+          tabId,
+          JSON.stringify(message, null, 2)
+        )
+      }
+
+      const { href, state } = message.data
+      const frame = this.getFrame({ tabId, frameId })
+      if (frame) {
+        // top and frameId, parentFrameId don't change
+        this.updateOrAddFrame('frameStateChange', tabId, frameId, {
+          href,
+          state
+        })
+      } else {
+        const navFrame = await this.getWebNavigationFrame(tabId, frameId)
+        this.updateOrAddFrame('frameStateChange', tabId, frameId, {
+          frameId,
+          href: navFrame.url,
+          state,
+          top: frameId === 0,
+          parentFrameId: navFrame.parentFrameId
+        })
+      }
+    }
+  }
+
+  private useWebNavigationToUpdateFrames(tabId: number) {
+    this.api.webNavigation.getAllFrames({ tabId }, frames => {
+      frames?.forEach(frame => {
+        if (
+          !frame.url.startsWith('http') ||
+          (frame.frameId !== 0 && frame.parentFrameId !== 0)
+        ) {
+          return
+        }
+        this.updateOrAddFrame(
+          'useWebNavigationToUpdateFrames',
+          tabId,
+          frame.frameId,
+          {
+            frameId: frame.frameId,
+            top: frame.frameId === 0,
+            href: frame.url,
+            state: null,
+            parentFrameId: frame.parentFrameId
+          }
+        )
+        const frameSpec = { tabId, frameId: frame.frameId }
+        if (this.getFrame(frameSpec)?.state == null) {
+          this.requestFrameState(frameSpec)
+        }
+      })
+    })
+  }
+
+  /**
+   * Somewhat interestingly, this seems to work even when a content script context
+   * is invalidated.
+   */
+  private requestFrameState({ tabId, frameId }: FrameSpec) {
+    this.api.tabs.executeScript(
+      tabId,
+      {
+        frameId: frameId,
+        // language=JavaScript
+        code: `
+          (function sendMessage() {
+            const frameStateChange = {
+              command: 'frameStateChange',
+              data: {
+                state: document.readyState,
+                href: window.location.href
+              }
+            }
+            chrome.runtime.sendMessage(frameStateChange)
+          })()
+        `
+      },
+      () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const ignored = this.api.runtime.lastError
+      }
+    )
+  }
+
+  private logTabs() {
+    this.log('tabs', JSON.stringify(this.tabs, null, 2))
+  }
+}
+
+export type FrameEvents =
+  | FrameAddedEvent
+  | FrameRemovedEvent
+  | FrameChangedEvent
+
+export type FramesEventType = FrameEvents['type']
+
+export interface FramesEventMap extends Record<FramesEventType, FrameEvents> {
+  frameAdded: FrameAddedEvent
+  frameRemoved: FrameRemovedEvent
+  frameChanged: FrameChangedEvent
+}
+export interface BackgroundFramesService extends EventEmitter {
+  on<T extends FramesEventType>(
+    event: T,
+    listener: (ev: FramesEventMap[T]) => void
+  ): this
+  once<T extends FramesEventType>(
+    event: T,
+    listener: (ev: FramesEventMap[T]) => void
+  ): this
+  emit<T extends FramesEventType>(event: T, ev: FramesEventMap[T]): boolean
+}

--- a/packages/coil-extension/src/background/services/BackgroundFramesService.ts
+++ b/packages/coil-extension/src/background/services/BackgroundFramesService.ts
@@ -98,6 +98,7 @@ export interface FrameChangedEvent extends FrameEventWithFrame {
 export class BackgroundFramesService extends EventEmitter {
   tabs: Record<number, Array<Frame>> = {}
   traceLogging = false
+  logEvents = false
   logTabsInterval = 0
 
   // noinspection TypeScriptFieldCanBeMadeReadonly
@@ -205,11 +206,14 @@ export class BackgroundFramesService extends EventEmitter {
 
   monitor() {
     const events = ['frameChanged', 'frameAdded', 'frameRemoved'] as const
-    events.forEach(e => {
-      this.on(e, (event: FrameEvent) => {
-        this.log(e, JSON.stringify(event, null, 2))
+
+    if (this.logEvents) {
+      events.forEach(e => {
+        this.on(e, (event: FrameEvent) => {
+          this.log(e, JSON.stringify(event, null, 2))
+        })
       })
-    })
+    }
 
     /**
      * Be wary of context invalidation during extension reloading causing

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -742,7 +742,8 @@ export class BackgroundScript {
   }
 
   _closeStreams(tabId: number, frameId?: number) {
-    const streamIds = this.assoc.getTabStreams(tabId)
+    // Make a copy
+    const streamIds = { ...this.assoc.getTabStreams(tabId) }
     const haveFrameId = typeof frameId !== 'undefined'
 
     let closed = 0

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -497,17 +497,6 @@ export class BackgroundScript {
     const { tabId, frameId } = frame
 
     if (frameId !== 0) {
-      // Handle race between monetization tag driven frame checking and
-      // framesService frame info.
-      // TODO: ?
-      let iterations = 5
-      while (!this.framesService.getFrame(frame)) {
-        await timeout(50)
-        if (--iterations === 0) {
-          throw new Error()
-        }
-      }
-
       const parentId = this.framesService.getFrame(frame)?.parentFrameId
       if (typeof parentId === 'undefined') {
         throw new Error(
@@ -608,8 +597,8 @@ export class BackgroundScript {
       emitPending()
     }
 
-    const lastCommand = this.tabStates.get(tabId).frameStates[frameId]
-      .lastMonetization.command
+    const lastCommand = this.tabStates.getFrameState(frame).lastMonetization
+      .command
     if (lastCommand !== 'start') {
       this.log('startWebMonetization cancelled via', lastCommand)
       return false

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -402,10 +402,9 @@ export class BackgroundScript {
       this.reloadTabState()
     }
 
-    // Channel image is provided if site is adapted
-    if (this.storage.getBoolean('adapted')) {
-      // Load favicon from this.runTime
-
+    // TODO: this doesn't actually seem to be used anywhere
+    // Channel image is provided if top frame is adapted
+    if (tabState.frameStates[0].adapted) {
       const { host } = new URL(senderUrl)
       this.favIcons
         .getFavicon(host)

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -597,8 +597,7 @@ export class BackgroundScript {
       emitPending()
     }
 
-    const lastCommand = this.tabStates.getFrameState(frame).lastMonetization
-      .command
+    const lastCommand = this.tabStates.getFrame(frame).lastMonetization.command
     if (lastCommand !== 'start') {
       this.log('startWebMonetization cancelled via', lastCommand)
       return false

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -616,10 +616,14 @@ export class BackgroundScript {
     return true
   }
 
-  private async sendTip() {
-    const tab = this.activeTab
-    // TODO
-    const stream = this.streams.getStream('')
+  private async sendTip(): Promise<{ success: boolean }> {
+    const tabId = this.activeTab
+    const streamId = this.assoc.getStreamId({ tabId, frameId: 0 })
+    if (!streamId) {
+      this.log('can not find top frame for tabId=%d', tabId)
+      return { success: false }
+    }
+    const stream = this.streams.getStream(streamId)
     const token = this.auth.getStoredToken()
 
     // TODO: return detailed errors

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -616,7 +616,7 @@ export class BackgroundScript {
     }
 
     this.log('starting stream', requestId)
-    this.assoc.setStreamID(frame, requestId)
+    this.assoc.setStreamId(frame, requestId)
     this.assoc.setFrame(requestId, { tabId, frameId })
     this.streams.beginStream(requestId, {
       token,
@@ -671,7 +671,7 @@ export class BackgroundScript {
 
   private doPauseWebMonetization(frame: FrameSpec) {
     this.tabStates.logLastMonetizationCommand(frame, 'pause')
-    const id = this.assoc.getStreamID(frame)
+    const id = this.assoc.getStreamId(frame)
     if (id) {
       this.log('pausing stream', id)
       this.streams.pauseStream(id)
@@ -683,7 +683,7 @@ export class BackgroundScript {
   private doResumeWebMonetization(frame: FrameSpec) {
     this.tabStates.logLastMonetizationCommand(frame, 'resume')
 
-    const id = this.assoc.getStreamID(frame)
+    const id = this.assoc.getStreamId(frame)
     if (id) {
       this.log('resuming stream', id)
       this.sendSetMonetizationStateMessage(frame, 'pending')
@@ -725,7 +725,7 @@ export class BackgroundScript {
     const closed = this._closeStreams(frame.tabId, frame.frameId)
     // May be noop other side if stop monetization was initiated from
     // ContentScript
-    const requestId = this.assoc.getStreamID(frame)
+    const requestId = this.assoc.getStreamId(frame)
     this.sendSetMonetizationStateMessage(frame, 'stopped', requestId)
     if (closed) {
       this.tabStates.clearFrame(frame)
@@ -745,7 +745,7 @@ export class BackgroundScript {
       command: 'setMonetizationState',
       data: {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        requestId: (this.assoc.getStreamID({ tabId, frameId }) ?? requestId)!,
+        requestId: (this.assoc.getStreamId({ tabId, frameId }) ?? requestId)!,
         state
       }
     }

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -776,7 +776,7 @@ export class BackgroundScript {
     for (const tabId of this.tabStates.tabKeys()) {
       // Make a copy as _closeStreams mutates and we want to actually close
       // the streams before we set the state to stopped.
-      const requestIds = this.assoc.getTabStreams(tabId)
+      const requestIds = { ...this.assoc.getTabStreams(tabId) }
       this._closeStreams(tabId)
       this.tabStates.clear(tabId)
       Object.entries(requestIds).forEach(([frameId, requestId]) => {

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -223,8 +223,8 @@ export class BackgroundScript {
   private routeStreamsMoneyEventsToContentScript() {
     // pass stream monetization events to the correct tab
     this.streams.on('money', (details: StreamMoneyEvent) => {
-      const spec = this.streamsToFrames[details.requestId]
-      const { tabId, frameId } = spec
+      const frame = this.streamsToFrames[details.requestId]
+      const { tabId, frameId } = frame
       if (details.packetNumber === 0) {
         const message: MonetizationStart = {
           command: 'monetizationStart',
@@ -247,7 +247,7 @@ export class BackgroundScript {
           sentAmount: details.sentAmount
         }
       }
-      this.handleMonetizedSite(spec, details.initiatingUrl, details)
+      this.handleMonetizedSite(frame, details.initiatingUrl, details)
       this.api.tabs.sendMessage(tabId, message, { frameId })
       this.savePacketToHistoryDb(details)
     })

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -759,7 +759,7 @@ export class BackgroundScript {
         closed++
       })
       if (haveFrameId) {
-        this.assoc.clearFrameStream(tabId, frameId as number)
+        this.assoc.clearStream({ tabId, frameId: frameId as number })
       } else {
         this.assoc.clearTabStreams(tabId)
       }

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -714,10 +714,10 @@ export class BackgroundScript {
 
   private doStopWebMonetization(frame: FrameSpec) {
     this.tabStates.logLastMonetizationCommand(frame, 'stop')
+    const requestId = this.assoc.getStreamId(frame)
     const closed = this._closeStreams(frame.tabId, frame.frameId)
     // May be noop other side if stop monetization was initiated from
     // ContentScript
-    const requestId = this.assoc.getStreamId(frame)
     this.sendSetMonetizationStateMessage(frame, 'stopped', requestId)
     if (closed) {
       this.tabStates.clearFrame(frame)

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -806,7 +806,7 @@ export class BackgroundScript {
       const checkAllowed: CheckAllowedIFrames = {
         command: 'checkAllowedIFrames',
         data: {
-          frameUuid: request.data.frameUuid
+          forAllowToken: request.data.allowToken
         }
       }
       this.api.tabs.sendMessage(frame.tabId, checkAllowed, {

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -741,8 +741,7 @@ export class BackgroundScript {
   }
 
   _closeStreams(tabId: number, frameId?: number) {
-    // Make a copy
-    const streamIds = { ...this.assoc.getTabStreams(tabId) }
+    const streamIds = this.assoc.getTabStreams(tabId)
     const haveFrameId = typeof frameId !== 'undefined'
 
     let closed = 0

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -430,9 +430,9 @@ export class BackgroundScript {
     packet: { sentAmount: string }
   ) {
     const tabState = this.tabStates.get(tabId)
-    const tabTotal = tabState?.frameStates[frameId]?.total ?? 0
-    const newTabTotal = tabTotal + Number(packet?.sentAmount ?? 0)
-    this.setTabMonetized({ tabId, frameId }, url, newTabTotal)
+    const frameTotal = tabState?.frameStates[frameId]?.total ?? 0
+    const newFrameTotal = frameTotal + Number(packet?.sentAmount ?? 0)
+    this.setTabMonetized({ tabId, frameId }, url, newFrameTotal)
   }
 
   adaptedSite(data: AdaptedSite['data'], sender: MessageSender) {

--- a/packages/coil-extension/src/background/services/StreamAssociations.ts
+++ b/packages/coil-extension/src/background/services/StreamAssociations.ts
@@ -40,7 +40,7 @@ export class StreamAssociations {
   clearFrameStream(tabId: number, frameId: number) {
     const tabsToFramesToStream = this.tabsToFramesToStreams[tabId]
     if (tabsToFramesToStream) {
-      delete tabsToFramesToStream[frameId as number]
+      delete tabsToFramesToStream[frameId]
     }
   }
 

--- a/packages/coil-extension/src/background/services/StreamAssociations.ts
+++ b/packages/coil-extension/src/background/services/StreamAssociations.ts
@@ -1,0 +1,53 @@
+import { FrameSpec } from '../../types/FrameSpec'
+
+export class StreamAssociations {
+  // TODO: extract these two variables into some kind of service
+  private tabsToFramesToStreams: {
+    [tab: number]: Record<
+      // frameId
+      number,
+      // streamId
+      string
+    >
+  } = {}
+
+  private streamsToFrames: {
+    [stream: string]: FrameSpec
+  } = {}
+
+  getTabStreams(tabId: number) {
+    return { ...this.tabsToFramesToStreams[tabId] }
+  }
+
+  clearTabStreams(tabId: number) {
+    delete this.tabsToFramesToStreams[tabId]
+  }
+
+  clearFrame(streamId: string) {
+    delete this.streamsToFrames[streamId]
+  }
+
+  getFrame(streamId: string) {
+    return this.streamsToFrames[streamId]
+  }
+
+  setFrame(streamId: string, frame: FrameSpec) {
+    this.streamsToFrames[streamId] = frame
+  }
+
+  clearFrameStream(tabId: number, frameId: number) {
+    delete this.tabsToFramesToStreams[tabId][frameId as number]
+  }
+
+  getStreamID({ tabId, frameId }: FrameSpec) {
+    return this.tabsToFramesToStreams[tabId]
+      ? this.tabsToFramesToStreams[tabId][frameId]
+      : undefined
+  }
+
+  setStreamID({ tabId, frameId }: FrameSpec, streamId: string) {
+    const ensured = (this.tabsToFramesToStreams[tabId] =
+      this.tabsToFramesToStreams[tabId] ?? {})
+    ensured[frameId] = streamId
+  }
+}

--- a/packages/coil-extension/src/background/services/StreamAssociations.ts
+++ b/packages/coil-extension/src/background/services/StreamAssociations.ts
@@ -4,7 +4,6 @@ import { FrameSpec } from '../../types/FrameSpec'
 
 @injectable()
 export class StreamAssociations {
-  // TODO: extract these two variables into some kind of service
   private tabsToFramesToStreams: {
     [tab: number]: Record<
       // frameId
@@ -15,7 +14,7 @@ export class StreamAssociations {
   } = {}
 
   private streamsToFrames: {
-    [stream: string]: FrameSpec
+    [streamId: string]: FrameSpec
   } = {}
 
   getTabStreams(tabId: number) {
@@ -42,13 +41,13 @@ export class StreamAssociations {
     delete this.tabsToFramesToStreams[tabId][frameId as number]
   }
 
-  getStreamID({ tabId, frameId }: FrameSpec) {
+  getStreamId({ tabId, frameId }: FrameSpec) {
     return this.tabsToFramesToStreams[tabId]
       ? this.tabsToFramesToStreams[tabId][frameId]
       : undefined
   }
 
-  setStreamID({ tabId, frameId }: FrameSpec, streamId: string) {
+  setStreamId({ tabId, frameId }: FrameSpec, streamId: string) {
     const ensured = (this.tabsToFramesToStreams[tabId] =
       this.tabsToFramesToStreams[tabId] ?? {})
     ensured[frameId] = streamId

--- a/packages/coil-extension/src/background/services/StreamAssociations.ts
+++ b/packages/coil-extension/src/background/services/StreamAssociations.ts
@@ -5,9 +5,12 @@ import { FrameSpec } from '../../types/FrameSpec'
 @injectable()
 export class StreamAssociations {
   private tabsToFramesToStreams: {
-    [tab: number]: {
-      [frameId: number]: string // streamId
-    }
+    [tab: number]: Record<
+      // frameId
+      number,
+      // streamId
+      string
+    >
   } = {}
 
   private streamsToFrames: {
@@ -15,7 +18,7 @@ export class StreamAssociations {
   } = {}
 
   getTabStreams(tabId: number) {
-    return this.tabsToFramesToStreams[tabId]
+    return { ...this.tabsToFramesToStreams[tabId] }
   }
 
   clearTabStreams(tabId: number) {

--- a/packages/coil-extension/src/background/services/StreamAssociations.ts
+++ b/packages/coil-extension/src/background/services/StreamAssociations.ts
@@ -1,5 +1,8 @@
+import { injectable } from 'inversify'
+
 import { FrameSpec } from '../../types/FrameSpec'
 
+@injectable()
 export class StreamAssociations {
   // TODO: extract these two variables into some kind of service
   private tabsToFramesToStreams: {

--- a/packages/coil-extension/src/background/services/StreamAssociations.ts
+++ b/packages/coil-extension/src/background/services/StreamAssociations.ts
@@ -5,12 +5,9 @@ import { FrameSpec } from '../../types/FrameSpec'
 @injectable()
 export class StreamAssociations {
   private tabsToFramesToStreams: {
-    [tab: number]: Record<
-      // frameId
-      number,
-      // streamId
-      string
-    >
+    [tab: number]: {
+      [frameId: number]: string // streamId
+    }
   } = {}
 
   private streamsToFrames: {
@@ -18,7 +15,7 @@ export class StreamAssociations {
   } = {}
 
   getTabStreams(tabId: number) {
-    return { ...this.tabsToFramesToStreams[tabId] }
+    return this.tabsToFramesToStreams[tabId]
   }
 
   clearTabStreams(tabId: number) {

--- a/packages/coil-extension/src/background/services/StreamAssociations.ts
+++ b/packages/coil-extension/src/background/services/StreamAssociations.ts
@@ -5,12 +5,9 @@ import { FrameSpec } from '../../types/FrameSpec'
 @injectable()
 export class StreamAssociations {
   private tabsToFramesToStreams: {
-    [tab: number]: Record<
-      // frameId
-      number,
-      // streamId
-      string
-    >
+    [tabId: number]: {
+      [frameId: number]: string
+    }
   } = {}
 
   private streamsToFrames: {
@@ -18,7 +15,7 @@ export class StreamAssociations {
   } = {}
 
   getTabStreams(tabId: number) {
-    return { ...this.tabsToFramesToStreams[tabId] }
+    return this.tabsToFramesToStreams[tabId]
   }
 
   clearTabStreams(tabId: number) {

--- a/packages/coil-extension/src/background/services/StreamAssociations.ts
+++ b/packages/coil-extension/src/background/services/StreamAssociations.ts
@@ -34,7 +34,7 @@ export class StreamAssociations {
     this.streamsToFrames[streamId] = frame
   }
 
-  clearFrameStream(tabId: number, frameId: number) {
+  clearStream({ tabId, frameId }: FrameSpec) {
     const tabsToFramesToStream = this.tabsToFramesToStreams[tabId]
     if (tabsToFramesToStream) {
       delete tabsToFramesToStream[frameId]

--- a/packages/coil-extension/src/background/services/StreamAssociations.ts
+++ b/packages/coil-extension/src/background/services/StreamAssociations.ts
@@ -38,7 +38,10 @@ export class StreamAssociations {
   }
 
   clearFrameStream(tabId: number, frameId: number) {
-    delete this.tabsToFramesToStreams[tabId][frameId as number]
+    const tabsToFramesToStream = this.tabsToFramesToStreams[tabId]
+    if (tabsToFramesToStream) {
+      delete tabsToFramesToStream[frameId as number]
+    }
   }
 
   getStreamId({ tabId, frameId }: FrameSpec) {

--- a/packages/coil-extension/src/background/services/TabStates.ts
+++ b/packages/coil-extension/src/background/services/TabStates.ts
@@ -22,7 +22,7 @@ export class TabStates {
   setFrame({ tabId, frameId }: FrameSpec, state: Partial<FrameState> = {}) {
     const frameStates = this.get(tabId).frameStates
     const existingFrameState =
-      this.get(tabId).frameStates[frameId] ?? this.makeFrameStateDefault()
+      frameStates[frameId] ?? this.makeFrameStateDefault()
     this.set(tabId, {
       frameStates: {
         ...frameStates,
@@ -32,7 +32,15 @@ export class TabStates {
   }
 
   clearFrame({ tabId, frameId }: FrameSpec) {
-    delete this.tabStates[tabId]?.frameStates[frameId]
+    const tabState = this.tabStates[tabId]
+    if (tabState) {
+      if (frameId !== 0) {
+        delete tabState.frameStates[frameId]
+      } else {
+        // maintain default
+        tabState.frameStates[0] = this.makeFrameStateDefault()
+      }
+    }
   }
 
   tabKeys(): number[] {

--- a/packages/coil-extension/src/background/services/TabStates.ts
+++ b/packages/coil-extension/src/background/services/TabStates.ts
@@ -85,6 +85,12 @@ export class TabStates {
     return this.tabStates[tab] || { ...defaultValue }
   }
 
+  getFrameState({ tabId, frameId }: FrameSpec) {
+    return (
+      this.tabStates[tabId].frameStates[frameId] ?? this.makeFrameStateDefault()
+    )
+  }
+
   clear(tab: number) {
     delete this.tabStates[tab]
   }

--- a/packages/coil-extension/src/background/services/TabStates.ts
+++ b/packages/coil-extension/src/background/services/TabStates.ts
@@ -85,7 +85,7 @@ export class TabStates {
     return this.tabStates[tab] || { ...defaultValue }
   }
 
-  getFrameState({ tabId, frameId }: FrameSpec) {
+  getFrame({ tabId, frameId }: FrameSpec) {
     return (
       this.tabStates[tabId].frameStates[frameId] ?? this.makeFrameStateDefault()
     )

--- a/packages/coil-extension/src/background/services/YoutubeService.ts
+++ b/packages/coil-extension/src/background/services/YoutubeService.ts
@@ -1,4 +1,4 @@
-import { injectable } from '@dier-makr/annotations'
+import { injectable } from 'inversify'
 
 import { logger, Logger } from './utils'
 
@@ -20,7 +20,11 @@ export class YoutubeService {
       this.log('searching chunk of length', chunk.length)
       const searched = this.searcher.exec(chunk)
       if (searched) {
-        return searched[1] || searched[2]
+        const found = searched[1] || searched[2]
+        this.log('found', found)
+        return found
+      } else {
+        this.log('not found')
       }
       return null
     }

--- a/packages/coil-extension/src/content/content.ts
+++ b/packages/coil-extension/src/content/content.ts
@@ -10,11 +10,11 @@ import { API, COIL_DOMAIN } from '../webpackDefines'
 import { ClientOptions } from '../services/ClientOptions'
 
 import { ContentScript } from './services/ContentScript'
-import { Frames } from './services/Frames'
 
 function configureContainer(container: Container) {
   container.bind(tokens.ContentRuntime).toConstantValue(API.runtime)
   container.bind(tokens.CoilDomain).toConstantValue(COIL_DOMAIN)
+  container.bind(tokens.WextApi).toConstantValue(API)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const noop = (..._: unknown[]) => undefined
   container
@@ -28,16 +28,12 @@ function configureContainer(container: Container) {
 }
 
 function main() {
-  const frames = new Frames(window, COIL_DOMAIN)
-  if (frames.isTopFrame || frames.isAnyCoilFrame) {
-    const container = new Container({
-      defaultScope: 'Singleton',
-      autoBindInjectable: true
-    })
-    inversifyModule(GlobalModule)
-    configureContainer(container)
-    container.get(ContentScript).init()
-  }
+  const container = new Container({
+    defaultScope: 'Singleton',
+    autoBindInjectable: true
+  })
+  inversifyModule(GlobalModule)
+  configureContainer(container)
+  container.get(ContentScript).init()
 }
-
 main()

--- a/packages/coil-extension/src/content/content.ts
+++ b/packages/coil-extension/src/content/content.ts
@@ -14,7 +14,6 @@ import { ContentScript } from './services/ContentScript'
 function configureContainer(container: Container) {
   container.bind(tokens.ContentRuntime).toConstantValue(API.runtime)
   container.bind(tokens.CoilDomain).toConstantValue(COIL_DOMAIN)
-  container.bind(tokens.WextApi).toConstantValue(API)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const noop = (..._: unknown[]) => undefined
   container

--- a/packages/coil-extension/src/content/services/AdaptedContentService.ts
+++ b/packages/coil-extension/src/content/services/AdaptedContentService.ts
@@ -28,7 +28,6 @@ export class AdaptedContentService {
     @inject(tokens.ContentRuntime)
     private contentRuntime: ContentRuntime,
     private window: Window,
-    private frames: Frames,
     private client: GraphQlClient
   ) {}
 
@@ -51,6 +50,7 @@ export class AdaptedContentService {
 
     if (site === 'youtube') {
       const channelId = await this.fetchChannelId(url)
+      debug('channelId', { channelId })
       if (channelId) {
         debug('found channel id', channelId, 'for', url)
         Object.assign(variables, { channelId })

--- a/packages/coil-extension/src/content/services/ContentScript.ts
+++ b/packages/coil-extension/src/content/services/ContentScript.ts
@@ -185,7 +185,6 @@ export class ContentScript {
       this.window.addEventListener('message', event => {
         const data = event.data
         if (typeof data.wmIFrameCorrelationId === 'string') {
-          console.error('reporting correlation id', data.wmIFrameCorrelationId)
           const message: ReportCorrelationIdFromIFrameContentScript = {
             command: 'reportCorrelationIdFromIFrameContentScript',
             data: {

--- a/packages/coil-extension/src/content/services/ContentScript.ts
+++ b/packages/coil-extension/src/content/services/ContentScript.ts
@@ -43,8 +43,6 @@ function startWebMonetizationMessage(request?: PaymentDetails) {
 
 @injectable()
 export class ContentScript {
-  allowToken = ''
-
   constructor(
     private storage: Storage,
     private window: Window,
@@ -67,14 +65,14 @@ export class ContentScript {
       })
       if (this.frames.isIFrame) {
         const allowed = await new Promise<boolean>(resolve => {
-          const newVar: CheckIFrameIsAllowedFromIFrameContentScript = {
+          const message: CheckIFrameIsAllowedFromIFrameContentScript = {
             command: 'checkIFrameIsAllowedFromIFrameContentScript'
           }
-          this.runtime.sendMessage(newVar, resolve)
+          this.runtime.sendMessage(message, resolve)
         })
         if (!allowed) {
           console.error(
-            '<iframe href="%s"> is not authorized to allow web monetization',
+            '<iframe> is not authorized to allow web monetization, %s',
             window.location.href
           )
           return
@@ -116,25 +114,17 @@ export class ContentScript {
     this.runtime.onMessage.addListener(
       (request: ToContentMessage, sender, sendResponse) => {
         if (request.command === 'checkAdaptedContent') {
-          if (this.window.location.href === request.data.url) {
-            if (request.data && request.data.from) {
-              debug(
-                'checkAdaptedContent with from',
-                this.document.readyState,
-                JSON.stringify(request.data),
-                window.location.href
-              )
-            } else {
-              debug('checkAdaptedContent without from')
-            }
-            void this.adaptedContent.checkAdaptedContent()
-          } else {
+          if (request.data && request.data.from) {
             debug(
-              'ignoring checkAdaptedContent with different url',
-              this.window.location.href,
-              request.data.url
+              'checkAdaptedContent with from',
+              this.document.readyState,
+              JSON.stringify(request.data),
+              window.location.href
             )
+          } else {
+            debug('checkAdaptedContent without from')
           }
+          void this.adaptedContent.checkAdaptedContent()
         } else if (request.command === 'setMonetizationState') {
           this.monetization.setState(request.data)
         } else if (request.command === 'monetizationProgress') {

--- a/packages/coil-extension/src/content/services/ContentScript.ts
+++ b/packages/coil-extension/src/content/services/ContentScript.ts
@@ -63,7 +63,7 @@ export class ContentScript {
         requestId: details.requestId,
         initiatingUrl: details.initiatingUrl
       })
-      if (this.frames.isIFrame) {
+      if (this.frames.isDirectChildFrame) {
         const allowed = await new Promise<boolean>(resolve => {
           const message: CheckIFrameIsAllowedFromIFrameContentScript = {
             command: 'checkIFrameIsAllowedFromIFrameContentScript'

--- a/packages/coil-extension/src/content/services/ContentScript.ts
+++ b/packages/coil-extension/src/content/services/ContentScript.ts
@@ -71,7 +71,9 @@ export class ContentScript {
             this.monetization.getMonetizationRequest()
           )
         )
+        // eslint-disable-next-line no-constant-condition
       } else {
+        // noinspection UnreachableCodeJS
         this.allowToken = uuid.v4()
         const request: StartIFrameWebMonetization = {
           command: 'startIFrameWebMonetization',

--- a/packages/coil-extension/src/content/services/ContentScript.ts
+++ b/packages/coil-extension/src/content/services/ContentScript.ts
@@ -103,7 +103,7 @@ export class ContentScript {
           stopMonetization(stopped)
         }
         if (started) {
-          startMonetization(started)
+          void startMonetization(started)
         }
       }
     )

--- a/packages/coil-extension/src/content/services/ContentScript.ts
+++ b/packages/coil-extension/src/content/services/ContentScript.ts
@@ -63,13 +63,15 @@ export class ContentScript {
         requestId: details.requestId,
         initiatingUrl: details.initiatingUrl
       })
-      if (this.frames.isDirectChildFrame) {
-        const allowed = await new Promise<boolean>(resolve => {
-          const message: CheckIFrameIsAllowedFromIFrameContentScript = {
-            command: 'checkIFrameIsAllowedFromIFrameContentScript'
-          }
-          this.runtime.sendMessage(message, resolve)
-        })
+      if (this.frames.isIFrame) {
+        const allowed = !this.frames.isDirectChildFrame
+          ? false
+          : await new Promise<boolean>(resolve => {
+              const message: CheckIFrameIsAllowedFromIFrameContentScript = {
+                command: 'checkIFrameIsAllowedFromIFrameContentScript'
+              }
+              this.runtime.sendMessage(message, resolve)
+            })
         if (!allowed) {
           console.error(
             '<iframe> is not authorized to allow web monetization, %s',

--- a/packages/coil-extension/src/content/services/ContentScript.ts
+++ b/packages/coil-extension/src/content/services/ContentScript.ts
@@ -71,9 +71,7 @@ export class ContentScript {
             this.monetization.getMonetizationRequest()
           )
         )
-        // eslint-disable-next-line no-constant-condition
       } else {
-        // noinspection UnreachableCodeJS
         this.allowToken = uuid.v4()
         const request: StartIFrameWebMonetization = {
           command: 'startIFrameWebMonetization',

--- a/packages/coil-extension/src/content/services/ContentScript.ts
+++ b/packages/coil-extension/src/content/services/ContentScript.ts
@@ -190,12 +190,16 @@ export class ContentScript {
             allowed
           }: { allowToken: string; allowed: boolean } = data.wmIframe
           if (allowToken === this.allowToken) {
-            if (allowed && this.monetization.hasRequest()) {
-              this.runtime.sendMessage(
-                startWebMonetizationMessage(
-                  this.monetization.getMonetizationRequest()
+            // allowToken is 'listened to' only once
+            this.allowToken = ''
+            if (allowed) {
+              if (this.monetization.hasRequest()) {
+                this.runtime.sendMessage(
+                  startWebMonetizationMessage(
+                    this.monetization.getMonetizationRequest()
+                  )
                 )
-              )
+              }
             } else {
               console.error(
                 '<iframe href="%s"> is not authorized to allow web monetization',

--- a/packages/coil-extension/src/content/services/Frames.ts
+++ b/packages/coil-extension/src/content/services/Frames.ts
@@ -47,7 +47,7 @@ export class Frames {
     })
   }
 
-  // iframe to FrameSpc
+  // iframe to FrameSpec
   frames = new WeakMap<
     HTMLIFrameElement,
     {
@@ -55,7 +55,7 @@ export class Frames {
     }
   >()
 
-  // correlationId to resolve/reject
+  // correlationId to promise resolver
   frameQueue = new Map<
     string,
     {
@@ -92,11 +92,8 @@ export class Frames {
         }
         this.frames.set(frameEl, result)
       }
-      // No else! result should be set if not in frames WeakMap
-      if (result) {
-        if (sameFrame(await result.frame, frameSpec)) {
-          return isMonetizationAllowed(frameEl)
-        }
+      if (sameFrame(await result.frame, frameSpec)) {
+        return isMonetizationAllowed(frameEl)
       }
     }
     return false

--- a/packages/coil-extension/src/content/services/Frames.ts
+++ b/packages/coil-extension/src/content/services/Frames.ts
@@ -1,6 +1,9 @@
 import { inject, injectable } from 'inversify'
+import { parsePolicyDirectives } from '@web-monetization/polyfill-utils'
 
 import * as tokens from '../../types/tokens'
+import { FrameStateChange, UnloadFrame } from '../../types/commands'
+import { ContentRuntime } from '../types/ContentRunTime'
 
 @injectable()
 export class Frames {
@@ -8,14 +11,83 @@ export class Frames {
   isAnyCoilFrame: boolean
   isIFrame: boolean
   isCoilTopFrame: boolean
+  isDirectChildFrame: boolean
+  isMonetizableFrame: boolean
 
   constructor(
+    private doc: Document,
     private window: Window,
+    @inject(tokens.ContentRuntime)
+    private runtime: ContentRuntime,
     @inject(tokens.CoilDomain) private coilDomain: string
   ) {
     this.isTopFrame = window === window.top
     this.isAnyCoilFrame = window.origin === coilDomain
     this.isIFrame = !this.isTopFrame
     this.isCoilTopFrame = this.isTopFrame && this.isAnyCoilFrame
+    this.isDirectChildFrame = this.isIFrame && window.parent === window.top
+    this.isMonetizableFrame = this.isTopFrame || this.isDirectChildFrame
+  }
+
+  monitor() {
+    this.sendStateChange()
+    this.doc.addEventListener('readystatechange', () => {
+      this.sendStateChange()
+    })
+
+    /**
+     * Be wary of context invalidation during extension reloading causing
+     * confusion here.
+     */
+    this.window.addEventListener('unload', () => {
+      this.sendUnloadMessage()
+    })
+  }
+
+  sendAllowMessages(forId: string) {
+    const iframes = Array.from(
+      this.doc.querySelectorAll<HTMLIFrameElement>('iframe')
+    )
+
+    for (const frame of iframes) {
+      let allowed = false
+      try {
+        if (frame.allow) {
+          const parsed = parsePolicyDirectives(frame.allow)
+          allowed = 'monetization' in parsed
+        }
+      } catch (e) {
+        allowed = false
+      }
+      if (frame.contentWindow) {
+        frame.contentWindow.postMessage(
+          {
+            wmIframe: {
+              forId,
+              allowed
+            }
+          },
+          '*'
+        )
+      }
+    }
+  }
+
+  private sendUnloadMessage() {
+    const unload: UnloadFrame = {
+      command: 'unloadFrame'
+    }
+    this.runtime.sendMessage(unload)
+  }
+
+  private sendStateChange() {
+    const frameStateChange: FrameStateChange = {
+      command: 'frameStateChange',
+      data: {
+        state: this.doc.readyState,
+        href: this.window.location.href
+      }
+    }
+    this.runtime.sendMessage(frameStateChange)
   }
 }

--- a/packages/coil-extension/src/content/services/Frames.ts
+++ b/packages/coil-extension/src/content/services/Frames.ts
@@ -44,7 +44,7 @@ export class Frames {
     })
   }
 
-  sendAllowMessages(forId: string) {
+  sendAllowMessages(allowToken: string) {
     const iframes = Array.from(
       this.doc.querySelectorAll<HTMLIFrameElement>('iframe')
     )
@@ -63,7 +63,7 @@ export class Frames {
         frame.contentWindow.postMessage(
           {
             wmIframe: {
-              forId,
+              allowToken,
               allowed
             }
           },

--- a/packages/coil-extension/src/content/util/isMonetizationAllowed.ts
+++ b/packages/coil-extension/src/content/util/isMonetizationAllowed.ts
@@ -1,0 +1,14 @@
+import { parsePolicyDirectives } from '@web-monetization/polyfill-utils'
+
+export function isMonetizationAllowed(frame: HTMLIFrameElement) {
+  let allowed = false
+  try {
+    if (frame.allow) {
+      const parsed = parsePolicyDirectives(frame.allow)
+      allowed = 'monetization' in parsed
+    }
+  } catch (e) {
+    allowed = false
+  }
+  return allowed
+}

--- a/packages/coil-extension/src/types/FrameSpec.ts
+++ b/packages/coil-extension/src/types/FrameSpec.ts
@@ -2,3 +2,7 @@ export interface FrameSpec {
   tabId: number
   frameId: number
 }
+
+export function sameFrame(f1: FrameSpec, f2: FrameSpec) {
+  return f1.tabId === f2.tabId && f1.frameId === f2.frameId
+}

--- a/packages/coil-extension/src/types/FrameSpec.ts
+++ b/packages/coil-extension/src/types/FrameSpec.ts
@@ -1,0 +1,4 @@
+export interface FrameSpec {
+  tabId: number
+  frameId: number
+}

--- a/packages/coil-extension/src/types/TabState.ts
+++ b/packages/coil-extension/src/types/TabState.ts
@@ -2,19 +2,22 @@ import { PlayOrPauseState, StickyState } from './streamControls'
 
 export type MonetizationCommand = 'pause' | 'stop' | 'start' | 'resume'
 
-export interface TabState {
-  favicon?: string
-  coilSite?: string
+export interface FrameState {
   adapted: boolean
   monetized: boolean
   // Tracks the total amount of `source` money sent (not was received)
   total: number
-  stickyState: StickyState
-  playState: PlayOrPauseState
   lastMonetization: {
     command: MonetizationCommand | null
     timeMs: number
   }
+}
+
+export interface TabState {
+  favicon?: string
+  coilSite?: string
+  stickyState: StickyState
+  playState: PlayOrPauseState
   icon?: {
     path: string
   }
@@ -22,4 +25,5 @@ export interface TabState {
     text: string
     color?: string
   }
+  frameStates: Record<number, FrameState>
 }

--- a/packages/coil-extension/src/types/commands.ts
+++ b/packages/coil-extension/src/types/commands.ts
@@ -203,7 +203,7 @@ export interface IsRateLimited extends Command {
  */
 export interface CheckAdaptedContent {
   command: 'checkAdaptedContent'
-  data: { from?: string; url?: string }
+  data: { from?: string }
 }
 
 /**

--- a/packages/coil-extension/src/types/commands.ts
+++ b/packages/coil-extension/src/types/commands.ts
@@ -80,7 +80,7 @@ export interface StartWebMonetization extends Command {
  */
 export interface StartIFrameWebMonetization extends Command {
   command: 'startIFrameWebMonetization'
-  data: { frameUuid: string }
+  data: { allowToken: string }
 }
 
 /**
@@ -278,7 +278,7 @@ export interface SendTipResult {
 export interface CheckAllowedIFrames {
   command: 'checkAllowedIFrames'
   data: {
-    frameUuid: string
+    forAllowToken: string
   }
 }
 

--- a/packages/coil-extension/src/types/commands.ts
+++ b/packages/coil-extension/src/types/commands.ts
@@ -71,7 +71,16 @@ export interface ResumeWebMonetization extends Command {
  */
 export interface StartWebMonetization extends Command {
   command: 'startWebMonetization'
-  data: PaymentDetails & { initiatingUrl: string }
+  data: PaymentDetails
+}
+
+/**
+ * content -> background
+ * browser.runtime.sendMessage
+ */
+export interface StartIFrameWebMonetization extends Command {
+  command: 'startIFrameWebMonetization'
+  data: { frameUuid: string }
 }
 
 /**
@@ -114,6 +123,27 @@ export interface FetchYoutubeChannelId extends Command {
   }
 }
 
+/**
+ * content -> background
+ * browser.runtime.sendMessage
+ */
+export interface FrameStateChange extends Command {
+  command: 'frameStateChange'
+  data: {
+    state: Document['readyState']
+    href: string
+  }
+}
+
+/**
+ * content -> background
+ * browser.runtime.sendMessage
+ */
+export interface UnloadFrame extends Command {
+  command: 'unloadFrame'
+  // frameId is retrieved via MessageSender['frameId']
+}
+
 export type ToBackgroundMessage =
   | PauseWebMonetization
   | ResumeWebMonetization
@@ -128,6 +158,9 @@ export type ToBackgroundMessage =
   | ContentScriptInit
   | FetchYoutubeChannelId
   | SendTip
+  | FrameStateChange
+  | UnloadFrame
+  | StartIFrameWebMonetization
 
 export type IconState =
   | 'streaming-paused'
@@ -238,10 +271,22 @@ export interface SendTipResult {
   success: boolean
 }
 
+/**
+ *  background -> content
+ *  browser.tabs.sendMessage
+ */
+export interface CheckAllowedIFrames {
+  command: 'checkAllowedIFrames'
+  data: {
+    frameUuid: string
+  }
+}
+
 export type ToContentMessage =
   | CheckAdaptedContent
   | MonetizationProgress
   | MonetizationStart
   | SetMonetizationState
+  | CheckAllowedIFrames
 
 export type ToPopupMessage = LocalStorageUpdate | ClosePopup

--- a/packages/coil-extension/src/types/commands.ts
+++ b/packages/coil-extension/src/types/commands.ts
@@ -6,6 +6,7 @@ import {
   StickyState,
   ToggleControlsAction
 } from './streamControls'
+import { FrameSpec } from './FrameSpec'
 
 /**
  * browser.runtime.sendMessage
@@ -78,29 +79,9 @@ export interface StartWebMonetization extends Command {
  * content -> background
  * browser.runtime.sendMessage
  */
-export interface StartIFrameWebMonetization extends Command {
-  command: 'startIFrameWebMonetization'
-  data: { allowToken: string }
-}
-
-/**
- * content -> background
- * browser.runtime.sendMessage
- */
 export interface StopWebMonetization extends Command {
   command: 'stopWebMonetization'
   data: PaymentDetails
-}
-
-/**
- * content -> backround
- * browser.runtime.sendMessage
- */
-export interface CheckToken extends Command {
-  command: 'checkToken'
-  data: {
-    token: string
-  }
 }
 
 /**
@@ -144,6 +125,29 @@ export interface UnloadFrame extends Command {
   // frameId is retrieved via MessageSender['frameId']
 }
 
+/**
+ * content -> background
+ * browser.runtime.sendMessage
+ */
+export interface ReportCorrelationIdFromIFrameContentScript extends Command {
+  command: 'reportCorrelationIdFromIFrameContentScript'
+  data: {
+    correlationId: string
+    // FrameSpec is implied
+  }
+}
+
+/**
+ * content -> background
+ * browser.runtime.sendMessage
+ */
+export interface CheckIFrameIsAllowedFromIFrameContentScript extends Command {
+  command: 'checkIFrameIsAllowedFromIFrameContentScript'
+  // data: {
+  // FrameSpec is implied
+  // }
+}
+
 export type ToBackgroundMessage =
   | PauseWebMonetization
   | ResumeWebMonetization
@@ -160,7 +164,8 @@ export type ToBackgroundMessage =
   | SendTip
   | FrameStateChange
   | UnloadFrame
-  | StartIFrameWebMonetization
+  | CheckIFrameIsAllowedFromIFrameContentScript
+  | ReportCorrelationIdFromIFrameContentScript
 
 export type IconState =
   | 'streaming-paused'
@@ -275,10 +280,22 @@ export interface SendTipResult {
  *  background -> content
  *  browser.tabs.sendMessage
  */
-export interface CheckAllowedIFrames {
-  command: 'checkAllowedIFrames'
+export interface CheckIFrameIsAllowedFromBackground {
+  command: 'checkIFrameIsAllowedFromBackground'
   data: {
-    forAllowToken: string
+    frame: FrameSpec
+  }
+}
+
+/**
+ *  background -> content
+ *  browser.tabs.sendMessage
+ */
+export interface ReportCorrelationIdToParentContentScript {
+  command: 'reportCorrelationIdToParentContentScript'
+  data: {
+    frame: FrameSpec
+    correlationId: string
   }
 }
 
@@ -287,6 +304,7 @@ export type ToContentMessage =
   | MonetizationProgress
   | MonetizationStart
   | SetMonetizationState
-  | CheckAllowedIFrames
+  | CheckIFrameIsAllowedFromBackground
+  | ReportCorrelationIdToParentContentScript
 
 export type ToPopupMessage = LocalStorageUpdate | ClosePopup

--- a/packages/coil-extension/src/util/tabs.ts
+++ b/packages/coil-extension/src/util/tabs.ts
@@ -1,0 +1,13 @@
+import MessageSender = chrome.runtime.MessageSender
+import { notNullOrUndef } from './nullables'
+
+export function getTab(sender: { tab?: { id?: number } }): number {
+  return notNullOrUndef(notNullOrUndef(sender.tab).id)
+}
+
+export function getFrameSpec(sender: MessageSender) {
+  const tabId = getTab(sender)
+  const frameId = notNullOrUndef(sender.frameId)
+  const spec = { tabId, frameId }
+  return { ...spec, spec }
+}

--- a/packages/coil-extension/test/fixtures/iframes/frame1.html
+++ b/packages/coil-extension/test/fixtures/iframes/frame1.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>IFrame 1</title>
+    <meta
+      id="money"
+      name="monetization"
+      content="$twitter.xrptipbot.com/Coil"
+    />
+  </head>
+  <body>
+    <h1>IFrame 1</h1>
+    <script type="text/javascript">
+      setInterval(() => {
+        document.title = 'IFame 1 - ' + Date.now()
+      }, 5e3)
+    </script>
+  </body>
+</html>

--- a/packages/coil-extension/test/fixtures/iframes/frame2.html
+++ b/packages/coil-extension/test/fixtures/iframes/frame2.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>IFrame 2</title>
+  </head>
+  <body>
+    <h1>IFrame 2</h1>
+    <iframe src="./frame3.html"></iframe>
+    <script>
+      window.addEventListener('message', message => {
+        console.log('received message', message)
+      })
+      setTimeout(() => {
+        window.location.href = 'http://localhost:4001/frame1.html'
+        window.addEventListener('message', message => {
+          console.log('received message second listener', message)
+        })
+      }, 10e3)
+    </script>
+  </body>
+</html>

--- a/packages/coil-extension/test/fixtures/iframes/frame3.html
+++ b/packages/coil-extension/test/fixtures/iframes/frame3.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>IFrame 3</title>
+  </head>
+  <body>
+    <h1>IFrame 3</h1>
+  </body>
+</html>

--- a/packages/coil-extension/test/fixtures/iframes/index.html
+++ b/packages/coil-extension/test/fixtures/iframes/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>TOP Frame</title>
+  </head>
+  <body>
+    <iframe allow="monetization" id="frame1" src="./frame1.html"></iframe>
+    <iframe
+      allow="monetization another"
+      id="frame2"
+      src="./frame2.html"
+    ></iframe>
+    <iframe
+      allow="monetization"
+      id="youtubeFrame"
+      width="806"
+      height="453"
+      src="https://www.youtube.com/embed/udPZODMRFJI?list=PLY551ge00sgyupLbTqGgBqyxNXuJoeuST"
+      frameborder="0"
+      allowfullscreen
+    ></iframe>
+    <iframe
+      allow="monetization"
+      id="cinnamonFrame"
+      width="806"
+      height="453"
+      src="https://www.cinnamon.video/aussieninja/watch?v=233496874017883674"
+      frameborder="0"
+    ></iframe>
+    <script></script>
+  </body>
+</html>

--- a/packages/coil-extension/test/fixtures/iframes/index.html
+++ b/packages/coil-extension/test/fixtures/iframes/index.html
@@ -4,6 +4,7 @@
     <title>TOP Frame</title>
   </head>
   <body>
+    <div id="log"></div>
     <iframe allow="monetization" id="frame1" src="./frame1.html"></iframe>
     <iframe
       allow="monetization another"
@@ -27,6 +28,14 @@
       src="https://www.cinnamon.video/aussieninja/watch?v=233496874017883674"
       frameborder="0"
     ></iframe>
-    <script></script>
+    <script type="text/javascript">
+      const log = document.querySelector('#log')
+      let ms = Date.now()
+      document.addEventListener('readystatechange', event => {
+        const now = Date.now()
+        log.innerHTML += `<p>${document.readyState} +${now - ms}</p>`
+        ms = now
+      })
+    </script>
   </body>
 </html>

--- a/packages/coil-oauth-scripts/src/MonetizationPolyfill.ts
+++ b/packages/coil-oauth-scripts/src/MonetizationPolyfill.ts
@@ -80,6 +80,7 @@ export class MonetizationPolyfill {
     const { clearWatch, setWatch } = watchPageEvents()
 
     const monitor = new MonetizationTagObserver(
+      window,
       document,
       async ({ started, stopped }) => {
         debug({ started, stopped })

--- a/packages/coil-puppeteer-utils/src/lib/testMonetization.ts
+++ b/packages/coil-puppeteer-utils/src/lib/testMonetization.ts
@@ -16,8 +16,7 @@ import {
   hasCommonRequestIdAndPaymentPointer,
   isValidPendingEvent,
   isValidProgressEvent,
-  isValidStartEvent,
-  isValidStopEvent
+  isValidStartEvent
 } from './validators'
 import { AWAIT_MONETIZATION_TIMEOUT_MS } from './env'
 
@@ -158,7 +157,11 @@ export async function testMonetization({
   let state: string | null = null
 
   if (success) {
-    state = await page.evaluate(() => (document as any).monetization.state)
+    try {
+      state = await page.evaluate(() => (document as any).monetization.state)
+    } catch (e) {
+      // ignored
+    }
   }
 
   debug('seen states: %s, events: %s', statesSeen, eventsSeen)

--- a/packages/coil-puppeteer-utils/src/lib/testMonetization.ts
+++ b/packages/coil-puppeteer-utils/src/lib/testMonetization.ts
@@ -129,7 +129,7 @@ export async function testMonetization({
           })
         } else {
           // Poll for document.monetization presence
-          setTimeout(setListener, 16)
+          setTimeout(setListener, 0)
         }
       }
       setListener()

--- a/packages/coil-puppeteer-utils/src/lib/testMonetization.ts
+++ b/packages/coil-puppeteer-utils/src/lib/testMonetization.ts
@@ -136,7 +136,7 @@ export async function testMonetization({
   }
 
   if (env.IS_CI) {
-    await timeout(1e3)
+    await timeout(2e3)
   }
 
   await listenFor('monetizationpending')

--- a/packages/web-monetization-polyfill-utils/src/index.ts
+++ b/packages/web-monetization-polyfill-utils/src/index.ts
@@ -17,3 +17,4 @@ export { BackoffWaiter } from './lib/BackoffWaiter'
 export { resolvePaymentEndpoint } from './lib/resolvePaymentEndpoint'
 export { asyncUtils }
 export { getFarFutureExpiry } from './lib/getFarFutureExpiry'
+export { parsePolicyDirectives } from './lib/parsePolicyDirectives'

--- a/packages/web-monetization-polyfill-utils/src/lib/MonetizationTagObserver.ts
+++ b/packages/web-monetization-polyfill-utils/src/lib/MonetizationTagObserver.ts
@@ -9,6 +9,7 @@ export interface PaymentDetails {
   // Web-Monetization-Id
   requestId: string
   paymentPointer: string
+  initiatingUrl: string
 }
 
 export enum IDGenerationStrategy {
@@ -51,6 +52,7 @@ export class MonetizationTagObserver {
   >()
 
   constructor(
+    private window: Window,
     private document: HTMLDocument,
     private callback: PaymentDetailsChangeCallback,
     private maxMetas = 1,
@@ -163,7 +165,8 @@ export class MonetizationTagObserver {
   private getPaymentDetails(meta: HTMLMetaElement): PaymentDetails {
     return {
       requestId: this.getWebMonetizationId(),
-      paymentPointer: meta.content
+      paymentPointer: meta.content,
+      initiatingUrl: this.window.location.href
     }
   }
 

--- a/packages/web-monetization-polyfill-utils/src/lib/parsePolicyDirectives.ts
+++ b/packages/web-monetization-polyfill-utils/src/lib/parsePolicyDirectives.ts
@@ -1,0 +1,21 @@
+interface PolicyResult {
+  [key: string]: string[]
+}
+
+export function parsePolicyDirectives(policy: string): PolicyResult {
+  return policy.split(';').reduce<PolicyResult>((result, directive) => {
+    const [directiveKey, ...directiveValue] = directive.trim().split(/\s+/g)
+
+    if (
+      !directiveKey ||
+      Object.prototype.hasOwnProperty.call(result, directiveKey)
+    ) {
+      return result
+    } else {
+      return {
+        ...result,
+        [directiveKey]: directiveValue
+      }
+    }
+  }, {})
+}

--- a/packages/web-monetization-polyfill-utils/test/jest/parsePolicyDirectives.test.ts
+++ b/packages/web-monetization-polyfill-utils/test/jest/parsePolicyDirectives.test.ts
@@ -1,0 +1,19 @@
+import { parsePolicyDirectives } from '../../src/lib/parsePolicyDirectives'
+
+describe('parsePolicyDirectives', () => {
+  it('should return an object with array values', () => {
+    const allow =
+      'vibrate https://a.com https://b.com;' +
+      " fullscreen 'none';" +
+      " payment 'src';" +
+      ' payment;' +
+      " usb '*'"
+    const actual = parsePolicyDirectives(allow)
+    expect(actual).toStrictEqual({
+      vibrate: ['https://a.com', 'https://b.com'],
+      fullscreen: ["'none'"],
+      payment: ["'src'"],
+      usb: ["'*'"]
+    })
+  })
+})

--- a/packages/web-monetization-wext/src/content/DocumentMonetization.ts
+++ b/packages/web-monetization-wext/src/content/DocumentMonetization.ts
@@ -7,7 +7,6 @@ import {
 } from '@web-monetization/types'
 import { injectable } from '@dier-makr/annotations'
 import { PaymentDetails } from '@web-monetization/polyfill-utils'
-import { StartWebMonetization } from '@coil/extension/src/types/commands'
 
 import { ScriptInjection } from './ScriptInjection'
 
@@ -62,15 +61,8 @@ export class DocumentMonetization {
     this.finalized = true
   }
 
-  startWebMonetizationMessage() {
-    if (!this.request) {
-      throw new Error(`Expecting request to be set`)
-    }
-    const request: StartWebMonetization = {
-      command: 'startWebMonetization',
-      data: { ...this.request }
-    }
-    return request
+  getMonetizationRequest() {
+    return this.request
   }
 
   /**


### PR DESCRIPTION
This pull request implements Web Monetization inside <iframe> elements. Only iframes that are direct children of the top frame, with monetization in their `allow` feature set policy will be monetized. 

It does this by changing the 1:1 mapping of WM streams to browser tabs to M:1, with the 1:1 mapping now of WM streams to iframes. 

To do so, it takes advantage of:
1. [webNavigation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation) wext apis 
    * New BackgroundFrameService
       * Keeps track of frames, including the current readyState/url/parentFrameId etc.
       * use `frameChanged` event where using chrome.tabs.onUpdated before (which was [problematic](https://github.com/coilhq/web-monetization-projects/issues/203))
    * Will require extra permissions which may be off-putting to some users
      * This will not actually give us any more private information than we already have. This may not be clear to all users though. 
2. [MessageSender](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/chrome/index.d.ts#L5500-L5505)['frameId'], MessageSender['tab'] attributes 
    Messages sent using `chrome.runtime.sendMessage` api from content scripts
    will be recieved in the background script onMessage listener with 
    tabId/frameId implied (i.e. not inside the message payload).

Whenever a monetization request occurs inside an iframe (that is only one level deep), a request will be sent to the background page to check if that iframe is allowed. 

The request handler in the background page consults the BackgroundFramesService to determine the parent frame of the sender (currently always 0) then sends a message to the associated content script via `tabs.sendMessage(tabId, msg, {frameId: parentId})`.  The `msg` contains the `{tabId, frameId}` monetization is requested from. 

* Inside the parent frame content script, a WeakMap of iframe elements to `Promise<{tabId, frameId}>` is maintained as well as a promise queue via a Map of correlationId to promise resolver. 
* A linear search is done over a query of all iframes, consulting the WeakMap, queuing new promises where necessary, `await`ing each promise in turn. The promise result frame is checked against the search element frame.
  * All `<iframe>`s in the page that have no promise queued already are sent a correlationId via `frame.contentWindow!.postMessage`
  * Concurrent searches initiated via multiple child frames requesting monetization are handled fine using this method
* Content scripts listen for the correlationId via adding listeners to the window `message` event
   * This is then reported to the background page, which looks up the parent frame of the sender and reports the correlationId/frame pair and the correlationId associated promise is resolved with the frame. 
   * It seems highly unlikely that nefarious actors could listen in on the event, replaying the message to another window and beat the content script listener to use the correlationId. 
     * We could take extra measures from the background page to ensure ids are only ever used once but it does not really seem necessary. 
        * unknown correlationIds are ignored

### Questions:
- Should we limit the amount of concurrently monetized frames ? 
   - If so, how ?
- Do we need to do anything special client side to adjust bandwidth? Or will the server do it all ? 
   - Is there anything needed server side to optimally support this ?
     - Seems to be some (transient) errors when a bunch of streams connect at the same time  ![image](https://user-images.githubusercontent.com/525211/75645769-ce4a5e80-5c79-11ea-9083-7748dad478eb.png)
      - it seems the retry logic handles them though

- Should we allow arbitrarily nested iframes to monetize as long as long as all iframes in the iframe hierarchy have specified allow="monetization" ? 
- What does the text in the popup mean now that 'content' could refer to inner frames as well as the top page ?
- Should there be some kind of 'in-page' indication that an iframe is being monetized ? (@fruehle offhand suggested maybe some kind of WM logo watermark)

## MacOS Chrome 80.0.3987.132 (Official Build) (64-bit)

- [x] Build for prod with release settings

  - e.g. `yarn build-prod chrome -p --run-prod --devtool=none`
    - as per [package.sh](../package.sh)

- [x] Import unpacked/temporary extension/add-on

  - For Firefox, go to `about:debugging`
    - Enable add-on debugging
    - Load Temporary Add-on...
  - For Chrome or MS Edge, go to `chrome://extensions` (or `edge://extensions`) and `Load Unpacked`

- [x] Ensure that you are [logged in with a user with valid subscription](https://coil.com/settings/payment)

  - ![image](https://user-images.githubusercontent.com/525211/71150879-28d04300-2265-11ea-96da-7d720c101575.png)

- [x] [example.com](http://example.com/) should say "This website is not supported"

  - ![image](https://user-images.githubusercontent.com/525211/66626576-f4b42280-ec22-11e9-9f77-4a95be08643e.png)

- [x] [xrpcommunity.blog](https://xrpcommunity.blog/) should monetize

  - ![image](https://user-images.githubusercontent.com/525211/66626655-3c3aae80-ec23-11e9-981a-0e317ab80b42.png)

- [x] [twitch.tv](https://twitch.tv/vinesauce) works

  - ![image](https://user-images.githubusercontent.com/525211/66626721-815ee080-ec23-11e9-8139-59a563822eb0.png)

- [x] [monetized youtube video](https://www.youtube.com/watch?v=-QMbZx_w2_Y)

  - ![image](https://user-images.githubusercontent.com/525211/66626878-0a761780-ec24-11e9-8015-19bf8348807b.png)

- Coil welcome and welcome to explore pages

  - [x] Go to coil.com, the browser action popup should show welcome to coil
    - ![image](https://user-images.githubusercontent.com/525211/66626988-6b9deb00-ec24-11e9-86c3-b55c17e891c2.png)
  - [x] Should have a link to coil.com/explore page
  - [x] Once on explore page should show `Start Exploring` with a rocket-ship graphic
    - ![image](https://user-images.githubusercontent.com/525211/66627053-a2740100-ec24-11e9-8759-76f40c46d6fa.png)

- [x] Check the monetization animation works properly

  - ![image](https://user-images.githubusercontent.com/525211/66627467-04813600-ec26-11e9-855a-517700af4e26.png)
  - Only required on desktop browsers
  - Should animate when monetized and packets received
  - Should stop animation when network disconnected
    - Note that on Firefox/MacOS the popup automatically closes when the
      tab loses focus so can use something like this in terminal:
      - `sudo sleep 10 && sudo ifconfig en0 down && sleep 10 && sudo ifconfig en0 up`

- [x] Check monetization works consistently

  - In the same tab, go to http://www.travisvcrist.com/gatehub
    - refresh and make sure streaming works 10 times in a rowg
      - should not get 'stuck' in 'setting up payment' state
  - Issue: [coil/coilhq#3038][ci3038]
  - Fix PRs: [#242][np242]

- [x] Will route to \$coildomain.com/login rather than open popup if logged out

  - Log out from \$coildomain.com
  - Check that icon is in 'unavailable' state
    - ![image](https://user-images.githubusercontent.com/525211/66627206-2a5a0b00-ec25-11e9-9c0c-74dc34370e13.png)
  - Click on browser action
  - Check that routed to login page
    - ![image](https://user-images.githubusercontent.com/525211/66627301-6beab600-ec25-11e9-8045-a4e35686dc34.png)

- [x] Popup icon should show if page is monetized even when logged out

  - Log out from extension
  - Go to a monetized page and check that the icon "monetized" black and in 'unavailable' state
    - ![image](https://user-images.githubusercontent.com/525211/70715784-8f150d00-1d1d-11ea-8f82-fe116b2e9a16.png)

- [x] Run the puppeteer [tests](./test.sh) (look at the [circle jobs](../../../.circleci/config.yml))

  - export BROWSER_TYPE='chrome' # or 'firefox'
  - logout test currently fails on Firefox due to puppeteer-firefox limitations

- [x] Go to a [youtube video](https://www.youtube.com/watch?v=l1btEwwRePs),
      manually skip to near end of video, and when autoplay of a video from
      another channel starts, check that monetization has stopped.

  - Issues: [#33][i33]
  - PRs: [#213][np213]

- [x] Go to [xrpcommunity.blog](https://xrpcommunity.blog/) and as page
      is loading very quickly open the popup.
      It should show "This page is Web-Monetized" even before streaming
      starts. Should show 'setting up payment' then 'coil is paying creator'
      [#120][i120]

- [x] Open the [reloading-every-15s.html](../test/fixtures/reloading-every-15s.html) file:

  - Use a localhost server so WM works (e.g. with `python -m http.server 4000`)
  - Open the developer tools console undocked so can view while **PAGE IS BACKGROUNDED**
    - Note the `Reloading page` logging
  - Open the extension background page developer tools and look at the stream logging
  - SHOULD NOT initiate a stream or SPSP request
    [#144][i144]

- [x] Open the [event-logger.html](test/fixtures/event-logger.html) file:

  - Use a localhost server so WM works (e.g. with `python -m http.server 4000`)
  - Look for unusual timings, check that pending state is emitted nearly
    immediately after page load or meta tag added
    - **TESTERS NOTE (resolved)**: 
      - ![image](https://user-images.githubusercontent.com/525211/75846181-1601ef00-5e0e-11ea-8f7d-fbb463d5468c.png)
      - *is this a performance regression? if so, is it acceptable ?* 
      - Normal time-to-pending on master: ![image](https://user-images.githubusercontent.com/525211/75846949-58c4c680-5e10-11ea-919f-38dc9330dc3c.png)
      - **NOTE**: this was simply due to having devtools open 

  - Issue: [#63][ni63]
  - Fix PR: [#69][np69]

- [x] Check started event fires when quickly switching between tabs

  - Open the [event-logger.html](test/fixtures/event-logger.html) file
  - Switch to another (non-monetized) tab. The payments stop. Quickly switch back to the first tab.
  - The payments restart. Make sure there is a monetizationstart event
  - Issue: [#105][ni105]
  - Fix PR: [#117][np117]

- [x] Check stopped event fires with correct requestId

  - Open the [event-logger.html](test/fixtures/event-logger.html) file
  - Induce a stop/start in same js 'tick'
    - **TESTERS NOTE** 
      - ![image](https://user-images.githubusercontent.com/525211/75846316-8577de80-5e0e-11ea-8e8c-750bf038ffad.png)
      - FIXED
  - Check that the stopped event has the correct requestId
  - Issue: [#127][ni127]
  - Fix PR: [#128][np128]

- [x] Run a local web server (e.g. with `python -m http.server 4000`) serving
      the dist folder, then open [static/popup.html](static/popup.html) in a
      normal tab and check the popup rendering in various states.

- [x] On MacOS Chromium browsers (Chrome/Edge) check that the monetized animation is working
      on non primary monitors.

  - Issue: [#312][i312]
  - Fix PR: [#317][p317]

- [x] Check that popup closes when another window is focused

  - Open two Browser windows, open the popup in one window
  - Focus on second window
  - Ensure that popup is closed

  - Issue: [#313][i313]
  - Fix PR: [#332][p332]

- [x] Check SPA apps keep streaming when url changed, meta stays

  - Go to e.g. https://www.wevolver.com/
  - Change other pages which uses HTML5 history.pushState
  - Check that streaming is maintained throughout

    - if not, use browser devtools to check if meta exists
      - `document.head.querySelector('meta[name="monetization"]')`

  - Issue: [#507][i507]
  - Fix PR: [#508][p508]

[i33]: https://github.com/coilhq/web-monetization/issues/33
[i120]: https://github.com/coilhq/web-monetization/issues/120
[i144]: https://github.com/coilhq/web-monetization/issues/144
[p166]: https://github.com/coilhq/web-monetization/pull/166
[i213]: https://github.com/coilhq/web-monetization/issues/213
[p222]: https://github.com/coilhq/web-monetization/pull/222
[p295]: https://github.com/coilhq/web-monetization/pull/295
[ci2084]: https://github.com/coilhq/coil/issues/2084
[ci3038]: https://github.com/coilhq/coil/issues/3038
[i312]: https://github.com/coilhq/web-monetization/issues/312
[p317]: https://github.com/coilhq/web-monetization/pull/317
[i313]: https://github.com/coilhq/web-monetization/issues/313
[p332]: https://github.com/coilhq/web-monetization/pull/332
[i507]: https://github.com/coilhq/web-monetization/issues/507
[p508]: https://github.com/coilhq/web-monetization/pull/508
[np28]: https://github.com/coilhq/web-monetization-projects/pull/28
[ni21]: https://github.com/coilhq/web-monetization-projects/issue/21
[ni63]: https://github.com/coilhq/web-monetization-projects/issue/63
[np69]: https://github.com/coilhq/web-monetization-projects/pull/69
[ni105]: https://github.com/coilhq/web-monetization-projects/issue/105
[np117]: https://github.com/coilhq/web-monetization-projects/pull/117
[ni127]: https://github.com/coilhq/web-monetization-projects/issue/127
[np128]: https://github.com/coilhq/web-monetization-projects/pull/128
[ni184]: https://github.com/coilhq/web-monetization-projects/issue/184
[np185]: https://github.com/coilhq/web-monetization-projects/pull/185
[np213]: https://github.com/coilhq/web-monetization-projects/pull/213
[np242]: https://github.com/coilhq/web-monetization-projects/pull/242
