### PR TITLE
fix: add "tabs" permission

### DIFF
--- a/packages/coil-extension/manifest.json
+++ b/packages/coil-extension/manifest.json
@@ -31,5 +31,5 @@
       "run_at": "document_start"
     }
   ],
-  "permissions": [ "webNavigation", "<all_urls>" ]
+  "permissions": [ "webNavigation", "tabs", "<all_urls>" ]
 }


### PR DESCRIPTION
To fix:

```
nullables.ts:6 Uncaught (in promise) Error: Expecting not null for sender.tab
    at Object.notNullOrUndef (nullables.ts:6)
    at getTab (tabs.ts:5)
    at Object.getFrameSpec (tabs.ts:9)
    at BackgroundScript../src/background/services/BackgroundScript.ts.BackgroundScript.contentScriptInit (BackgroundScript.ts:848)
    at BackgroundScript.<anonymous> (BackgroundScript.ts:337)
    at step (BackgroundFramesService.ts:98)
    at Object.next (BackgroundFramesService.ts:98)
    at BackgroundFramesService.ts:98
    at new Promise (<anonymous>)
    at ./src/background/services/BackgroundScript.ts.__awaiter (BackgroundFramesService.ts:98)
```

in staging, on the background page.

For some reason the prod build of the extension worked without this change...