### PR TITLE
chore: rename main to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Development Process
 
-Ultimately we want `master` branch to be in a 'good' state at all times, with good test
+Ultimately we want `main` branch to be in a 'good' state at all times, with good test
 coverage so we can practice CD.
 
 However, currently there are known bugs, very little automated tests and the code will
@@ -16,7 +16,7 @@ manual release checklist on each PR/commit.
 
 Till then:
 
-- **do not assume master branch is in a good state** !
+- **do not assume main branch is in a good state** !
   - Go through the release [release checklist](packages/coil-extension/docs/release-checklist.md) carefully!
 
 ## Setting up dev environment

--- a/packages/coil-anonymous-tokens/package.json
+++ b/packages/coil-anonymous-tokens/package.json
@@ -7,7 +7,7 @@
     "ilp",
     "web-monetization"
   ],
-  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/master/packages/coil-anonymous-tokens",
+  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/main/packages/coil-anonymous-tokens",
   "repository": {
     "type": "git",
     "url": "git@github.com:coilhq/web-monetization-projects.git"

--- a/packages/coil-client/package.json
+++ b/packages/coil-client/package.json
@@ -7,7 +7,7 @@
     "ilp",
     "web-monetization"
   ],
-  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/master/packages/coil-client",
+  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/main/packages/coil-client",
   "repository": {
     "type": "git",
     "url": "git@github.com:coilhq/web-monetization-projects.git"

--- a/packages/coil-extension/package.json
+++ b/packages/coil-extension/package.json
@@ -10,7 +10,7 @@
     "ilp",
     "web-monetization"
   ],
-  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/master/packages/coil-extension",
+  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/main/packages/coil-extension",
   "repository": {
     "type": "git",
     "url": "git@github.com:coilhq/web-monetization-projects.git"

--- a/packages/coil-monorepo-upkeep/package.json
+++ b/packages/coil-monorepo-upkeep/package.json
@@ -16,7 +16,7 @@
     "monorepo",
     "willy"
   ],
