### PR TITLE
fix(extension): don't unnecessarily update icon

### DIFF
--- a/packages/coil-extension/src/background/services/PopupBrowserAction.ts
+++ b/packages/coil-extension/src/background/services/PopupBrowserAction.ts
@@ -64,7 +64,10 @@ export class PopupBrowserAction {
     // In some strange cases on android these are not set
     const api = this.api
 
-    if (api.browserAction.setIcon) {
+    if (
+      api.browserAction.setIcon &&
+      state?.icon?.path !== this.icons.getInactive()
+    ) {
       api.browserAction.setIcon({
         tabId,
         path: state?.icon?.path ?? this.icons.getInactive()


### PR DESCRIPTION
Only update the badge icon when it changes. This reduces noise in the background page's Network panel.