### PR TITLE
chore(coil-extension): bump version to 0.0.49

### DIFF
--- a/packages/coil-extension/CHANGELOG.md
+++ b/packages/coil-extension/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="coil-extension@0.0.49"></a>
+
+# [coil-extension@0.0.49](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.48...coil-extension@0.0.49) (2020-04-06)
+
+### Features
+
+- Add anonymous tokens service to authenticate to Coil's Web Monetization infrastructure anonymously. This prevents Web Monetization usage from being tied back to users
+
 <a name="coil-extension@0.0.48"></a>
 
 # [coil-extension@0.0.48](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.47...coil-extension@0.0.48) (2020-03-16)

--- a/packages/coil-extension/docs/release-checklist.md
+++ b/packages/coil-extension/docs/release-checklist.md
@@ -16,7 +16,7 @@ When releasing, we can copy this markdown into the PR for a release.
 - [ ] Update the [CHANGELOG.md](../CHANGELOG.md)
 
   - You can compare with latest commit before tagging via something like:
-    `https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.47...897307ebc212b8464dd974d0a13ff37b20257576`
+    `https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.48...8f359e45f843a4f9a01c090a02e73519413d900b`
 
 ### Zipping Extension Source Files
 

--- a/packages/coil-extension/docs/release-checklist.md
+++ b/packages/coil-extension/docs/release-checklist.md
@@ -86,7 +86,7 @@ make sense.
 - [ ] Check monetization works consistently
 
   - In the same tab, go to http://www.travisvcrist.com/gatehub
