### PR TITLE
feat: dont unnecessarily query whoami

### DIFF
--- a/packages/coil-client/src/queries/queryToken.ts
+++ b/packages/coil-client/src/queries/queryToken.ts
@@ -1,5 +1,4 @@
 import { CoilUser } from '../types'
-
 import { GraphQlClient } from '..'
 
 export interface QueryTokenData {
@@ -18,6 +17,8 @@ export const queryTokenQuery = `{
     customerId
     subscription {
       active
+      endDate
+      trialEndDate
     }
 
     currencyPreferences {

--- a/packages/coil-client/src/queries/whoAmI.ts
+++ b/packages/coil-client/src/queries/whoAmI.ts
@@ -1,5 +1,4 @@
 import { CoilUser } from '../types'
-
 import { GraphQlClient } from '..'
 
 export interface WhoAmIData {
@@ -15,6 +14,8 @@ export const whoamiQuery = `{
 
     subscription {
       active
+      endDate
+      trialEndDate
     }
 
     currencyPreferences {

--- a/packages/coil-client/src/types.ts
+++ b/packages/coil-client/src/types.ts
@@ -8,6 +8,8 @@ export interface CoilUser {
   customerId?: string
   subscription?: {
     active: boolean
+    endDate?: string
+    trialEndDate?: string
   }
   currencyPreferences?: {
     code: string

--- a/packages/coil-extension/src/content/services/Frames.ts
+++ b/packages/coil-extension/src/content/services/Frames.ts
@@ -18,6 +18,7 @@ export class Frames {
   isAnyCoilFrame: boolean
   isIFrame: boolean
   isCoilTopFrame: boolean
+  isCoilHandlerFrame: boolean
   isDirectChildFrame: boolean
   isMonetizableFrame: boolean
 
@@ -32,8 +33,15 @@ export class Frames {
     this.isAnyCoilFrame = window.origin === coilDomain
     this.isIFrame = !this.isTopFrame
     this.isCoilTopFrame = this.isTopFrame && this.isAnyCoilFrame
+    // injected into background page in an <iframe>
+    this.isCoilHandlerFrame =
+      this.isAnyCoilFrame &&
+      !this.isTopFrame &&
+      window.location.pathname == '/handler.html'
     this.isDirectChildFrame = this.isIFrame && window.parent === window.top
-    this.isMonetizableFrame = true
+    // don't monetize the handler page (or send messages with sender
+    // without `tab`)
+    this.isMonetizableFrame = !this.isCoilHandlerFrame
   }
 
   monitor() {

--- a/packages/coil-extension/src/types/user.ts
+++ b/packages/coil-extension/src/types/user.ts
@@ -5,6 +5,8 @@ export interface User {
   canTip?: boolean
   subscription?: {
     active: boolean
+    endDate?: string
+    trialEndDate?: string
   }
   invitation?: {
     usedAt: string


### PR DESCRIPTION
Don't unnecessarily query the user/subscription -- wait until the subscription/trial expires. This is more efficient, and prevents correlation with token redeeming.