### PR TITLE
feat(coil-extension): monetize nested iframes

### DIFF
--- a/packages/coil-extension/src/background/services/CachedOperations.ts
+++ b/packages/coil-extension/src/background/services/CachedOperations.ts
@@ -1,0 +1,32 @@
+import { injectable } from 'inversify'
+
+interface QueryParams<T> {
+  key: string
+  maxAgeMs: number
+  operationFactory: () => Promise<T>
+}
+
+@injectable()
+export class CachedOperations {
+  cache = new Map<string, { time: number; result: Promise<any> }>()
+
+  async query<T>({ key, maxAgeMs, operationFactory }: QueryParams<T>) {
+    let cached = this.cache.get(key)
+    if (!cached || Date.now() - cached.time >= maxAgeMs) {
+      cached = {
+        time: Date.now(),
+        result: operationFactory()
+      }
+      this.cache.set(key, cached)
+    }
+    const resultForInvokation = cached.result
+    try {
+      return await cached.result
+    } catch (e) {
+      if (this.cache.get(key)?.result === resultForInvokation) {
+        this.cache.delete(key)
+      }
+      throw e
+    }
+  }
+}

--- a/packages/coil-extension/src/background/services/Stream.ts
+++ b/packages/coil-extension/src/background/services/Stream.ts
@@ -248,7 +248,6 @@ export class Stream extends EventEmitter {
   onMoney(data: OnMoneyEvent) {
     if (data.amount <= 0) return
 
-    this._debug(`emitting money. amount=${data.amount}`)
     const now = Date.now()
     const msSinceLastPacket = now - this._lastOutgoingMs
     this._lastOutgoingMs = now

--- a/packages/coil-extension/src/background/util/flatMapSlow.ts
+++ b/packages/coil-extension/src/background/util/flatMapSlow.ts
@@ -1,0 +1,10 @@
+export function flatMapSlow<T, U>(
+  array: T[],
+  callbackfn: (value: T, index: number, array: T[]) => U[]
+): U[] {
+  if (typeof array.flatMap !== 'undefined') {
+    return array.flatMap(callbackfn)
+  } else {
+    return Array.prototype.concat(...array.map(callbackfn))
+  }
+}

--- a/packages/coil-extension/src/content/services/ContentScript.ts
+++ b/packages/coil-extension/src/content/services/ContentScript.ts
@@ -261,13 +261,15 @@ export class ContentScript {
     const monetizationRequest = this.monetization.getMonetizationRequest()
     if (allowed) {
       if (monetizationRequest && this.monetization.getState() === 'stopped') {
-        void this.doStartMonetization()
-        if (this.paused) {
-          const pause: PauseWebMonetization = {
-            command: 'pauseWebMonetization'
+        // The pause needs to be done after the async allow checks and start
+        this.doStartMonetization().then(() => {
+          if (this.paused) {
+            const pause: PauseWebMonetization = {
+              command: 'pauseWebMonetization'
+            }
+            this.runtime.sendMessage(pause)
           }
-          this.runtime.sendMessage(pause)
-        }
+        })
       }
     } else {
       if (monetizationRequest) {

--- a/packages/coil-extension/src/content/services/Frames.ts
+++ b/packages/coil-extension/src/content/services/Frames.ts
@@ -33,7 +33,7 @@ export class Frames {
     this.isIFrame = !this.isTopFrame
     this.isCoilTopFrame = this.isTopFrame && this.isAnyCoilFrame
     this.isDirectChildFrame = this.isIFrame && window.parent === window.top
-    this.isMonetizableFrame = this.isTopFrame || this.isDirectChildFrame
+    this.isMonetizableFrame = true
   }
 
   monitor() {

--- a/packages/coil-extension/src/content/util/isMonetizationAllowed.ts
+++ b/packages/coil-extension/src/content/util/isMonetizationAllowed.ts
@@ -1,10 +1,11 @@
 import { parsePolicyDirectives } from '@web-monetization/polyfill-utils'
 
 export function isMonetizationAllowed(frame: HTMLIFrameElement) {
+  const allowValue = frame.attributes.getNamedItem('allow')?.value
   let allowed = false
   try {
-    if (frame.allow) {
-      const parsed = parsePolicyDirectives(frame.allow)
+    if (allowValue) {
+      const parsed = parsePolicyDirectives(allowValue)
       allowed = 'monetization' in parsed
     }
   } catch (e) {

--- a/packages/coil-extension/src/content/util/timeout.ts
+++ b/packages/coil-extension/src/content/util/timeout.ts
@@ -1,3 +1,3 @@
-export async function timeout(ms: number) {
+export async function timeout(ms: number): Promise<undefined> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }

--- a/packages/coil-extension/src/types/commands.ts
+++ b/packages/coil-extension/src/types/commands.ts
@@ -17,7 +17,7 @@ export interface LocalStorageUpdate extends Command {
   key: string
 }
 
-interface Command<T = any> {
+export interface Command<T = any> {
   command: string
   data?: T
 }

--- a/packages/coil-extension/test/fixtures/iframes/frame4.html
+++ b/packages/coil-extension/test/fixtures/iframes/frame4.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>IFrame 4</title>
+  </head>
+  <body>
+    <h1>IFrame 4</h1>
+    <iframe allow="monetization" id="frame1" src="./frame1.html"></iframe>
+    <iframe allow="monetization" id="frame1copy" src="./frame1.html"></iframe>
+  </body>
+</html>

--- a/packages/coil-extension/test/fixtures/iframes/top-nested-allowed-iframe.html
+++ b/packages/coil-extension/test/fixtures/iframes/top-nested-allowed-iframe.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>TOP Frame NESTED</title>
+  </head>
+  <body>
+    <div id="log"></div>
+    <iframe allow="monetization" id="frame4" src="./frame4.html"></iframe>
+    <iframe allow="monetization" id="frame4Copy" src="./frame4.html"></iframe>
+  </body>
+</html>


### PR DESCRIPTION
This PR implements nested <iframe> support.

For an iframe to be monetized the allow feature set policy must include monetization in all parent frames.
 
![image](https://user-images.githubusercontent.com/525211/76395359-b6758780-63a9-11ea-980e-7aeeabd4647b.png)
For example, in the image above, the children inside `<iframe id="frame4copy">` (highlighted) will **NOT** monetize, while those in `<iframe id="frame4">` **WILL**. 

### Questions
Some questions from the initial PR are still relevant:
https://github.com/coilhq/web-monetization-projects/pull/415

### Testing 

1. Open a terminal and `cd packages/coil-extension/test/fixtures/iframes/`
2. Start a server (via `python -m http.server 4000` or equivalent)
3. Open http://localhost:4000/top-nested-allowed-iframe.html in browser
4. Open developer tools and look at the structure of the dom
  -  Use expand recursively feature
    - ![image](https://user-images.githubusercontent.com/525211/76400168-71098800-63b2-11ea-8069-5ee7b8b0707a.png)
5. With the console set `localStorage.WM_DEBUG = true`

#### Test 1: basic monetization
1. Load the page
2. Look for 4 monetizationpending events and 4 corresponding (same requestId) monetizationstart events logged in the console.

![image](https://user-images.githubusercontent.com/525211/76397844-6a791180-63ae-11ea-8f1c-72ef3a6183fb.png)

#### Test 2: refresh page / turn off / turn on
1. [re]load the page
2. Open developer tools and turn "off" monetization via editing allow attribute of top level iframes
   - ![image](https://user-images.githubusercontent.com/525211/76398261-28040480-63af-11ea-85cb-396960ced1bb.png)
   - Popup icon (and background page logging) should show no monetization: 
     - ![image](https://user-images.githubusercontent.com/525211/76398281-305c3f80-63af-11ea-857c-6ab6b409daa5.png)
   - Corresponding monetization events should be logged: 
     - ![image](https://user-images.githubusercontent.com/525211/76398873-3999dc00-63b0-11ea-8ee6-7ca45d8b44f0.png)

3. turn "on" monetization via editing allow attribute of top level iframes
   -  ![image](https://user-images.githubusercontent.com/525211/76398370-57b30c80-63af-11ea-86a8-133271e46b91.png)
   - Popup icon (and background page logging) should show monetization 
     - ![image](https://user-images.githubusercontent.com/525211/76398417-6d283680-63af-11ea-88e6-c4b0ed5c35f7.png)
   -  Corresponding monetization events should be logged:
     - ![image](https://user-images.githubusercontent.com/525211/76399026-841b5880-63b0-11ea-8b0b-c0ecbff13bee.png)

#### Test 3:  refresh page / turn off / background tab / turn on / foreground tab 
- As above but while the tab is backgrounded, after turning on each top level iframe a sequence of pending -> stopped events should be fired:
  - ![image](https://user-images.githubusercontent.com/525211/76399956-1a03b300-63b2-11ea-9b77-671e94a1bf16.png)

#### Test 4: nested 
- As per test 2 
- Turn off one top level and then turn off the nested frames in top level that is allowed
- allow *one* nested iframe and check for indications of monetization