### PR TITLE
feat(coil-extension): update safari bundleids

### DIFF
--- a/packages/coil-extension/safari/Coil/Coil.xcodeproj/project.pbxproj
+++ b/packages/coil-extension/safari/Coil/Coil.xcodeproj/project.pbxproj
@@ -427,7 +427,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.ndudfield.coil.extension.safari.Coil-Extension";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.coil.safari.extension.Coil-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
@@ -447,7 +447,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.ndudfield.coil.extension.safari.Coil-Extension";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.coil.safari.extension.Coil-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
@@ -470,7 +470,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.ndudfield.coil.extension.safari.Coil;
+				PRODUCT_BUNDLE_IDENTIFIER = com.coil.safari.extension.Coil;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 			};
@@ -492,7 +492,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.ndudfield.coil.extension.safari.Coil;
+				PRODUCT_BUNDLE_IDENTIFIER = com.coil.safari.extension.Coil;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 			};


### PR DESCRIPTION
I added the XCode project files to WM repo, using a ndudfield namespaced bundle id. It's been a while since I did any serious iOS ( edit: or ANY MacOS) dev, but iirc they register bundle-ids per dev. Would be nice/simpler to just commit a static bundle id to the repo.


