### PR TITLE
feat: begin working on components for advanced tipping view

### DIFF
--- a/packages/coil-client/src/types.ts
+++ b/packages/coil-client/src/types.ts
@@ -1,5 +1,10 @@
+export interface GraphQlError {
+  message: string
+}
+
 export interface GraphQlResponse<T> {
   data: T
+  errors: GraphQlError[]
 }
 
 export interface CoilUser {

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -390,7 +390,7 @@ export class BackgroundScript {
         sendResponse(await this.youtube.fetchChannelId(request.data.youtubeUrl))
         break
       case 'sendTip':
-        sendResponse(await this.sendTip())
+        sendResponse(await this.sendTip(request.data.amount))
         break
       case 'checkIFrameIsAllowedFromIFrameContentScript':
         sendResponse(
@@ -694,7 +694,7 @@ export class BackgroundScript {
     return true
   }
 
-  private async sendTip(): Promise<{ success: boolean }> {
+  private async sendTip(tipAmount = 100): Promise<{ success: boolean }> {
     const tabId = this.activeTab
     const streamId = this.assoc.getStreamId({ tabId, frameId: 0 })
     if (!streamId) {
@@ -716,23 +716,26 @@ export class BackgroundScript {
 
     const receiver = stream.getPaymentPointer()
     const { assetCode, assetScale, exchangeRate } = stream.getAssetDetails()
-    const amount = Math.floor(1e9 * exchangeRate).toString() // 1 USD, assetScale = 9
+    const amount = Math.floor((tipAmount / 1e2) * 1e9 * exchangeRate).toString()
 
     try {
       this.log(`sendTip: sending tip to ${receiver}`)
       const result = await this.client.query({
         query: `
-          mutation sendTip($receiver: String!) {
-            sendTip(receiver: $receiver) {
+          mutation sendTip($receiver: String!, $amount: Int!) {
+            sendTip(receiver: $receiver, amount: $amount) {
               success
             }
           }
         `,
         token,
         variables: {
-          receiver
+          receiver,
+          // amount is USD cents
+          amount: tipAmount
         }
       })
+
       this.log(`sendTip: sent tip to ${receiver}`, result)
       const message: TipSent = {
         command: 'tip',
@@ -744,7 +747,7 @@ export class BackgroundScript {
         }
       }
       this.api.tabs.sendMessage(tabId, message, { frameId: 0 })
-      return { success: true }
+      return { success: result.data.sendTip.success }
     } catch (e) {
       this.log(`sendTip: error. msg=${e.message}`)
       return { success: false }

--- a/packages/coil-extension/src/popup/Index.tsx
+++ b/packages/coil-extension/src/popup/Index.tsx
@@ -2,21 +2,11 @@ import React, { useEffect, useState } from 'react'
 import { styled, Typography } from '@material-ui/core'
 
 import { ToPopupMessage } from '../types/commands'
-import { Colors } from '../shared-theme/colors'
 
-import { Container } from './components/util/Container'
 import { AccountBar } from './components/AccountBar'
 import { WebMonetizedBar } from './components/WebMonetizedBar'
 import { Status } from './components/Status'
 import { PopupProps } from './types'
-
-const CoilContainer = styled(Container)(({ theme }) => ({
-  paddingRight: `${theme.spacing(4)}px`,
-  paddingLeft: `${theme.spacing(4)}px`,
-  paddingTop: `${theme.spacing(2)}px`,
-  paddingBottom: `${theme.spacing(2)}px`,
-  backgroundColor: Colors.Grey99
-}))
 
 const OuterDiv = styled('div')({
   minWidth: '308px',
@@ -60,9 +50,7 @@ export function Index(props: PopupProps) {
   return (
     <OuterDiv>
       <AccountBar context={context} />
-      <CoilContainer>
-        <Status context={context} />
-      </CoilContainer>
+      <Status context={context} />
       <WebMonetizedBar context={context} />
       {footer && (
         <Typography variant='caption'>

--- a/packages/coil-extension/src/popup/Index.tsx
+++ b/packages/coil-extension/src/popup/Index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { styled, Typography } from '@material-ui/core'
 
+import { Colors } from '../shared-theme/colors'
 import { ToPopupMessage } from '../types/commands'
 
 import { AccountBar } from './components/AccountBar'

--- a/packages/coil-extension/src/popup/components/CoilContainer.tsx
+++ b/packages/coil-extension/src/popup/components/CoilContainer.tsx
@@ -1,0 +1,12 @@
+import { styled } from '@material-ui/core'
+
+import { Container } from '../components/util/Container'
+import { Colors } from '../../shared-theme/colors'
+
+export const CoilContainer = styled(Container)(({ theme }) => ({
+  paddingRight: `${theme.spacing(4)}px`,
+  paddingLeft: `${theme.spacing(4)}px`,
+  paddingTop: `${theme.spacing(2)}px`,
+  paddingBottom: `${theme.spacing(2)}px`,
+  backgroundColor: Colors.Grey99
+}))

--- a/packages/coil-extension/src/popup/components/MonetizedPage.tsx
+++ b/packages/coil-extension/src/popup/components/MonetizedPage.tsx
@@ -1,13 +1,13 @@
-import React, { Fragment, useEffect, useState } from 'react'
+import React, { Fragment } from 'react'
 import { Grid, styled } from '@material-ui/core'
 
 import { PopupProps } from '../types'
 
-import { Link } from './util/Link'
 import { StatusTypography } from './util/StatusTypography'
 import { MonetizeAnimation } from './MonetizationAnimation'
 import { StreamControls } from './StreamControls'
-import { TipButton } from './TipButton'
+import { TipControl } from './TipControl'
+import { CoilContainer } from './CoilContainer'
 import { useShowIfClicked } from './util/useShowIfClicked'
 
 const FlexBox = styled('div')(({ theme }) => ({
@@ -20,52 +20,26 @@ const FlexBox = styled('div')(({ theme }) => ({
 }))
 
 export function MonetizedPage(props: PopupProps) {
-  const [limitRefreshDate, setLimitRefreshDate] = useState<string | null>(null)
   const [showControls, onClick] = useShowIfClicked({
     clicksRequired: 9,
     withinMs: 5000,
     key: 'showStreamingControls'
   })
 
-  useEffect(() => {
-    props.context.runtime.sendMessage(
-      {
-        command: 'isRateLimited'
-      },
-      result => {
-        if (result && result.limitExceeded) {
-          const date = new Date(result.limitRefreshDate)
-          const formatted = date.toLocaleDateString(undefined, {
-            month: 'long',
-            day: 'numeric',
-            year: 'numeric'
-          })
-          setLimitRefreshDate(formatted)
-        }
-      }
-    )
-  }, [])
   const context = props.context
   return (
     <>
-      <Grid container alignItems='center' justify='center'>
-        <div>
-          {limitRefreshDate != null ? (
-            <RateLimited
-              context={context}
-              limitRefreshDate={limitRefreshDate}
-            />
-          ) : (
-            <div onClick={onClick}>
-              <Donating context={context} />
-            </div>
-          )}
-        </div>
-      </Grid>
-      {showControls && <StreamControls context={context} />}
+      <CoilContainer>
+        <Grid container alignItems='center' justify='center'>
+          <div onClick={onClick}>
+            <Donating context={context} />
+          </div>
+        </Grid>
 
+        {showControls && <StreamControls context={context} />}
+      </CoilContainer>
       {/* this will only show if user is enabled */}
-      <TipButton context={context} />
+      <TipControl context={context} />
     </>
   )
 }
@@ -89,56 +63,6 @@ function Donating(props: PopupProps) {
       <FlexBox>
         <MonetizeAnimation context={props.context} />
       </FlexBox>
-    </Fragment>
-  )
-}
-
-function RateLimited(props: PopupProps & { limitRefreshDate: string }) {
-  const {
-    context: {
-      coilDomain,
-      runtime: { tabOpener }
-    },
-    limitRefreshDate
-  } = props
-  const mailOpener = tabOpener('mailto:accountreview@coil.com')
-  const termsOpener = tabOpener(`${coilDomain}/terms`)
-
-  return (
-    <Fragment>
-      <StatusTypography variant='h6' align='center'>
-        Important Notice
-      </StatusTypography>
-
-      <StatusTypography variant='body1' align='left'>
-        Your usage might be in violation of our
-        <Link onClick={termsOpener} target='_blank'>
-          {' '}
-          Terms of Service
-        </Link>
-        , which prohibit:
-      </StatusTypography>
-
-      <StatusTypography variant='body1' align='left'>
-        <ul>
-          <li>Long-term idling on websites</li>
-          <li>Participating in a scheme to direct funds to yourself</li>
-        </ul>
-      </StatusTypography>
-
-      <StatusTypography variant='body1' align='left'>
-        If you believe you are receiving this message in error, please reach out
-        to
-        <Link onClick={mailOpener} target='_blank'>
-          {' '}
-          accountreview@coil.com
-        </Link>
-      </StatusTypography>
-
-      <StatusTypography variant='body1' align='left'>
-        Your membership is still active. Your usage will be restored on{' '}
-        {limitRefreshDate}. Please adhere to the Terms of Service in the future.
-      </StatusTypography>
     </Fragment>
   )
 }

--- a/packages/coil-extension/src/popup/components/PaidViews.tsx
+++ b/packages/coil-extension/src/popup/components/PaidViews.tsx
@@ -5,16 +5,25 @@ import { PopupProps } from '../types'
 import { UnmonetizedPage } from './UnmonetizedPage'
 import { MonetizedPage } from './MonetizedPage'
 import { CoilViews } from './CoilViews'
+import { CoilContainer } from './CoilContainer'
 
 export const PaidViews = (props: PopupProps) => {
   const context = props.context
   const { monetized, coilSite } = context.store
 
   if (coilSite && !monetized) {
-    return <CoilViews context={context} />
+    return (
+      <CoilContainer>
+        <CoilViews context={context} />
+      </CoilContainer>
+    )
   } else if (monetized) {
     return <MonetizedPage context={context} />
   } else {
-    return <UnmonetizedPage context={context} />
+    return (
+      <CoilContainer>
+        <UnmonetizedPage context={context} />
+      </CoilContainer>
+    )
   }
 }

--- a/packages/coil-extension/src/popup/components/Status.tsx
+++ b/packages/coil-extension/src/popup/components/Status.tsx
@@ -5,6 +5,7 @@ import { PopupProps } from '../types'
 import { LoggedOut } from './LoggedOut'
 import { Unsubscribed } from './Unsubscribed'
 import { PaidViews } from './PaidViews'
+import { CoilContainer } from './CoilContainer'
 
 export const Status = (props: PopupProps) => {
   const context = props.context
@@ -15,11 +16,19 @@ export const Status = (props: PopupProps) => {
       !user.subscription ||
       (user.subscription && !user.subscription.active)
     ) {
-      return <Unsubscribed context={context} />
+      return (
+        <CoilContainer>
+          <Unsubscribed context={context} />
+        </CoilContainer>
+      )
     } else {
       return <PaidViews context={context} />
     }
   } else {
-    return <LoggedOut context={context} />
+    return (
+      <CoilContainer>
+        <LoggedOut context={context} />
+      </CoilContainer>
+    )
   }
 }

--- a/packages/coil-extension/src/popup/components/TipAddButton.tsx
+++ b/packages/coil-extension/src/popup/components/TipAddButton.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { styled } from '@material-ui/core'
+
+import { Colors } from '../../shared-theme/colors'
+
+interface TipAddButtonProps {
+  onClick: () => any
+  limited: boolean
+  tipAmount: string
+}
+
+const Wrapper = styled('div')(() => ({
+  width: '60px',
+  display: 'block'
+}))
+
+const Message = styled('p')(() => ({
+  fontFamily: 'Circular Std',
+  fontStyle: 'normal',
+  fontWeight: 'normal',
+  fontSize: '12px',
+  lineHeight: '24px',
+  display: 'flex',
+  alignItems: 'center',
+  textAlign: 'center',
+  color: Colors.Red400,
+  margin: '0 0 0 -10px',
+  position: 'absolute',
+  width: '60px'
+}))
+
+export const TipAddButton = ({
+  onClick,
+  limited,
+  tipAmount
+}: TipAddButtonProps) => {
+  return (
+    <Wrapper onMouseDown={e => e.preventDefault()} onClick={onClick}>
+      <svg
+        width='40'
+        height='40'
+        viewBox='0 0 40 40'
+        fill='none'
+        xmlns='http://www.w3.org/2000/svg'
+      >
+        <circle
+          cx='20'
+          cy='20'
+          r='20'
+          fill={limited ? Colors.Red50 : Colors.Grey89}
+        />
+        <rect
+          x='12'
+          y='18'
+          width='16'
+          height='4'
+          rx='2'
+          fill={limited ? Colors.Red400 : Colors.Grey700}
+        />
+        <rect
+          x='22'
+          y='12'
+          width='16'
+          height='4'
+          rx='2'
+          transform='rotate(90 22 12)'
+          fill={limited ? Colors.Red400 : Colors.Grey700}
+        />
+      </svg>
+      <Message style={{ display: limited ? 'block' : 'none' }}>
+        Max {tipAmount}
+      </Message>
+    </Wrapper>
+  )
+}

--- a/packages/coil-extension/src/popup/components/TipButton.tsx
+++ b/packages/coil-extension/src/popup/components/TipButton.tsx
@@ -1,8 +1,24 @@
 import React, { useState } from 'react'
-import { Button } from '@material-ui/core'
+import { styled, Button } from '@material-ui/core'
 
-import { PopupProps } from '../types'
-import { SendTip, SendTipResult } from '../../types/commands'
+import { formatAmount } from '../../util/currencyFormatting'
+import { Colors } from '../../shared-theme/colors'
+
+const TipStyleButton = styled(Button)(() => ({
+  padding: '0px',
+  width: '212px',
+  height: '32px',
+  backgroundColor: Colors.Grey800,
+  color: Colors.Grey99,
+  fontSize: '12px',
+  lineHeight: '24px',
+  '&:hover': {
+    backgroundColor: Colors.Grey700
+  },
+  '&:disabled': {
+    color: Colors.Grey99
+  }
+}))
 
 export enum TipState {
   READY = 0,
@@ -11,55 +27,34 @@ export enum TipState {
   ERROR
 }
 
-export const TipButton = (props: PopupProps) => {
-  const [tipState, setTipState] = useState(TipState.READY)
-  const onClickTip = async () => {
-    setTipState(TipState.LOADING)
+export interface TipButtonProps {
+  onClick: () => void
+  tipState: TipState
+  readyToTip: boolean
+  tipAmount: number
+}
 
-    const { success } = await sendTip()
-
-    if (success) {
-      setTipState(TipState.COMPLETE)
-    } else {
-      setTipState(TipState.ERROR)
-    }
-
-    setTimeout(() => {
-      setTipState(TipState.READY)
-    }, 1000)
-  }
-
-  const sendTip = async () => {
-    const message: SendTip = { command: 'sendTip' }
-
-    return new Promise(resolve => {
-      props.context.runtime.sendMessage(message, (result: SendTipResult) => {
-        resolve(result)
-      })
-    }) as Promise<SendTipResult>
-  }
-
-  if (props.context.store.user.canTip) {
-    switch (tipState) {
-      case TipState.READY:
-        return (
-          <Button
-            disabled={props.context.store.monetizedTotal === 0}
-            onClick={onClickTip}
-          >
-            Tip this creator $1!
-          </Button>
-        )
-      case TipState.LOADING:
-        return <Button disabled>Tipping...</Button>
-
-      case TipState.COMPLETE:
-        return <Button disabled>Tip complete!</Button>
-
-      case TipState.ERROR:
-        return <Button disabled>Something went wrong.</Button>
-    }
-  } else {
-    return <></>
+export const TipButton = (props: TipButtonProps) => {
+  const formattedAmount = formatAmount(
+    {
+      amount: String(props.tipAmount),
+      assetCode: 'USD',
+      assetScale: 2
+    },
+    { precision: 0 }
+  )
+  switch (props.tipState) {
+    case TipState.READY:
+      return (
+        <TipStyleButton disabled={!props.readyToTip} onClick={props.onClick}>
+          TIP {formattedAmount}
+        </TipStyleButton>
+      )
+    case TipState.LOADING:
+      return <TipStyleButton disabled>[Spinner]</TipStyleButton>
+    case TipState.COMPLETE:
+      return <TipStyleButton disabled>[Check mark]</TipStyleButton>
+    case TipState.ERROR:
+      return <TipStyleButton disabled>Something went wrong.</TipStyleButton>
   }
 }

--- a/packages/coil-extension/src/popup/components/TipControl.tsx
+++ b/packages/coil-extension/src/popup/components/TipControl.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react'
+import { styled } from '@material-ui/core'
+
+import { PopupProps } from '../types'
+import { SendTip, SendTipResult } from '../../types/commands'
+
+import { TipButton, TipState } from './TipButton'
+import { CoilContainer } from './CoilContainer'
+import { TipRule } from './TipRule'
+import { TipCounter } from './TipCounter'
+
+const MIN_TIP_AMOUNT = 100
+const MAX_TIP_AMOUNT = 2000
+
+export const TipControl = styled((props: PopupProps) => {
+  const [tipState, setTipState] = useState(TipState.READY)
+  const [tipAmount, setTipAmount] = useState(100)
+  const increaseTip = () =>
+    setTipAmount(Math.min(tipAmount + 100, MAX_TIP_AMOUNT))
+  const decreaseTip = () =>
+    setTipAmount(Math.max(tipAmount - 100, MIN_TIP_AMOUNT))
+
+  const sendTip = async () => {
+    const message: SendTip = {
+      command: 'sendTip',
+      data: {
+        amount: tipAmount
+      }
+    }
+
+    return new Promise(resolve => {
+      props.context.runtime.sendMessage(message, (result: SendTipResult) => {
+        resolve(result)
+      })
+    }) as Promise<SendTipResult>
+  }
+
+  const onClickTip = async () => {
+    setTipState(TipState.LOADING)
+
+    // TODO: pass amount in here
+    const { success } = await sendTip()
+
+    if (success) {
+      setTipState(TipState.COMPLETE)
+    } else {
+      setTipState(TipState.ERROR)
+    }
+
+    setTimeout(() => {
+      setTipState(TipState.READY)
+    }, 1000)
+  }
+
+  // TODO: should load from background
+  const [tipBalance, setTipBalance] = useState(500)
+  const readyToTip = Boolean(props.context.store.monetizedTotal > 0)
+
+  const userCanTip = props.context.store.user.canTip
+  return userCanTip ? (
+    <>
+      <TipRule />
+      <CoilContainer>
+        <TipCounter
+          tipAmount={tipAmount}
+          decrease={decreaseTip}
+          increase={increaseTip}
+          max={MAX_TIP_AMOUNT}
+          min={MIN_TIP_AMOUNT}
+        />
+        <TipButton
+          tipAmount={tipAmount}
+          onClick={onClickTip}
+          readyToTip={readyToTip}
+          tipState={tipState}
+        />
+      </CoilContainer>
+    </>
+  ) : (
+    <></>
+  )
+})({ userSelect: 'none' })

--- a/packages/coil-extension/src/popup/components/TipCounter.tsx
+++ b/packages/coil-extension/src/popup/components/TipCounter.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { styled } from '@material-ui/core'
+
+import { Colors } from '../../shared-theme/colors'
+import { formatAmount } from '../../util/currencyFormatting'
+
+import { TipAddButton } from './TipAddButton'
+import { TipSubButton } from './TipSubButton'
+
+export interface TipCounterProps {
+  tipAmount: number
+  increase: () => void
+  decrease: () => void
+  max: number
+  min: number
+}
+
+const BigBalance = styled('p')(() => ({
+  fontSize: '56px',
+  lineHeight: '64px',
+  margin: '0px',
+  flex: 1,
+  color: Colors.Grey800,
+  // userSelect: 'none',
+  cursor: 'default'
+}))
+
+const Flex = styled('div')(() => ({
+  display: 'flex',
+  flexDirection: 'row',
+  flexAlign: 'center',
+  height: '80px',
+  width: '212px',
+  margin: '0 auto'
+}))
+
+const TipButtonWrap = styled('div')(() => ({
+  display: 'flex',
+  width: '36px',
+  textAlign: 'center',
+  paddingTop: '14px'
+}))
+
+export const TipCounter = (props: TipCounterProps) => {
+  const formattedAmount = formatAmount(
+    {
+      amount: String(props.tipAmount),
+      assetCode: 'USD',
+      assetScale: 2
+    },
+    { precision: 0 }
+  )
+
+  return (
+    <Flex>
+      <TipButtonWrap>
+        <TipSubButton
+          onClick={props.decrease}
+          limited={props.tipAmount == props.min}
+          tipAmount={formattedAmount}
+        />
+      </TipButtonWrap>
+      <BigBalance>{formattedAmount}</BigBalance>
+      <TipButtonWrap>
+        <TipAddButton
+          onClick={props.increase}
+          limited={props.tipAmount == props.max}
+          tipAmount={formattedAmount}
+        />
+      </TipButtonWrap>
+    </Flex>
+  )
+}

--- a/packages/coil-extension/src/popup/components/TipRule.tsx
+++ b/packages/coil-extension/src/popup/components/TipRule.tsx
@@ -1,0 +1,9 @@
+import { styled } from '@material-ui/core'
+
+import { Colors } from '../../shared-theme/colors'
+
+export const TipRule = styled('hr')(() => ({
+  border: 0,
+  topBorderColor: Colors.Grey89,
+  topBorderWidth: '1px'
+}))

--- a/packages/coil-extension/src/popup/components/TipSubButton.tsx
+++ b/packages/coil-extension/src/popup/components/TipSubButton.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { styled } from '@material-ui/core'
+
+import { Colors } from '../../shared-theme/colors'
+
+interface TipSubButtonProps {
+  onClick: () => any
+  limited: boolean
+  tipAmount: string
+}
+
+const Wrapper = styled('div')(() => ({
+  width: '60px',
+  display: 'block'
+}))
+
+const Message = styled('p')(() => ({
+  fontFamily: 'Circular Std',
+  fontStyle: 'normal',
+  fontWeight: 'normal',
+  fontSize: '12px',
+  lineHeight: '24px',
+  display: 'flex',
+  alignItems: 'center',
+  textAlign: 'center',
+  margin: '0 0 0 -10px',
+  position: 'absolute',
+  color: Colors.Red400,
+  width: '60px'
+}))
+
+export const TipSubButton = ({
+  onClick,
+  limited,
+  tipAmount
+}: TipSubButtonProps) => (
+  <Wrapper onMouseDown={e => e.preventDefault()}>
+    <svg
+      onClick={onClick}
+      width='40'
+      height='40'
+      viewBox='0 0 40 40'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <circle
+        cx='20'
+        cy='20'
+        r='20'
+        fill={limited ? Colors.Red50 : Colors.Grey89}
+      />
+      <rect
+        x='12'
+        y='18'
+        width='16'
+        height='4'
+        rx='2'
+        fill={limited ? Colors.Red400 : Colors.Grey700}
+      />
+    </svg>
+    <Message style={{ display: limited ? 'block' : 'none' }}>
+      Min {tipAmount}
+    </Message>
+  </Wrapper>
+)
+
+// '#E3E5E9' fill='#8F949F'

--- a/packages/coil-extension/src/shared-theme/colors.ts
+++ b/packages/coil-extension/src/shared-theme/colors.ts
@@ -9,6 +9,7 @@ export const Colors = {
   Grey700: '#636975',
   Grey800: '#2D333A',
   Grey900: '#0B1621',
+  Red50: '#FDDFE2',
   Red200: '#FB7A75',
   Red400: '#EC5F59',
   Red700: '#DF251D',

--- a/packages/coil-extension/src/types/commands.ts
+++ b/packages/coil-extension/src/types/commands.ts
@@ -296,8 +296,11 @@ export interface SetMonetizationState {
  * popup -> background
  * browser.runtime.sendMessage
  */
-export interface SendTip {
+export interface SendTip extends Command {
   command: 'sendTip'
+  data: {
+    amount?: number
+  }
 }
 
 /**


### PR DESCRIPTION
[re]based on @sharafian work at https://github.com/coilhq/web-monetization-projects/pull/502

Adds the next iteration of tipping from the extension. Features included are:

* Adjustable tip amount
* Show tip balance

All tipping features are still experimental; it can be issued with a promo code or by belonging to Coil's email domain.

See backend impl @ https://github.com/coilhq/coil/pull/3237

Figma sketch @ https://www.figma.com/file/A1gNHNHKzcd1lkWUlrsBa9/Tipping?node-id=0%3A1