### PR TITLE
feat: tipping preview

### DIFF
--- a/packages/coil-client/src/queries/whoAmI.ts
+++ b/packages/coil-client/src/queries/whoAmI.ts
@@ -12,6 +12,7 @@ export const whoamiQuery = `{
     id
     fullName
     customerId
+    canTip
 
     subscription {
       active

--- a/packages/coil-client/src/queries/whoAmI.ts
+++ b/packages/coil-client/src/queries/whoAmI.ts
@@ -6,11 +6,13 @@ export interface WhoAmIData {
   whoami: CoilUser
 }
 
+// TODO: when in staging amend this with canTip
 export const whoamiQuery = `{
   whoami {
     id
     fullName
     customerId
+
     subscription {
       active
     }

--- a/packages/coil-client/src/queries/whoAmI.ts
+++ b/packages/coil-client/src/queries/whoAmI.ts
@@ -6,7 +6,6 @@ export interface WhoAmIData {
   whoami: CoilUser
 }
 
-// TODO: when in staging amend this with canTip
 export const whoamiQuery = `{
   whoami {
     id

--- a/packages/coil-extension/src/background/services/AuthService.ts
+++ b/packages/coil-extension/src/background/services/AuthService.ts
@@ -65,7 +65,6 @@ export class AuthService extends EventEmitter {
     if (resp.data?.whoami) {
       this.store.user = {
         ...resp.data.whoami,
-        canTip: true
       }
       return token
     } else {

--- a/packages/coil-extension/src/background/services/AuthService.ts
+++ b/packages/coil-extension/src/background/services/AuthService.ts
@@ -63,7 +63,10 @@ export class AuthService extends EventEmitter {
     const resp = await this.client.whoAmI(token)
     this.log('updateWhoAmi resp', resp.data)
     if (resp.data?.whoami) {
-      this.store.user = resp.data.whoami
+      this.store.user = {
+        ...resp.data.whoami,
+        canTip: true
+      }
       return token
     } else {
       return null

--- a/packages/coil-extension/src/background/services/AuthService.ts
+++ b/packages/coil-extension/src/background/services/AuthService.ts
@@ -64,7 +64,7 @@ export class AuthService extends EventEmitter {
     this.log('updateWhoAmi resp', resp.data)
     if (resp.data?.whoami) {
       this.store.user = {
-        ...resp.data.whoami,
+        ...resp.data.whoami
       }
       return token
     } else {

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -316,7 +316,6 @@ export class BackgroundScript {
         break
       case 'sendTip':
         sendResponse(await this.sendTip())
-        // sendResponse({ success: true })
         break
       default:
         sendResponse(false)
@@ -509,14 +508,18 @@ export class BackgroundScript {
     return true
   }
 
-  private async sendTip () {
+  private async sendTip() {
     const tab = this.activeTab
     const stream = this.streams.getStream(this.tabsToStreams[tab])
     const token = this.auth.getStoredToken()
 
     // TODO: return detailed errors
     if (!stream || !token) {
-      this.log('sendTip: no stream | token. !!stream !!token ', !!stream, !!token)
+      this.log(
+        'sendTip: no stream | token. !!stream !!token ',
+        !!stream,
+        !!token
+      )
       return { success: false }
     }
 
@@ -647,7 +650,7 @@ export class BackgroundScript {
   // This feature is no longer used
   async isRateLimited() {
     return {
-      limitExceeded: false,
+      limitExceeded: false
     }
   }
 

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -314,6 +314,10 @@ export class BackgroundScript {
       case 'fetchYoutubeChannelId':
         sendResponse(await this.youtube.fetchChannelId(request.data.youtubeUrl))
         break
+      case 'sendTip':
+        sendResponse(await this.sendTip())
+        // sendResponse({ success: true })
+        break
       default:
         sendResponse(false)
         break
@@ -505,6 +509,42 @@ export class BackgroundScript {
     return true
   }
 
+  private async sendTip () {
+    const tab = this.activeTab
+    const stream = this.streams.getStream(this.tabsToStreams[tab])
+    const token = this.auth.getStoredToken()
+
+    // TODO: return detailed errors
+    if (!stream || !token) {
+      this.log('sendTip: no stream | token. !!stream !!token ', !!stream, !!token)
+      return { success: false }
+    }
+
+    const receiver = stream.getPaymentPointer()
+
+    try {
+      this.log(`sendTip: sending tip to ${receiver}`)
+      const result = await this.client.query({
+        query: `
+          mutation sendTip($receiver: String!) {
+            sendTip(receiver: $receiver) {
+              success
+            }
+          }
+        `,
+        token,
+        variables: {
+          receiver
+        }
+      })
+      this.log(`sendTip: sent tip to ${receiver}`, result)
+      return { success: true }
+    } catch (e) {
+      this.log(`sendTip: error. msg=${e.message}`)
+      return { success: false }
+    }
+  }
+
   private doPauseWebMonetization(tab: number) {
     this.tabStates.logLastMonetizationCommand(tab, 'pause')
     const id = this.tabsToStreams[tab]
@@ -604,34 +644,10 @@ export class BackgroundScript {
     return !!streamId
   }
 
+  // This feature is no longer used
   async isRateLimited() {
-    const token = this.auth.getStoredToken()
-
-    interface ResponseData {
-      whoami: {
-        usage: {
-          resetDate: string
-          exceededLimit: boolean
-        }
-      }
-    }
-
-    const response = await this.client.query<ResponseData>({
-      query: `query isRateLimited {
-      whoami {
-        usage {
-          resetDate
-          exceededLimit
-        }
-      }
-    }`,
-      token
-    })
-
-    const usage = response.data.whoami.usage
     return {
-      limitExceeded: usage.exceededLimit,
-      limitRefreshDate: usage.resetDate
+      limitExceeded: false,
     }
   }
 

--- a/packages/coil-extension/src/background/services/Stream.ts
+++ b/packages/coil-extension/src/background/services/Stream.ts
@@ -285,7 +285,7 @@ export class Stream extends EventEmitter {
     this.emit('abort', this._requestId)
   }
 
-  getPaymentPointer () {
+  getPaymentPointer() {
     return this._paymentPointer
   }
 }

--- a/packages/coil-extension/src/background/services/Stream.ts
+++ b/packages/coil-extension/src/background/services/Stream.ts
@@ -284,6 +284,10 @@ export class Stream extends EventEmitter {
     // stop.
     this.emit('abort', this._requestId)
   }
+
+  getPaymentPointer () {
+    return this._paymentPointer
+  }
 }
 
 interface StreamAttemptOptions {

--- a/packages/coil-extension/src/background/services/Streams.ts
+++ b/packages/coil-extension/src/background/services/Streams.ts
@@ -64,4 +64,8 @@ export class Streams extends EventEmitter {
       delete this._streams[id]
     }
   }
+
+  getStream(id: string) {
+    return this._streams[id]
+  }
 }

--- a/packages/coil-extension/src/popup/components/MonetizedPage.tsx
+++ b/packages/coil-extension/src/popup/components/MonetizedPage.tsx
@@ -7,6 +7,7 @@ import { Link } from './util/Link'
 import { StatusTypography } from './util/StatusTypography'
 import { MonetizeAnimation } from './MonetizationAnimation'
 import { StreamControls } from './StreamControls'
+import { TipButton } from './TipButton'
 import { useShowIfClicked } from './util/useShowIfClicked'
 
 const FlexBox = styled('div')(({ theme }) => ({
@@ -62,6 +63,9 @@ export function MonetizedPage(props: PopupProps) {
         </div>
       </Grid>
       {showControls && <StreamControls context={context} />}
+
+      {/* this will only show if user is enabled */}
+      <TipButton context={context} />
     </>
   )
 }

--- a/packages/coil-extension/src/popup/components/TipButton.tsx
+++ b/packages/coil-extension/src/popup/components/TipButton.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react'
+import { Button } from '@material-ui/core'
+
+import { PopupProps } from '../types'
+
+export enum TipState {
+  READY = 0,
+  LOADING,
+  COMPLETE
+}
+
+export const TipButton = (props: PopupProps) => {
+  const [tipState, setTipState] = useState(TipState.READY)
+  const onClickTip = () => {
+    setTipState(TipState.LOADING)
+    // TODO: kick off async tip instead
+    setTimeout(() => {
+      setTipState(TipState.COMPLETE)
+      setTimeout(() => {
+        setTipState(TipState.READY)
+      }, 1000)
+    }, 500)
+  }
+
+  if (props.context.store.user.canTip) {
+    switch (tipState) {
+      case TipState.READY:
+        return <Button onClick={onClickTip}>Tip this creator $1!</Button>
+
+      case TipState.LOADING:
+        return <Button disabled>Tipping...</Button>
+
+      case TipState.COMPLETE:
+        return <Button disabled>Tip complete!</Button>
+    }
+  } else {
+    return <></>
+  }
+}

--- a/packages/coil-extension/src/popup/components/TipButton.tsx
+++ b/packages/coil-extension/src/popup/components/TipButton.tsx
@@ -22,6 +22,18 @@ export const TipButton = (props: PopupProps) => {
     }, 500)
   }
 
+  /* TODO: use something like this to tip the current page.
+ * TODO: how do we grab the payment pointer from here?
+ * TODO: should we just handle the response inline?
+  const setStreamControls = (data: SetStreamControlsParams) => {
+    const message: SetStreamControls = {
+      command: 'setStreamControls',
+      data
+    }
+    props.context.runtime.sendMessage(message)
+  }
+  */
+
   if (props.context.store.user.canTip) {
     switch (tipState) {
       case TipState.READY:

--- a/packages/coil-extension/src/popup/components/TipButton.tsx
+++ b/packages/coil-extension/src/popup/components/TipButton.tsx
@@ -16,7 +16,6 @@ export const TipButton = (props: PopupProps) => {
   const onClickTip = async () => {
     setTipState(TipState.LOADING)
 
-    // TODO: get the real payment pointer
     const { success } = await sendTip()
 
     if (success) {
@@ -30,9 +29,6 @@ export const TipButton = (props: PopupProps) => {
     }, 1000)
   }
 
-  /* TODO: use something like this to tip the current page.
-   * TODO: how do we grab the payment pointer from here?
-   * TODO: should we just handle the response inline?*/
   const sendTip = async () => {
     const message: SendTip = { command: 'sendTip' }
 

--- a/packages/coil-extension/src/popup/components/TipButton.tsx
+++ b/packages/coil-extension/src/popup/components/TipButton.tsx
@@ -2,37 +2,50 @@ import React, { useState } from 'react'
 import { Button } from '@material-ui/core'
 
 import { PopupProps } from '../types'
+import { SendTip, SendTipResult } from '../../types/commands'
 
 export enum TipState {
   READY = 0,
   LOADING,
-  COMPLETE
+  COMPLETE,
+  ERROR
 }
 
 export const TipButton = (props: PopupProps) => {
   const [tipState, setTipState] = useState(TipState.READY)
-  const onClickTip = () => {
+  const onClickTip = async () => {
     setTipState(TipState.LOADING)
-    // TODO: kick off async tip instead
-    setTimeout(() => {
+
+    // TODO: get the real payment pointer
+    const { success } = await sendTip('$example.com')
+
+    if (success) {
       setTipState(TipState.COMPLETE)
-      setTimeout(() => {
-        setTipState(TipState.READY)
-      }, 1000)
-    }, 500)
+    } else {
+      setTipState(TipState.ERROR)
+    }
+
+    setTimeout(() => {
+      setTipState(TipState.READY)
+    }, 1000)
   }
 
   /* TODO: use something like this to tip the current page.
- * TODO: how do we grab the payment pointer from here?
- * TODO: should we just handle the response inline?
-  const setStreamControls = (data: SetStreamControlsParams) => {
-    const message: SetStreamControls = {
-      command: 'setStreamControls',
-      data
+   * TODO: how do we grab the payment pointer from here?
+   * TODO: should we just handle the response inline?*/
+  const sendTip = async (receiver: string) => {
+    const message: SendTip = {
+      command: 'sendTip',
+      data: {
+        receiver
+      }
     }
-    props.context.runtime.sendMessage(message)
+
+    // TODO: is this the right typing?
+    return (props.context.runtime.sendMessage(message) as unknown) as Promise<
+      SendTipResult
+    >
   }
-  */
 
   if (props.context.store.user.canTip) {
     switch (tipState) {
@@ -44,6 +57,9 @@ export const TipButton = (props: PopupProps) => {
 
       case TipState.COMPLETE:
         return <Button disabled>Tip complete!</Button>
+
+      case TipState.ERROR:
+        return <Button disabled>Something went wrong.</Button>
     }
   } else {
     return <></>

--- a/packages/coil-extension/src/popup/components/TipButton.tsx
+++ b/packages/coil-extension/src/popup/components/TipButton.tsx
@@ -17,7 +17,7 @@ export const TipButton = (props: PopupProps) => {
     setTipState(TipState.LOADING)
 
     // TODO: get the real payment pointer
-    const { success } = await sendTip('$example.com')
+    const { success } = await sendTip()
 
     if (success) {
       setTipState(TipState.COMPLETE)
@@ -33,18 +33,14 @@ export const TipButton = (props: PopupProps) => {
   /* TODO: use something like this to tip the current page.
    * TODO: how do we grab the payment pointer from here?
    * TODO: should we just handle the response inline?*/
-  const sendTip = async (receiver: string) => {
-    const message: SendTip = {
-      command: 'sendTip',
-      data: {
-        receiver
-      }
-    }
+  const sendTip = async () => {
+    const message: SendTip = { command: 'sendTip' }
 
-    // TODO: is this the right typing?
-    return (props.context.runtime.sendMessage(message) as unknown) as Promise<
-      SendTipResult
-    >
+    return new Promise(resolve => {
+      props.context.runtime.sendMessage(message, (result: SendTipResult) => {
+        resolve(result)
+      })
+    }) as Promise<SendTipResult>
   }
 
   if (props.context.store.user.canTip) {

--- a/packages/coil-extension/src/types/commands.ts
+++ b/packages/coil-extension/src/types/commands.ts
@@ -221,6 +221,25 @@ export interface SetMonetizationState {
   }
 }
 
+/**
+ * popup -> background
+ * browser.runtime.sendMessage
+ */
+export interface SendTip {
+  command: 'sendTip'
+  data: {
+    receiver: string
+  }
+}
+
+/**
+ * background -> popup
+ * reply to browser.runtime.sendMessage
+ */
+export interface SendTipResult {
+  success: boolean
+}
+
 export type ToContentMessage =
   | CheckAdaptedContent
   | MonetizationProgress

--- a/packages/coil-extension/src/types/commands.ts
+++ b/packages/coil-extension/src/types/commands.ts
@@ -127,6 +127,7 @@ export type ToBackgroundMessage =
   | IsRateLimited
   | ContentScriptInit
   | FetchYoutubeChannelId
+  | SendTip
 
 export type IconState =
   | 'streaming-paused'
@@ -227,9 +228,6 @@ export interface SetMonetizationState {
  */
 export interface SendTip {
   command: 'sendTip'
-  data: {
-    receiver: string
-  }
 }
 
 /**

--- a/packages/coil-extension/src/types/user.ts
+++ b/packages/coil-extension/src/types/user.ts
@@ -2,6 +2,7 @@ export interface User {
   id: string
   fullName: string
   customerId?: string
+  canTip?: boolean
   subscription?: {
     active: boolean
   }


### PR DESCRIPTION
For users enabled for tipping, this adds a button to the popup on Web Monetized pages. Right now it's an internal pilot that sends out one dollar at a time. This does not affect the experience for users on which `canTip` is not true (i.e. they aren't `@coil.com`)