-    - refresh and make sure streaming works 10 times in a rowg
+    - refresh and make sure streaming works 10 times in a row
       - should not get 'stuck' in 'setting up payment' state
   - Issue: [coil/coilhq#3038][ci3038]
   - Fix PRs: [#242][np242]

--- a/packages/coil-extension/manifest.json
+++ b/packages/coil-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Coil",
   "description": "Support websites and creators with Web Monetization",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "manifest_version": 2,
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "browser_specific_settings": {

--- a/packages/coil-extension/package.json
+++ b/packages/coil-extension/package.json
@@ -1,10 +1,10 @@
 {
   "$schema": "../coil-monorepo-upkeep/resources/package-json-schema-nested-overrides.json",
   "$overRideUpKeep": {
-    "version": "0.0.48"
+    "version": "0.0.49"
   },
   "name": "@coil/extension",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "private": false,
   "keywords": [
     "ilp",

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -187,12 +187,14 @@ export class BackgroundScript {
 
       // Always get the url from the tab
       const url = event.frame.href
-      if (status === 'loading') {
+      if (status === 'loading' && event.frame.top) {
         this.setCoilUrlForPopupIfNeeded(tabId, url)
       }
 
       if (becameComplete || (isComplete && changedUrl)) {
-        this.setCoilUrlForPopupIfNeeded(tabId, url)
+        if (event.frame.top) {
+          this.setCoilUrlForPopupIfNeeded(tabId, url)
+        }
         const from = `onFrameChanged directly, event=${JSON.stringify(event)}, `
         const message: CheckAdaptedContent = {
           command: 'checkAdaptedContent',


### PR DESCRIPTION
## Chores

- [x] Make sure the manifest version was bumped but doesn't skip versions

- [x] Update the [CHANGELOG.md](../CHANGELOG.md)

  - You can compare with latest commit before tagging via something like:
    `https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.48...8f359e45f843a4f9a01c090a02e73519413d900b`

### Zipping Extension Source Files

- [x] Zip the source code for the extension

  - Some web stores will require the submission of source files.
  - So far, zipping the `coil-extension` folder (instead of zipping at the project root)
    has given us the least trouble with passing review.
    - For example, `zip -r coil-extension.zip coil-extension/`
  - `node_modules` should be deleted prior to zipping the source files.

## Firefox MacOS 75.0 (64-bit)

- [x] Build for prod with release settings

  - e.g. `yarn build-prod chrome -p --run-prod --devtool=none`
    - as per [package.sh](../package.sh)

- [x] Import unpacked/temporary extension/add-on

  - For Firefox, go to `about:debugging`
    - Enable add-on debugging
    - Load Temporary Add-on...
  - For Chrome or MS Edge, go to `chrome://extensions` (or `edge://extensions`) and `Load Unpacked`

- [x] Ensure that you are [logged in with a user with valid subscription](https://coil.com/settings/payment)

  - ![image](https://user-images.githubusercontent.com/525211/71150879-28d04300-2265-11ea-96da-7d720c101575.png)

- [x] [example.com](http://example.com/) should say "This website is not supported"

  - ![image](https://user-images.githubusercontent.com/525211/66626576-f4b42280-ec22-11e9-9f77-4a95be08643e.png)

- [x] [xrpcommunity.blog](https://xrpcommunity.blog/) should monetize

  - ![image](https://user-images.githubusercontent.com/525211/66626655-3c3aae80-ec23-11e9-981a-0e317ab80b42.png)

- [x] [twitch.tv](https://twitch.tv/vinesauce) works

  - ![image](https://user-images.githubusercontent.com/525211/66626721-815ee080-ec23-11e9-8139-59a563822eb0.png)

- [x] [monetized youtube video](https://www.youtube.com/watch?v=-QMbZx_w2_Y)

  - ![image](https://user-images.githubusercontent.com/525211/66626878-0a761780-ec24-11e9-8015-19bf8348807b.png)

- Coil welcome and welcome to explore pages

  - [x] Go to coil.com, the browser action popup should show welcome to coil
    - ![image](https://user-images.githubusercontent.com/525211/66626988-6b9deb00-ec24-11e9-86c3-b55c17e891c2.png)
  - [x] Should have a link to coil.com/explore page
  - [x] Once on explore page should show `Start Exploring` with a rocket-ship graphic
    - ![image](https://user-images.githubusercontent.com/525211/66627053-a2740100-ec24-11e9-8759-76f40c46d6fa.png)

- [x] Check the monetization animation works properly

  - ![image](https://user-images.githubusercontent.com/525211/66627467-04813600-ec26-11e9-855a-517700af4e26.png)
  - Only required on desktop browsers
  - Should animate when monetized and packets received
  - Should stop animation when network disconnected
    - Note that on Firefox/MacOS the popup automatically closes when the
      tab loses focus so can use something like this in terminal:
      - `sudo sleep 10 && sudo ifconfig en0 down && sleep 10 && sudo ifconfig en0 up`

- [x] Check monetization works consistently

  - In the same tab, go to http://www.travisvcrist.com/gatehub
    - refresh and make sure streaming works 10 times in a rowg
      - should not get 'stuck' in 'setting up payment' state
  - Issue: [coil/coilhq#3038][ci3038]
  - Fix PRs: [#242][np242]

- [x] Will route to \$coildomain.com/login rather than open popup if logged out
  - **TESTERS NOTE**: see https://github.com/coilhq/web-monetization-projects/issues/548
  - Log out from \$coildomain.com
  - Check that icon is in 'unavailable' state
    - ![image](https://user-images.githubusercontent.com/525211/66627206-2a5a0b00-ec25-11e9-9c0c-74dc34370e13.png)
  - Click on browser action
  - Check that routed to login page
    - ![image](https://user-images.githubusercontent.com/525211/66627301-6beab600-ec25-11e9-8045-a4e35686dc34.png)

- [ ] Popup icon should show if page is monetized even when logged out

  - Log out from extension
  - Go to a monetized page and check that the icon "monetized" black and in 'unavailable' state
    - ![image](https://user-images.githubusercontent.com/525211/70715784-8f150d00-1d1d-11ea-8f82-fe116b2e9a16.png)

- [ ] Run the puppeteer [tests](./test.sh) (look at the [circle jobs](../../../.circleci/config.yml))

  - export BROWSER_TYPE='chrome' # or 'firefox'
  - logout test currently fails on Firefox due to puppeteer-firefox limitations

- [ ] Go to a [youtube video](https://www.youtube.com/watch?v=l1btEwwRePs),
      manually skip to near end of video, and when autoplay of a video from
      another channel starts, check that monetization has stopped.

  - Issues: [#33][i33]
  - PRs: [#213][np213]

- [ ] Go to [xrpcommunity.blog](https://xrpcommunity.blog/) and as page
      is loading very quickly open the popup.
      It should show "This page is Web-Monetized" even before streaming
      starts. Should show 'setting up payment' then 'coil is paying creator'
      [#120][i120]

- [ ] Open the [reloading-every-15s.html](../test/fixtures/reloading-every-15s.html) file:

  - Use a localhost server so WM works (e.g. with `python -m http.server 4000`)
  - Open the developer tools console undocked so can view while **PAGE IS BACKGROUNDED**
    - Note the `Reloading page` logging
  - Open the extension background page developer tools and look at the stream logging
  - SHOULD NOT initiate a stream or SPSP request
    [#144][i144]

- [ ] Open the [event-logger.html](test/fixtures/event-logger.html) file:

  - Use a localhost server so WM works (e.g. with `python -m http.server 4000`)
  - Look for unusual timings, check that pending state is emitted nearly
    immediately after page load or meta tag added
  - Issue: [#63][ni63]
  - Fix PR: [#69][np69]

- [ ] Check started event fires when quickly switching between tabs

  - Open the [event-logger.html](test/fixtures/event-logger.html) file
  - Switch to another (non-monetized) tab. The payments stop. Quickly switch back to the first tab.
  - The payments restart. Make sure there is a monetizationstart event
  - Issue: [#105][ni105]
  - Fix PR: [#117][np117]

- [ ] Check stopped event fires with correct requestId

  - Open the [event-logger.html](test/fixtures/event-logger.html) file
  - Induce a stop/start in same js 'tick'
  - Check that the stopped event has the correct requestId
  - Issue: [#127][ni127]
  - Fix PR: [#128][np128]

- [ ] Run a local web server (e.g. with `python -m http.server 4000`) serving
      the dist folder, then open [static/popup.html](static/popup.html) in a
      normal tab and check the popup rendering in various states.

- [ ] If the browser is running on android, check that the "popup" browser action
      simply opens settings.

  - Install android-sdk on PC and Firefox on android
  - Enable developer mode on android and enable usb debugging
  - Plug in android to PC via usb
  - `adb devices # make note of device id`
  - `adb shell pm grant org.mozilla.firefox android.permission.READ_EXTERNAL_STORAGE`
  - `adb shell pm grant org.mozilla.firefox android.permission.WRITE_EXTERNAL_STORAGE`
  - Build the extension
  - `yarn web-ext run -s $PWD/dist --target=firefox-android --android-device=WUJ01PNSVY # from adb devices step`
  - Issue: [coil/coilhq#2084][ci2084]
  - Fix PRs: [#166][p166] [#295][p295]

- [ ] On MacOS Chromium browsers (Chrome/Edge) check that the monetized animation is working
      on non primary monitors.

  - Issue: [#312][i312]
  - Fix PR: [#317][p317]

- [ ] Check that popup closes when another window is focused

  - Open two Browser windows, open the popup in one window
  - Focus on second window
  - Ensure that popup is closed

  - Issue: [#313][i313]
  - Fix PR: [#332][p332]

- [ ] Check SPA apps keep streaming when url changed, meta stays

  - Go to e.g. https://www.wevolver.com/
  - Change other pages which uses HTML5 history.pushState
  - Check that streaming is maintained throughout

    - if not, use browser devtools to check if meta exists
      - `document.head.querySelector('meta[name="monetization"]')`

  - Issue: [#507][i507]
  - Fix PR: [#508][p508]

- [ ] Check extension doesn't attempt to stream when unsubscribed

  - Log in with coil user that doesn't have active subscription
  - Open the developer tools and check the logging
  - SHOULD NOT even attempt to stream
  - ![image](https://user-images.githubusercontent.com/525211/66631124-c9840000-ec2f-11e9-95a4-3bebe7fdebd6.png)
  - Issue: [#213][i213]
  - Fix PR: [#222][p222]

- [ ] Check can stream immediately after subscribing
  - Likely best to test this with staging where can use a test card
  - Log in with coil user that doesn't have active subscription
  - Add a subscription (can use [testing card](https://stripe.com/docs/testing) 4242 4242 4242 4242 )
  - Go to a monetized page and check that streaming works immediately

### Iframe testing

1. - [ ] Open a terminal and `cd packages/coil-extension/test/fixtures/iframes/`
2. - [ ] Start a server (via `python -m http.server 4000` or equivalent)
3. - [ ] Open http://localhost:4000/top-nested-allowed-iframe.html in browser
4. Open developer tools and look at the structure of the dom

- Use expand recursively feature
  - ![image](https://user-images.githubusercontent.com/525211/76400168-71098800-63b2-11ea-8069-5ee7b8b0707a.png)

5. - [ ] With the console set `localStorage.WM_DEBUG = true`

#### Test 1: basic monetization

1. Load the page
2. - [ ] Look for 4 monetizationpending events and 4 corresponding (same requestId) monetizationstart events logged in the console.

![image](https://user-images.githubusercontent.com/525211/76397844-6a791180-63ae-11ea-8f1c-72ef3a6183fb.png)

#### Test 2: refresh page / turn off / turn on

1. - [ ] [re]load the page
2. - [ ] Open developer tools and turn "off" monetization via editing allow attribute of top level iframes
   - ![image](https://user-images.githubusercontent.com/525211/76398261-28040480-63af-11ea-85cb-396960ced1bb.png)
   - Popup icon (and background page logging) should show no monetization:
     - [ ] ![image](https://user-images.githubusercontent.com/525211/76398281-305c3f80-63af-11ea-857c-6ab6b409daa5.png)
   - Corresponding monetization events should be logged:
     - [ ] ![image](https://user-images.githubusercontent.com/525211/76398873-3999dc00-63b0-11ea-8ee6-7ca45d8b44f0.png)

3. turn "on" monetization via editing allow attribute of top level iframes
   - ![image](https://user-images.githubusercontent.com/525211/76398370-57b30c80-63af-11ea-86a8-133271e46b91.png)
   - [ ] Popup icon (and background page logging) should show monetization
     - ![image](https://user-images.githubusercontent.com/525211/76398417-6d283680-63af-11ea-88e6-c4b0ed5c35f7.png)
   - [ ] Corresponding monetization events should be logged:
     - ![image](https://user-images.githubusercontent.com/525211/76399026-841b5880-63b0-11ea-8b0b-c0ecbff13bee.png)

#### Test 3: refresh page / turn off / background tab / turn on / foreground tab

- As above but while the tab is backgrounded, after turning on each top level iframe a sequence of pending -> stopped events should be fired:
  - [ ] ![image](https://user-images.githubusercontent.com/525211/76399956-1a03b300-63b2-11ea-9b77-671e94a1bf16.png)

#### Test 4: nested

- As per test 2
- Turn off one top level and then turn off the nested frames in top level that is allowed
- [ ] allow _one_ nested iframe and check for indications of monetization


## Chrome

Copy below for each platform/browser/version tested, filtering steps where it
make sense.

- [x] Build for prod with release settings

  - e.g. `yarn build-prod chrome -p --run-prod --devtool=none`
    - as per [package.sh](../package.sh)

- [x] Import unpacked/temporary extension/add-on

  - For Firefox, go to `about:debugging`
    - Enable add-on debugging
    - Load Temporary Add-on...
  - For Chrome or MS Edge, go to `chrome://extensions` (or `edge://extensions`) and `Load Unpacked`

- [x] Ensure that you are [logged in with a user with valid subscription](https://coil.com/settings/payment)

  - ![image](https://user-images.githubusercontent.com/525211/71150879-28d04300-2265-11ea-96da-7d720c101575.png)

- [x] [example.com](http://example.com/) should say "This website is not supported"

  - ![image](https://user-images.githubusercontent.com/525211/66626576-f4b42280-ec22-11e9-9f77-4a95be08643e.png)

- [x] [xrpcommunity.blog](https://xrpcommunity.blog/) should monetize

  - ![image](https://user-images.githubusercontent.com/525211/66626655-3c3aae80-ec23-11e9-981a-0e317ab80b42.png)

- [x] [twitch.tv](https://twitch.tv/vinesauce) works

  - ![image](https://user-images.githubusercontent.com/525211/66626721-815ee080-ec23-11e9-8139-59a563822eb0.png)

- [x] [monetized youtube video](https://www.youtube.com/watch?v=-QMbZx_w2_Y)

  - ![image](https://user-images.githubusercontent.com/525211/66626878-0a761780-ec24-11e9-8015-19bf8348807b.png)

- Coil welcome and welcome to explore pages

  - [x] Go to coil.com, the browser action popup should show welcome to coil
    - ![image](https://user-images.githubusercontent.com/525211/66626988-6b9deb00-ec24-11e9-86c3-b55c17e891c2.png)
  - [x] Should have a link to coil.com/explore page
  - [x] Once on explore page should show `Start Exploring` with a rocket-ship graphic
    - ![image](https://user-images.githubusercontent.com/525211/66627053-a2740100-ec24-11e9-8759-76f40c46d6fa.png)

- [x] Check the monetization animation works properly

  - ![image](https://user-images.githubusercontent.com/525211/66627467-04813600-ec26-11e9-855a-517700af4e26.png)
  - Only required on desktop browsers
  - Should animate when monetized and packets received
  - Should stop animation when network disconnected
    - Note that on Firefox/MacOS the popup automatically closes when the
      tab loses focus so can use something like this in terminal:
      - `sudo sleep 10 && sudo ifconfig en0 down && sleep 10 && sudo ifconfig en0 up`

- [x] Check monetization works consistently

  - In the same tab, go to http://www.travisvcrist.com/gatehub
    - refresh and make sure streaming works 10 times in a rowg
      - should not get 'stuck' in 'setting up payment' state
  - Issue: [coil/coilhq#3038][ci3038]
  - Fix PRs: [#242][np242]

- [x] Will route to \$coildomain.com/login rather than open popup if logged out

  - Log out from \$coildomain.com
  - Check that icon is in 'unavailable' state
    - ![image](https://user-images.githubusercontent.com/525211/66627206-2a5a0b00-ec25-11e9-9c0c-74dc34370e13.png)
  - Click on browser action
  - Check that routed to login page
    - ![image](https://user-images.githubusercontent.com/525211/66627301-6beab600-ec25-11e9-8045-a4e35686dc34.png)

- [x] Popup icon should show if page is monetized even when logged out

  - Log out from extension
  - Go to a monetized page and check that the icon "monetized" black and in 'unavailable' state
    - ![image](https://user-images.githubusercontent.com/525211/70715784-8f150d00-1d1d-11ea-8f82-fe116b2e9a16.png)

- [x] Run the puppeteer [tests](./test.sh) (look at the [circle jobs](../../../.circleci/config.yml))

  - export BROWSER_TYPE='chrome' # or 'firefox'
  - logout test currently fails on Firefox due to puppeteer-firefox limitations

- [x] Go to a [youtube video](https://www.youtube.com/watch?v=l1btEwwRePs),
      manually skip to near end of video, and when autoplay of a video from
      another channel starts, check that monetization has stopped.

  - Issues: [#33][i33]
  - PRs: [#213][np213]

- [x] Go to [xrpcommunity.blog](https://xrpcommunity.blog/) and as page
      is loading very quickly open the popup.
      It should show "This page is Web-Monetized" even before streaming
      starts. Should show 'setting up payment' then 'coil is paying creator'
      [#120][i120]

- [x] Open the [reloading-every-15s.html](../test/fixtures/reloading-every-15s.html) file:

  - Use a localhost server so WM works (e.g. with `python -m http.server 4000`)
  - Open the developer tools console undocked so can view while **PAGE IS BACKGROUNDED**
    - Note the `Reloading page` logging
  - Open the extension background page developer tools and look at the stream logging
  - SHOULD NOT initiate a stream or SPSP request
    [#144][i144]

- [x] Open the [event-logger.html](test/fixtures/event-logger.html) file:

  - Use a localhost server so WM works (e.g. with `python -m http.server 4000`)
  - Look for unusual timings, check that pending state is emitted nearly
    immediately after page load or meta tag added
  - Issue: [#63][ni63]
  - Fix PR: [#69][np69]

- [x] Check started event fires when quickly switching between tabs

  - Open the [event-logger.html](test/fixtures/event-logger.html) file
  - Switch to another (non-monetized) tab. The payments stop. Quickly switch back to the first tab.
  - The payments restart. Make sure there is a monetizationstart event
  - Issue: [#105][ni105]
  - Fix PR: [#117][np117]

- [x] Check stopped event fires with correct requestId

  - Open the [event-logger.html](test/fixtures/event-logger.html) file
  - Induce a stop/start in same js 'tick'
  - Check that the stopped event has the correct requestId
  - Issue: [#127][ni127]
  - Fix PR: [#128][np128]

- [x] Run a local web server (e.g. with `python -m http.server 4000`) serving
      the dist folder, then open [static/popup.html](static/popup.html) in a
      normal tab and check the popup rendering in various states.

- [x] On MacOS Chromium browsers (Chrome/Edge) check that the monetized animation is working
      on non primary monitors.

  - Issue: [#312][i312]
  - Fix PR: [#317][p317]

- [x] Check that popup closes when another window is focused

  - Open two Browser windows, open the popup in one window
  - Focus on second window
  - Ensure that popup is closed

  - Issue: [#313][i313]
  - Fix PR: [#332][p332]

- [x] Check SPA apps keep streaming when url changed, meta stays

  - Go to e.g. https://www.wevolver.com/
  - Change other pages which uses HTML5 history.pushState
  - Check that streaming is maintained throughout

    - if not, use browser devtools to check if meta exists
      - `document.head.querySelector('meta[name="monetization"]')`

  - Issue: [#507][i507]
  - Fix PR: [#508][p508]

- [x] Check extension doesn't attempt to stream when unsubscribed

  - Log in with coil user that doesn't have active subscription
  - Open the developer tools and check the logging
  - SHOULD NOT even attempt to stream
  - ![image](https://user-images.githubusercontent.com/525211/66631124-c9840000-ec2f-11e9-95a4-3bebe7fdebd6.png)
  - Issue: [#213][i213]
  - Fix PR: [#222][p222]

- [x] Check can stream immediately after subscribing
  - Likely best to test this with staging where can use a test card
  - Log in with coil user that doesn't have active subscription
  - Add a subscription (can use [testing card](https://stripe.com/docs/testing) 4242 4242 4242 4242 )
  - Go to a monetized page and check that streaming works immediately
  - **TESTERS NOTE**:
    - Have issue with streaming not immediately working after creating new user: https://github.com/coilhq/web-monetization-projects/issues/526 

### Iframe testing

1. - [x] Open a terminal and `cd packages/coil-extension/test/fixtures/iframes/`
2. - [x] Start a server (via `python -m http.server 4000` or equivalent)
3. - [x] Open http://localhost:4000/top-nested-allowed-iframe.html in browser
4. Open developer tools and look at the structure of the dom

- Use expand recursively feature
  - ![image](https://user-images.githubusercontent.com/525211/76400168-71098800-63b2-11ea-8069-5ee7b8b0707a.png)

5. - [x] With the console set `localStorage.WM_DEBUG = true`

#### Test 1: basic monetization

1. Load the page
2. - [x] Look for 4 monetizationpending events and 4 corresponding (same requestId) monetizationstart events logged in the console.

![image](https://user-images.githubusercontent.com/525211/76397844-6a791180-63ae-11ea-8f1c-72ef3a6183fb.png)

#### Test 2: refresh page / turn off / turn on

1. - [x] [re]load the page
2. - [x] Open developer tools and turn "off" monetization via editing allow attribute of top level iframes
   - ![image](https://user-images.githubusercontent.com/525211/76398261-28040480-63af-11ea-85cb-396960ced1bb.png)
   - Popup icon (and background page logging) should show no monetization:
     - [x] ![image](https://user-images.githubusercontent.com/525211/76398281-305c3f80-63af-11ea-857c-6ab6b409daa5.png)
   - Corresponding monetization events should be logged:
     - [x] ![image](https://user-images.githubusercontent.com/525211/76398873-3999dc00-63b0-11ea-8ee6-7ca45d8b44f0.png)

3. turn "on" monetization via editing allow attribute of top level iframes
   - ![image](https://user-images.githubusercontent.com/525211/76398370-57b30c80-63af-11ea-86a8-133271e46b91.png)
   - [x] Popup icon (and background page logging) should show monetization
     - ![image](https://user-images.githubusercontent.com/525211/76398417-6d283680-63af-11ea-88e6-c4b0ed5c35f7.png)
   - [x] Corresponding monetization events should be logged:
     - ![image](https://user-images.githubusercontent.com/525211/76399026-841b5880-63b0-11ea-8b0b-c0ecbff13bee.png)

#### Test 3: refresh page / turn off / background tab / turn on / foreground tab

- As above but while the tab is backgrounded, after turning on each top level iframe a sequence of pending -> stopped events should be fired:
  - [x] ![image](https://user-images.githubusercontent.com/525211/76399956-1a03b300-63b2-11ea-9b77-671e94a1bf16.png)

#### Test 4: nested

- As per test 2
- Turn off one top level and then turn off the nested frames in top level that is allowed
- [x] allow _one_ nested iframe and check for indications of monetization