### PR TITLE
feat(coil-oauth-scripts): add receipts

### DIFF
--- a/packages/web-monetization-demo/src/verifier/main.ts
+++ b/packages/web-monetization-demo/src/verifier/main.ts
@@ -22,6 +22,11 @@ async function main() {
       })
     )
     app.use(bodyParser.text())
+    app.use('*', (req, res, next) => {
+      res.set('Access-Control-Allow-Origin', '*')
+      res.set('Access-Control-Allow-Headers', '*')
+      next()
+    })
   })
 
   const app = server.build()


### PR DESCRIPTION
How to test in only 5000 easy steps!

### Terminal 1 - Build OAuth Scripts 
```
cd packages/coil-oauth-scripts
OUTPUT_TO=$PWD/../coil-extension/test/fixtures yarn build --watch
```

### Terminal 2 - SPSP Receiver
```
cd packages/web-monetization-demo
SERVER_PORT=4002 yarn run server:dev
```
### Terminal 3 - SPSP Verifier
```
# runs on port 4001, proxies to receiver running on port 4002
cd packages/web-monetization-demo
SPSP_ENDPOINT=http://localhost:4002/spsp/~niq yarn run verifier:dev
```

### Terminal 4 - Sender Event Logger
```
cd packages/coil-oauth-scripts
export COIL_USER='*'
export COIL_PASSWORD='*'
SUBSTITUTES='{"$twitter.xrptipbot.com/Coil": "http://localhost:4001/spsp/~niq"}' \
POLYFILL_INIT_ARGS='{"btpEndpoint": "btp+ws://localhost:3000"}' \
yarn serve-it ../coil-extension/test/fixtures/event-logger.html
```

Load the page at http://localhost:4000 