-  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/master/packages/coil-monorepo-upkeep",
+  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/main/packages/coil-monorepo-upkeep",
   "repository": {
     "type": "git",
     "url": "git@github.com:coilhq/web-monetization-projects.git"

--- a/packages/coil-monorepo-upkeep/src/commands/doUpKeep/doUpKeep.ts
+++ b/packages/coil-monorepo-upkeep/src/commands/doUpKeep/doUpKeep.ts
@@ -88,7 +88,7 @@ function setCommonScriptsAndMergeOverrides(
     ...subPackageJSON,
     version: '0.0.0',
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    homepage: `https://github.com/${githubPath}/tree/master/packages/${folderName}`,
+    homepage: `https://github.com/${githubPath}/tree/main/packages/${folderName}`,
     keywords: rootPackageJSON.keywords,
     repository: rootPackageJSON.repository,
     main: './build',

--- a/packages/coil-monorepo-upkeep/src/types.ts
+++ b/packages/coil-monorepo-upkeep/src/types.ts
@@ -49,7 +49,7 @@ export interface DependabotUpdateConfigsItem {
   package_manager: 'javascript' | string
   directory: string
   update_schedule: 'live' | string
-  target_branch: 'master' | string
+  target_branch: 'main' | string
 }
 
 export interface DependabotConfig {

--- a/packages/coil-oauth-scripts/package.json
+++ b/packages/coil-oauth-scripts/package.json
@@ -8,7 +8,7 @@
     "ilp",
     "web-monetization"
   ],
-  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/master/packages/coil-oauth-scripts",
+  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/main/packages/coil-oauth-scripts",
   "repository": {
     "type": "git",
     "url": "git@github.com:coilhq/web-monetization-projects.git"

--- a/packages/coil-polyfill-utils/package.json
+++ b/packages/coil-polyfill-utils/package.json
@@ -7,7 +7,7 @@
     "ilp",
     "web-monetization"
   ],
-  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/master/packages/coil-polyfill-utils",
+  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/main/packages/coil-polyfill-utils",
   "repository": {
     "type": "git",
     "url": "git@github.com:coilhq/web-monetization-projects.git"

--- a/packages/coil-privacypass-sjcl/package.json
+++ b/packages/coil-privacypass-sjcl/package.json
@@ -14,7 +14,7 @@
     "ilp",
     "web-monetization"
   ],
-  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/master/packages/coil-privacypass-sjcl",
+  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/main/packages/coil-privacypass-sjcl",
   "repository": {
     "type": "git",
     "url": "git@github.com:coilhq/web-monetization-projects.git"

--- a/packages/coil-puppeteer-utils/package.json
+++ b/packages/coil-puppeteer-utils/package.json
@@ -7,7 +7,7 @@
     "ilp",
     "web-monetization"
   ],
-  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/master/packages/coil-puppeteer-utils",
+  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/main/packages/coil-puppeteer-utils",
   "repository": {
     "type": "git",
     "url": "git@github.com:coilhq/web-monetization-projects.git"

--- a/packages/dier-makr-annotations/package.json
+++ b/packages/dier-makr-annotations/package.json
@@ -7,7 +7,7 @@
     "ilp",
     "web-monetization"
   ],
-  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/master/packages/dier-makr-annotations",
+  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/main/packages/dier-makr-annotations",
   "repository": {
     "type": "git",
     "url": "git@github.com:coilhq/web-monetization-projects.git"

--- a/packages/dier-makr-inversify/package.json
+++ b/packages/dier-makr-inversify/package.json
@@ -7,7 +7,7 @@
     "ilp",
     "web-monetization"
   ],
-  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/master/packages/dier-makr-inversify",
+  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/main/packages/dier-makr-inversify",
   "repository": {
     "type": "git",
     "url": "git@github.com:coilhq/web-monetization-projects.git"

--- a/packages/interledger-minute-extension/package.json
+++ b/packages/interledger-minute-extension/package.json
@@ -8,7 +8,7 @@
     "ilp",
     "web-monetization"
   ],
-  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/master/packages/interledger-minute-extension",
+  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/main/packages/interledger-minute-extension",
   "repository": {
     "type": "git",
     "url": "git@github.com:coilhq/web-monetization-projects.git"

--- a/packages/web-monetization-demo/package.json
+++ b/packages/web-monetization-demo/package.json
@@ -7,7 +7,7 @@
     "ilp",
     "web-monetization"
   ],
-  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/master/packages/web-monetization-demo",
+  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/main/packages/web-monetization-demo",
   "repository": {
     "type": "git",
     "url": "git@github.com:coilhq/web-monetization-projects.git"

--- a/packages/web-monetization-polyfill-utils/package.json
+++ b/packages/web-monetization-polyfill-utils/package.json
@@ -8,7 +8,7 @@
     "ilp",
     "web-monetization"
   ],
-  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/master/packages/web-monetization-polyfill-utils",
+  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/main/packages/web-monetization-polyfill-utils",
   "repository": {
     "type": "git",
     "url": "git@github.com:coilhq/web-monetization-projects.git"

--- a/packages/web-monetization-react/package.json
+++ b/packages/web-monetization-react/package.json
@@ -11,7 +11,7 @@
     "ilp",
     "web-monetization"
   ],
-  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/master/packages/web-monetization-react",
+  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/main/packages/web-monetization-react",
   "repository": {
     "type": "git",
     "url": "git@github.com:coilhq/web-monetization-projects.git"

--- a/packages/web-monetization-types/package.json
+++ b/packages/web-monetization-types/package.json
@@ -8,7 +8,7 @@
     "ilp",
     "web-monetization"
   ],
-  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/master/packages/web-monetization-types",
+  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/main/packages/web-monetization-types",
   "repository": {
     "type": "git",
     "url": "git@github.com:coilhq/web-monetization-projects.git"

--- a/packages/web-monetization-wext/package.json
+++ b/packages/web-monetization-wext/package.json
@@ -7,7 +7,7 @@
     "ilp",
     "web-monetization"
   ],
-  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/master/packages/web-monetization-wext",
+  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/main/packages/web-monetization-wext",
   "repository": {
     "type": "git",
     "url": "git@github.com:coilhq/web-monetization-projects.git"

--- a/packages/webexts-build-utils/package.json
+++ b/packages/webexts-build-utils/package.json
@@ -7,7 +7,7 @@
     "ilp",
     "web-monetization"
   ],
-  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/master/packages/webexts-build-utils",
+  "homepage": "https://github.com/coilhq/web-monetization-projects/tree/main/packages/webexts-build-utils",
   "repository": {
     "type": "git",
     "url": "git@github.com:coilhq/web-monetization-projects.git"


### PR DESCRIPTION
Renames master to main. Locally devs should do the following to update their HEAD.

```
git checkout master
git branch -m master main
git fetch
git branch --unset-upstream
git branch -u origin/main
git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
```