### PR TITLE
chore(coil-extension): bump version to 0.0.50

### DIFF
--- a/packages/coil-extension/CHANGELOG.md
+++ b/packages/coil-extension/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="coil-extension@0.0.50"></a>
+
+# [coil-extension@0.0.50](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.49...coil-extension@0.0.50) (2020-05-22)
+
+### Features
+
+- Add support for STREAM receipts [#533](https://github.com/coilhq/web-monetization-projects/pull/533)
+
 <a name="coil-extension@0.0.49"></a>
 
 # [coil-extension@0.0.49](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.48...coil-extension@0.0.49) (2020-04-06)

--- a/packages/coil-extension/docs/release-checklist.md
+++ b/packages/coil-extension/docs/release-checklist.md
@@ -118,7 +118,7 @@ make sense.
   - Issues: [#33][i33]
   - PRs: [#213][np213]
 
-- [ ] Go to [xrpcommunity.blog](https://xrpcommunity.blog/) and as page
+- [ ] Go to [xrptipbot.com](https://www.xrptipbot.com/) and as page
       is loading very quickly open the popup.
       It should show "This page is Web-Monetized" even before streaming
       starts. Should show 'setting up payment' then 'coil is paying creator'

--- a/packages/coil-extension/docs/release-checklist.md
+++ b/packages/coil-extension/docs/release-checklist.md
@@ -45,7 +45,7 @@ make sense.
     - Load Temporary Add-on...
   - For Chrome or MS Edge, go to `chrome://extensions` (or `edge://extensions`) and `Load Unpacked`
 
-- [ ] Ensure that you are [logged in with a user with valid subscription](https://coil.com/settings/payment)
+- [ ] Ensure that you are [logged in with a user with valid subscription](https://coil.com/settings/membership)
 
   - ![image](https://user-images.githubusercontent.com/525211/71150879-28d04300-2265-11ea-96da-7d720c101575.png)
 
@@ -53,7 +53,7 @@ make sense.
 
   - ![image](https://user-images.githubusercontent.com/525211/66626576-f4b42280-ec22-11e9-9f77-4a95be08643e.png)
 
-- [ ] [xrpcommunity.blog](https://xrpcommunity.blog/) should monetize
+- [ ] [xrptipbot.com](https://www.xrptipbot.com/) should monetize
 
   - ![image](https://user-images.githubusercontent.com/525211/66626655-3c3aae80-ec23-11e9-981a-0e317ab80b42.png)
 
@@ -70,7 +70,7 @@ make sense.
   - [ ] Go to coil.com, the browser action popup should show welcome to coil
     - ![image](https://user-images.githubusercontent.com/525211/66626988-6b9deb00-ec24-11e9-86c3-b55c17e891c2.png)
   - [ ] Should have a link to coil.com/explore page
-  - [ ] Once on explore page should show `Start Exploring` with a rocket-ship graphic
+  - [ ] Once on explore page should show `Discover Now` with a rocket-ship graphic
     - ![image](https://user-images.githubusercontent.com/525211/66627053-a2740100-ec24-11e9-8759-76f40c46d6fa.png)
 
 - [ ] Check the monetization animation works properly

--- a/packages/coil-extension/manifest.json
+++ b/packages/coil-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Coil",
   "description": "Support websites and creators with Web Monetization",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "manifest_version": 2,
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "browser_specific_settings": {

--- a/packages/coil-extension/package.json
+++ b/packages/coil-extension/package.json
@@ -1,10 +1,10 @@
 {
   "$schema": "../coil-monorepo-upkeep/resources/package-json-schema-nested-overrides.json",
   "$overRideUpKeep": {
-    "version": "0.0.49"
+    "version": "0.0.50"
   },
   "name": "@coil/extension",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "private": false,
   "keywords": [
     "ilp",

--- a/packages/coil-extension/src/popup/components/CoilPopup.tsx
+++ b/packages/coil-extension/src/popup/components/CoilPopup.tsx
@@ -24,7 +24,7 @@ export const CoilPopup = (props: PopupProps) => {
           Check out our Discover page to explore Web-Monetized content.
         </StatusTypography>
         <StatusButton
-          text='Go to Discover'
+          text='Discover now'
           variant='contained'
           onClick={onClick}
         />

--- a/packages/coil-extension/src/popup/components/TipButton.tsx
+++ b/packages/coil-extension/src/popup/components/TipButton.tsx
@@ -39,7 +39,10 @@ export const TipButton = (props: PopupProps) => {
     }) as Promise<SendTipResult>
   }
 
-  if (props.context.store.user.canTip) {
+  if (
+    props.context.store.user.canTip &&
+    props.context.store.monetizedTotal > 0
+  ) {
     switch (tipState) {
       case TipState.READY:
         return <Button onClick={onClickTip}>Tip this creator $1!</Button>

--- a/packages/coil-extension/src/popup/components/Unsubscribed.tsx
+++ b/packages/coil-extension/src/popup/components/Unsubscribed.tsx
@@ -8,7 +8,7 @@ import { StatusButton } from './StatusButton'
 import { StatusTypography } from './util/StatusTypography'
 
 const titleString = 'Become a member'
-const subheading1 = 'To use Coil you need an active membership'
+const subheading1 = 'To use Coil you need an active membership.'
 const footerString =
   'You can cancel your membership any time in the account settings page.'
 
@@ -16,6 +16,11 @@ const Muted = styled('p')({
   color: Colors.Grey500,
   fontSize: '12px',
   fontWeight: 600
+})
+
+const Button = styled(StatusButton)({
+  paddingLeft: '29px',
+  paddingRight: '29px'
 })
 
 export const Unsubscribed = (props: PopupProps) => {
@@ -36,7 +41,11 @@ export const Unsubscribed = (props: PopupProps) => {
         <StatusTypography variant='subtitle1' align='center'>
           {subheading1}
         </StatusTypography>
-        <StatusButton text='join' variant='contained' onClick={onClick} />
+        <Button
+          text='Join&nbsp;Coil&nbsp;for&nbsp;$5/mo'
+          variant='contained'
+          onClick={onClick}
+        />
         <Muted>{footerString}</Muted>
       </div>
     </Grid>

--- a/packages/coil-extension/src/popup/components/WebMonetizedBar.tsx
+++ b/packages/coil-extension/src/popup/components/WebMonetizedBar.tsx
@@ -26,6 +26,8 @@ export const WebMonetizedBar = (props: PopupProps) => {
   if (coilSite && !monetized) {
     return null
   } else {
+    // TODO: adapted here should mean adaptable
+    const contentOrSite = adapted ? 'content' : 'site'
     return (
       <CoilBar>
         <Typography variant='caption'>
@@ -36,7 +38,7 @@ export const WebMonetizedBar = (props: PopupProps) => {
           )}
           {adapted && monetized
             ? ' Coil can donate to this channel'
-            : ' This content is'}
+            : ' This ' + contentOrSite + ' is'}
           {monetized ? '' : ' not'}
           {monetized && adapted ? '' : ' Web-Monetized'}
         </Typography>


### PR DESCRIPTION
## Chores

- [x] Make sure the manifest version was bumped but doesn't skip versions

- [x] Update the [CHANGELOG.md](../CHANGELOG.md)

  - You can compare with latest commit before tagging via something like:
    `https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.48...8f359e45f843a4f9a01c090a02e73519413d900b`

## MacOS Chrome Version 83.0.4103.61 (Official Build) (64-bit)

Copy below for each platform/browser/version tested, filtering steps where it
make sense.

- [x] Build for prod with release settings

  - e.g. `yarn build-prod chrome -p --run-prod --devtool=none`
    - as per [package.sh](../package.sh)

- [x] Import unpacked/temporary extension/add-on

  - For Firefox, go to `about:debugging`
    - Enable add-on debugging
    - Load Temporary Add-on...
  - For Chrome or MS Edge, go to `chrome://extensions` (or `edge://extensions`) and `Load Unpacked`

- [x] Ensure that you are [logged in with a user with valid subscription](https://coil.com/settings/membership)

  - ![image](https://user-images.githubusercontent.com/525211/71150879-28d04300-2265-11ea-96da-7d720c101575.png)

- [x] [example.com](http://example.com/) should say "This website is not supported"

  - ![image](https://user-images.githubusercontent.com/525211/66626576-f4b42280-ec22-11e9-9f77-4a95be08643e.png)

- [x] [xrptipbot.com](https://www.xrptipbot.com/) should monetize

  - ![image](https://user-images.githubusercontent.com/525211/66626655-3c3aae80-ec23-11e9-981a-0e317ab80b42.png)

- [x] [twitch.tv](https://twitch.tv/vinesauce) works

  - ![image](https://user-images.githubusercontent.com/525211/66626721-815ee080-ec23-11e9-8139-59a563822eb0.png)

- [x] [monetized youtube video](https://www.youtube.com/watch?v=-QMbZx_w2_Y)

  - ![image](https://user-images.githubusercontent.com/525211/66626878-0a761780-ec24-11e9-8015-19bf8348807b.png)

- Coil welcome and welcome to explore pages

  - [x] Go to coil.com, the browser action popup should show welcome to coil
    - ![image](https://user-images.githubusercontent.com/525211/66626988-6b9deb00-ec24-11e9-86c3-b55c17e891c2.png)
  - [x] Should have a link to coil.com/explore page
  - [x] Once on explore page should show `Start Exploring` with a rocket-ship graphic
    - ![image](https://user-images.githubusercontent.com/525211/66627053-a2740100-ec24-11e9-8759-76f40c46d6fa.png)

- [x] Check the monetization animation works properly

  - ![image](https://user-images.githubusercontent.com/525211/66627467-04813600-ec26-11e9-855a-517700af4e26.png)
  - Only required on desktop browsers
  - Should animate when monetized and packets received
  - Should stop animation when network disconnected
    - Note that on Firefox/MacOS the popup automatically closes when the
      tab loses focus so can use something like this in terminal:
      - `sudo sleep 10 && sudo ifconfig en0 down && sleep 10 && sudo ifconfig en0 up`

- [x] Check monetization works consistently

  - In the same tab, go to http://www.travisvcrist.com/gatehub
    - refresh and make sure streaming works 10 times in a row
      - should not get 'stuck' in 'setting up payment' state
  - Issue: [coil/coilhq#3038][ci3038]
  - Fix PRs: [#242][np242]

- [x] Will route to \$coildomain.com/login rather than open popup if logged out

  - Log out from \$coildomain.com
  - Check that icon is in 'unavailable' state
    - ![image](https://user-images.githubusercontent.com/525211/66627206-2a5a0b00-ec25-11e9-9c0c-74dc34370e13.png)
  - Click on browser action
  - Check that routed to login page
    - ![image](https://user-images.githubusercontent.com/525211/66627301-6beab600-ec25-11e9-8045-a4e35686dc34.png)

- [x] Popup icon should show if page is monetized even when logged out

  - Log out from extension
  - Go to a monetized page and check that the icon "monetized" black and in 'unavailable' state
    - ![image](https://user-images.githubusercontent.com/525211/70715784-8f150d00-1d1d-11ea-8f82-fe116b2e9a16.png)

- [x] Run the puppeteer [tests](./test.sh) (look at the [circle jobs](../../../.circleci/config.yml))

  - export BROWSER_TYPE='chrome' # or 'firefox'
  - logout test currently fails on Firefox due to puppeteer-firefox limitations

- [x] Go to a [youtube video](https://www.youtube.com/watch?v=l1btEwwRePs),
      manually skip to near end of video, and when autoplay of a video from
      another channel starts, check that monetization has stopped.

  - Issues: [#33][i33]
  - PRs: [#213][np213]

- [x] Go to [xrpcommunity.blog](https://xrpcommunity.blog/) and as page
      is loading very quickly open the popup.
      It should show "This page is Web-Monetized" even before streaming
      starts. Should show 'setting up payment' then 'coil is paying creator'
      [#120][i120]

- [x] Open the [reloading-every-15s.html](../test/fixtures/reloading-every-15s.html) file:

  - Use a localhost server so WM works (e.g. with `python -m http.server 4000`)
  - Open the developer tools console undocked so can view while **PAGE IS BACKGROUNDED**
    - Note the `Reloading page` logging
  - Open the extension background page developer tools and look at the stream logging
  - SHOULD NOT initiate a stream or SPSP request
    [#144][i144]

- [x] Open the [event-logger.html](../test/fixtures/event-logger.html) file:

  - Use a localhost server so WM works (e.g. with `python -m http.server 4000`)
  - Look for unusual timings, check that pending state is emitted nearly
    immediately after page load or meta tag added
  - Issue: [#63][ni63]
  - Fix PR: [#69][np69]

- [x] Check started event fires when quickly switching between tabs

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Switch to another (non-monetized) tab. The payments stop. Quickly switch back to the first tab.
  - The payments restart. Make sure there is a monetizationstart event
  - Issue: [#105][ni105]
  - Fix PR: [#117][np117]

- [x] Check stopped event fires with correct requestId

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Induce a stop/start in same js 'tick'
  - Check that the stopped event has the correct requestId
  - Issue: [#127][ni127]
  - Fix PR: [#128][np128]

- [x] Check tip event fires when clicked on in the popup

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Open the extension popup and click on "Tip this creator \$1!"
  - Check that the tip event occurs

- [x] Run a local web server (e.g. with `python -m http.server 4000`) serving
      the dist folder, then open [static/popup.html](static/popup.html) in a
      normal tab and check the popup rendering in various states.

- [x] On MacOS Chromium browsers (Chrome/Edge) check that the monetized animation is working
      on non primary monitors.

  - Issue: [#312][i312]
  - Fix PR: [#317][p317]

- [x] Check that popup closes when another window is focused

  - Open two Browser windows, open the popup in one window
  - Focus on second window
  - Ensure that popup is closed

  - Issue: [#313][i313]
  - Fix PR: [#332][p332]

- [x] Check SPA apps keep streaming when url changed, meta stays

  - Go to e.g. https://www.wevolver.com/
  - Change other pages which uses HTML5 history.pushState
  - Check that streaming is maintained throughout

    - if not, use browser devtools to check if meta exists
      - `document.head.querySelector('meta[name="monetization"]')`

  - Issue: [#507][i507]
  - Fix PR: [#508][p508]

- [x] Check extension doesn't attempt to stream when unsubscribed

  - Log in with coil user that doesn't have active subscription
  - Open the developer tools and check the logging
  - SHOULD NOT even attempt to stream
  - ![image](https://user-images.githubusercontent.com/525211/66631124-c9840000-ec2f-11e9-95a4-3bebe7fdebd6.png)
  - Issue: [#213][i213]
  - Fix PR: [#222][p222]

- [x] Check can stream immediately after subscribing
  - Likely best to test this with staging where can use a test card
  - Log in with coil user that doesn't have active subscription
  - Add a subscription (can use [testing card](https://stripe.com/docs/testing) 4242 4242 4242 4242 )
  - Go to a monetized page and check that streaming works immediately

### Iframe testing

1. - [x] Open a terminal and `cd packages/coil-extension/test/fixtures/iframes/`
2. - [x] Start a server (via `python -m http.server 4000` or equivalent)
3. - [x] Open http://localhost:4000/top-nested-allowed-iframe.html in browser
4. Open developer tools and look at the structure of the dom

- Use expand recursively feature
  - ![image](https://user-images.githubusercontent.com/525211/76400168-71098800-63b2-11ea-8069-5ee7b8b0707a.png)

5. - [x] With the console set `localStorage.WM_DEBUG = true`

#### Test 1: basic monetization

1. Load the page
2. - [x] Look for 4 monetizationpending events and 4 corresponding (same requestId) monetizationstart events logged in the console.

![image](https://user-images.githubusercontent.com/525211/76397844-6a791180-63ae-11ea-8f1c-72ef3a6183fb.png)

#### Test 2: refresh page / turn off / turn on

1. - [x] [re]load the page
2. - [x] Open developer tools and turn "off" monetization via editing allow attribute of top level iframes
   - ![image](https://user-images.githubusercontent.com/525211/76398261-28040480-63af-11ea-85cb-396960ced1bb.png)
   - Popup icon (and background page logging) should show no monetization:
     - [x] ![image](https://user-images.githubusercontent.com/525211/76398281-305c3f80-63af-11ea-857c-6ab6b409daa5.png)
   - Corresponding monetization events should be logged:
     - [x] ![image](https://user-images.githubusercontent.com/525211/76398873-3999dc00-63b0-11ea-8ee6-7ca45d8b44f0.png)

3. turn "on" monetization via editing allow attribute of top level iframes
   - ![image](https://user-images.githubusercontent.com/525211/76398370-57b30c80-63af-11ea-86a8-133271e46b91.png)
   - [x] Popup icon (and background page logging) should show monetization
     - ![image](https://user-images.githubusercontent.com/525211/76398417-6d283680-63af-11ea-88e6-c4b0ed5c35f7.png)
   - [x] Corresponding monetization events should be logged:
     - ![image](https://user-images.githubusercontent.com/525211/76399026-841b5880-63b0-11ea-8b0b-c0ecbff13bee.png)

#### Test 3: refresh page / turn off / background tab / turn on / foreground tab

- As above but while the tab is backgrounded, after turning on each top level iframe a sequence of pending -> stopped events should be fired:
  - [x] ![image](https://user-images.githubusercontent.com/525211/76399956-1a03b300-63b2-11ea-9b77-671e94a1bf16.png)

#### Test 4: nested

- As per test 2
- Turn off one top level and then turn off the nested frames in top level that is allowed
- [x] allow _one_ nested iframe and check for indications of monetization

[i33]: https://github.com/coilhq/web-monetization/issues/33
[i120]: https://github.com/coilhq/web-monetization/issues/120
[i144]: https://github.com/coilhq/web-monetization/issues/144
[p166]: https://github.com/coilhq/web-monetization/pull/166
[i213]: https://github.com/coilhq/web-monetization/issues/213
[p222]: https://github.com/coilhq/web-monetization/pull/222
[p295]: https://github.com/coilhq/web-monetization/pull/295
[ci2084]: https://github.com/coilhq/coil/issues/2084
[ci3038]: https://github.com/coilhq/coil/issues/3038
[i312]: https://github.com/coilhq/web-monetization/issues/312
[p317]: https://github.com/coilhq/web-monetization/pull/317
[i313]: https://github.com/coilhq/web-monetization/issues/313
[p332]: https://github.com/coilhq/web-monetization/pull/332
[i507]: https://github.com/coilhq/web-monetization/issues/507
[p508]: https://github.com/coilhq/web-monetization/pull/508
[np28]: https://github.com/coilhq/web-monetization-projects/pull/28
[ni21]: https://github.com/coilhq/web-monetization-projects/issue/21
[ni63]: https://github.com/coilhq/web-monetization-projects/issue/63
[np69]: https://github.com/coilhq/web-monetization-projects/pull/69
[ni105]: https://github.com/coilhq/web-monetization-projects/issue/105
[np117]: https://github.com/coilhq/web-monetization-projects/pull/117
[ni127]: https://github.com/coilhq/web-monetization-projects/issue/127
[np128]: https://github.com/coilhq/web-monetization-projects/pull/128
[ni184]: https://github.com/coilhq/web-monetization-projects/issue/184
[np185]: https://github.com/coilhq/web-monetization-projects/pull/185
[np213]: https://github.com/coilhq/web-monetization-projects/pull/213
[np242]: https://github.com/coilhq/web-monetization-projects/pull/242
