### PR TITLE
feat(coil-extension): fast prepay tokens

### DIFF
--- a/packages/coil-anonymous-tokens/src/index.ts
+++ b/packages/coil-anonymous-tokens/src/index.ts
@@ -73,6 +73,11 @@ export interface AnonymousTokensOptions {
   batchSize: number
 }
 
+export interface RedeemedToken {
+  btpToken: string
+  throughput: number // amount-per-second
+}
+
 export class AnonymousTokens {
   private redeemerUrl: string
   private signerUrl: string
@@ -109,7 +114,7 @@ export class AnonymousTokens {
     initECSettings(h2cParams())
   }
 
-  async getToken(coilAuthToken: string): Promise<string> {
+  async getToken(coilAuthToken: string): Promise<RedeemedToken> {
     // When there is only 1 token left, fetch some more in the background.
     if (this.storedTokenCount === 1) {
       this.populateTokens(coilAuthToken)
@@ -122,22 +127,23 @@ export class AnonymousTokens {
         await this.populateTokens(coilAuthToken)
         continue
       }
-      const btpToken = await this._redeemToken(token)
-      if (btpToken) return btpToken
+      const redeemedToken = await this._redeemToken(token)
+      if (redeemedToken) return redeemedToken
       // Otherwise, try again, since the retrieved token was likely expired.
     }
   }
 
   private async _redeemToken(
     token: StorableBlindToken
-  ): Promise<string | undefined> {
+  ): Promise<RedeemedToken | undefined> {
     const usableToken = deserializeToken(token)
     const redeemRequest = BuildRedeemHeader(usableToken, '', '')
     const response = await portableFetch(this.redeemerUrl + '/redeem', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
-        bl_sig_req: redeemRequest
+        bl_sig_req: redeemRequest,
+        mode: 'fast'
       })
     })
 
@@ -161,7 +167,7 @@ export class AnonymousTokens {
 
     // TODO: make sure the token data is a string and is a good identifier for the token
     this.tokenMap.set(btpToken, storableTokenName(token))
-    return btpToken
+    return { btpToken, throughput: body.throughput }
   }
 
   private _getSignedToken(): Promise<StorableBlindToken | undefined> {

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -396,11 +396,20 @@ export class BackgroundScript {
   ) {
     const tabState = this.tabStates.get(tabId)
 
+    const streamId = this.assoc.getStreamId({ tabId, frameId })
+    let isPaying = false
+    if (streamId) {
+      isPaying = this.streams.getStream(streamId).isPaying()
+    } else {
+      this.log('can not find top frame for tabId=%d', tabId)
+    }
+
     this.tabStates.setFrame(
       { tabId, frameId },
       {
         monetized: true,
-        total: total || (tabState.frameStates[frameId]?.total ?? 0)
+        total: total || (tabState.frameStates[frameId]?.total ?? 0),
+        isPaying
       }
     )
 
@@ -491,7 +500,12 @@ export class BackgroundScript {
 
     if (state) {
       const total = frameStates.reduce((acc, val) => acc + val.total, 0)
+      //const isPaying = frameStates.reduce((acc, val) => acc || val., false)
       this.storage.set('monetizedTotal', total)
+      this.storage.set(
+        'isPaying',
+        frameStates.reduce((acc, val) => acc || val.isPaying, false)
+      )
     }
     this.storage.set(
       'monetizedFavicon',

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -500,12 +500,9 @@ export class BackgroundScript {
 
     if (state) {
       const total = frameStates.reduce((acc, val) => acc + val.total, 0)
-      //const isPaying = frameStates.reduce((acc, val) => acc || val., false)
+      const isPaying = frameStates.some(state => state.isPaying)
       this.storage.set('monetizedTotal', total)
-      this.storage.set(
-        'isPaying',
-        frameStates.reduce((acc, val) => acc || val.isPaying, false)
-      )
+      this.storage.set('isPaying', isPaying)
     }
     this.storage.set(
       'monetizedFavicon',

--- a/packages/coil-extension/src/background/services/PaymentScheduler.ts
+++ b/packages/coil-extension/src/background/services/PaymentScheduler.ts
@@ -1,0 +1,78 @@
+import { injectable } from 'inversify'
+import { Logger, logger } from './utils'
+
+// The duration "paid" per token.
+const TOKEN_DURATION = 60_000 // milliseconds
+// For additional privacy, obfuscate token schedules by varying delays by ±jitter (uniform distribution).
+const JITTER = 5_000 // milliseconds
+// Except for the first token, full payment for interval [T₀,T₁] is sent at time T₀.
+// The interval is `tokensPerBatch * TOKEN_DURATION` milliseconds.
+// `tokensPerBatch` is the maximum of:
+// - `TOKEN_DURATION` (1 minute).
+// - `1+floor(sent*PREPAY)`
+//
+// For example, when `PREPAY==0.1`, after 10 minutes it will pay 2 tokens at a time.
+// After 20 minutes, it will pay 3 tokens at a time.
+const PREPAY = 0.1
+
+@injectable()
+export class PaymentScheduler {
+  private sent = 0 // tokens sent
+  private startT = 0
+  private relT = 0 // time relative to first send
+  private batchSize = 1 // tokens per batch
+  private batchIndex = 0 // index within batch
+  private timer?: NodeJS.Timer
+  private onClose?: (err: Error) => void
+
+  constructor(@logger('PaymentScheduler') private readonly debug: Logger) {}
+
+  onSent(): void {
+    // The very first payment sent starts the scheduler's timer for the remaining
+    // points (just to simplify `timeOfSend`'s calculation).
+    if (this.sent === 0) {
+      this.startT = Date.now()
+    }
+    this.sent++
+    if (++this.batchIndex === this.batchSize) {
+      this.batchIndex = 0
+      this.batchSize = 1 + Math.floor(this.sent * PREPAY)
+      this.relT += TOKEN_DURATION * this.batchSize
+    }
+  }
+
+  async wait(): Promise<void> {
+    const ms = this.waitTimeWithJitter()
+    this.debug(
+      'waiting %dms before sending payment number %d',
+      ms,
+      this.sent + 1
+    )
+    if (!ms) return
+    await new Promise((resolve, reject): void => {
+      this.timer = setTimeout(resolve, ms)
+      this.onClose = reject
+    })
+  }
+
+  stop(): void {
+    if (this.timer) clearTimeout(this.timer)
+    if (this.onClose) this.onClose(new Error('closed'))
+  }
+
+  private waitTimeWithJitter(): number {
+    const w = this.waitTime()
+    const j = randBetween(-JITTER, JITTER)
+    return w === 0 ? w : Math.max(0, w + j)
+  }
+
+  private waitTime(): number {
+    const relSendTime = this.relT - TOKEN_DURATION * this.batchSize
+    const absSendTime = this.startT + relSendTime
+    return Math.max(0, absSendTime - Date.now())
+  }
+}
+
+function randBetween(a: number, b: number): number {
+  return Math.random() * (b - a) + a
+}

--- a/packages/coil-extension/src/background/services/Stream.ts
+++ b/packages/coil-extension/src/background/services/Stream.ts
@@ -100,8 +100,6 @@ export class Stream extends EventEmitter {
   private _coilDomain: string
   private _anonTokens: AnonymousTokens
 
-  private _schedule: PaymentScheduler
-
   private _assetCode: string
   private _assetScale: number
   private _exchangeRate: number
@@ -110,6 +108,8 @@ export class Stream extends EventEmitter {
     @logger('Stream')
     private readonly _debug: Logger,
     private container: Container,
+    @inject(PaymentScheduler)
+    private _schedule: PaymentScheduler,
     @inject(tokens.StreamDetails)
     {
       requestId,
@@ -131,7 +131,6 @@ export class Stream extends EventEmitter {
     this._authToken = token
     this._coilDomain = container.get(tokens.CoilDomain)
     this._anonTokens = container.get(AnonymousTokens)
-    this._schedule = container.get(PaymentScheduler)
 
     this._assetCode = ''
     this._assetScale = 0

--- a/packages/coil-extension/src/background/services/Streams.ts
+++ b/packages/coil-extension/src/background/services/Streams.ts
@@ -6,6 +6,7 @@ import { BandwidthTiers } from '@coil/polyfill-utils'
 
 import * as tokens from '../../types/tokens'
 
+import { PaymentScheduler } from './PaymentScheduler'
 import { Stream } from './Stream'
 
 @injectable()
@@ -35,6 +36,7 @@ export class Streams extends EventEmitter {
   ) {
     const child = this.container.createChild()
     child.bind(tokens.StreamDetails).toConstantValue({ ...options })
+    child.bind(PaymentScheduler).toSelf().inTransientScope()
     this._streams[id] = child.get(Stream)
     this._streams[id].on('money', details => {
       this.emit('money', { url: options.initiatingUrl, id, ...details })

--- a/packages/coil-extension/src/background/services/TabStates.ts
+++ b/packages/coil-extension/src/background/services/TabStates.ts
@@ -69,6 +69,7 @@ export class TabStates {
     return {
       monetized: false,
       adapted: false,
+      isPaying: false,
       total: 0,
       lastMonetization: {
         command: null,

--- a/packages/coil-extension/src/popup/components/MonetizationAnimation.tsx
+++ b/packages/coil-extension/src/popup/components/MonetizationAnimation.tsx
@@ -7,12 +7,12 @@ import { notNullOrUndef } from '../../util/nullables'
 const ANIMATION_INTERVAL = 1800
 
 export const MonetizeAnimation = (props: PopupProps) => {
-  const isPaying = localStorage.getItem('isPaying') === 'true'
-  const [animated, setAnimated] = useState<boolean>(isPaying)
+  const store = props.context.store
+  const [animated, setAnimated] = useState<boolean>(store.isPaying)
 
   useEffect(() => {
     const loopInterval = setInterval(() => {
-      setAnimated(localStorage.getItem('isPaying') === 'true')
+      setAnimated(store.isPaying)
     }, ANIMATION_INTERVAL)
 
     return () => {

--- a/packages/coil-extension/src/popup/components/MonetizationAnimation.tsx
+++ b/packages/coil-extension/src/popup/components/MonetizationAnimation.tsx
@@ -7,44 +7,16 @@ import { notNullOrUndef } from '../../util/nullables'
 const ANIMATION_INTERVAL = 1800
 
 export const MonetizeAnimation = (props: PopupProps) => {
-  const [lastPacket, setLastPacket] = useState<Date | null>(null)
-  const [animated, setAnimated] = useState<boolean | null>(false)
-  const lastPacketRef = useRef(lastPacket)
-  lastPacketRef.current = lastPacket
+  const isPaying = localStorage.getItem('isPaying') === 'true'
+  const [animated, setAnimated] = useState<boolean>(isPaying)
 
   useEffect(() => {
-    let animateTimeout: number | null
+    const loopInterval = setInterval(() => {
+      setAnimated(localStorage.getItem('isPaying') === 'true')
+    }, ANIMATION_INTERVAL)
 
-    const loopHandler = () => {
-      const now = new Date()
-      const lastPacketPlus2s = new Date(notNullOrUndef(lastPacketRef.current))
-      lastPacketPlus2s.setSeconds(lastPacketPlus2s.getSeconds() + 2)
-      if (now > lastPacketPlus2s) {
-        animateTimeout = null
-        setAnimated(false)
-      } else {
-        animateTimeout = window.setTimeout(loopHandler, ANIMATION_INTERVAL)
-      }
-    }
-
-    const listener = (msg: ToPopupMessage) => {
-      if (
-        msg.command === 'localStorageUpdate' &&
-        msg.key === 'monetizedTotal'
-      ) {
-        setLastPacket(new Date())
-        setAnimated(true)
-        if (!animateTimeout) {
-          window.setTimeout(loopHandler, ANIMATION_INTERVAL)
-        }
-      }
-    }
-    props.context.runtime.onMessageAddListener(listener)
     return () => {
-      props.context.runtime.onMessageRemoveListener(listener)
-      if (animateTimeout != null) {
-        clearTimeout(animateTimeout)
-      }
+      clearInterval(loopInterval)
     }
   }, [])
 

--- a/packages/coil-extension/src/popup/services/PopupState.ts
+++ b/packages/coil-extension/src/popup/services/PopupState.ts
@@ -9,6 +9,7 @@ const STORAGE_KEYS = [
   'monetized',
   'monetizedFavicon',
   'monetizedTotal',
+  'isPaying',
   'stickyState',
   'playState',
   'user',
@@ -25,6 +26,7 @@ export class PopupState implements PopupStateType {
   readonly monetized!: boolean
   readonly monetizedFavicon!: string
   readonly monetizedTotal!: number
+  readonly isPaying!: boolean
   readonly user!: User
   readonly validToken!: boolean
 

--- a/packages/coil-extension/src/services/decorateThirdPartyClasses.ts
+++ b/packages/coil-extension/src/services/decorateThirdPartyClasses.ts
@@ -1,7 +1,6 @@
 import { EventEmitter } from 'events'
 
 import { decorate, injectable } from 'inversify'
-import { AdaptiveBandwidth } from '@web-monetization/polyfill-utils'
 import { BandwidthTiers } from '@coil/polyfill-utils'
 import { inversifyModule } from '@dier-makr/inversify'
 import { GlobalModule } from '@dier-makr/annotations'
@@ -10,5 +9,4 @@ export function decorateThirdPartyClasses() {
   inversifyModule(GlobalModule)
   decorate(injectable(), EventEmitter)
   decorate(injectable(), BandwidthTiers)
-  decorate(injectable(), AdaptiveBandwidth)
 }

--- a/packages/coil-extension/src/types/TabState.ts
+++ b/packages/coil-extension/src/types/TabState.ts
@@ -5,6 +5,7 @@ export type MonetizationCommand = 'pause' | 'stop' | 'start' | 'resume'
 export interface FrameState {
   adapted: boolean
   monetized: boolean
+  isPaying: boolean
   // Tracks the total amount of `source` money sent (not was received)
   total: number
   lastMonetization: {

--- a/packages/coil-extension/test/jest/PaymentScheduler.test.ts
+++ b/packages/coil-extension/test/jest/PaymentScheduler.test.ts
@@ -1,0 +1,91 @@
+import '@abraham/reflection'
+import { PaymentScheduler } from '../../src/background/services/PaymentScheduler'
+
+const M = 60_000
+const log = args => {}
+
+describe('PaymentScheduler', () => {
+  let ps,
+    spy,
+    time = Date.now()
+  beforeEach(() => {
+    jest.useFakeTimers()
+    spy = jest.spyOn(Date, 'now').mockImplementation(() => time)
+    ps = new PaymentScheduler(log)
+    // The first minute's payment is not scheduled using PaymentScheduler.
+    ps.onSent()
+  })
+
+  afterEach(() => {
+    spy.mockRestore()
+  })
+
+  describe('waitTimeWithJitter', () => {
+    it('varies by at most JITTER', () => {
+      ps.onSent()
+      for (let i = 0; i < 1000; i++) {
+        const w = ps.waitTimeWithJitter()
+        expect(Math.abs(w - M)).toBeLessThan(5_000)
+        expect(w).toBeGreaterThanOrEqual(0)
+      }
+    })
+  })
+
+  describe('waitTime', () => {
+    it('spaces absolute token times', () => {
+      const waits = []
+      for (let i = 0; i < 40; i++) {
+        const w = ps.waitTime()
+        waits.push(w)
+        ps.onSent()
+      }
+      // This also verifies that "overspending" tokens still results in a
+      // correctly-computed delay.
+      // prettier-ignore
+      expect(waits).toStrictEqual([
+         0*M,  1*M,  2*M,  3*M,  4*M,  5*M,  6*M,  7*M,  8*M,  9*M,  9*M,
+        11*M, 11*M, 13*M, 13*M, 15*M, 15*M, 17*M, 17*M, 19*M, 19*M, 19*M,
+        22*M, 22*M, 22*M, 25*M, 25*M, 25*M, 28*M, 28*M, 28*M, 31*M, 31*M,
+        31*M, 31*M, 35*M, 35*M, 35*M, 35*M, 39*M,
+      ])
+    })
+
+    it('spaces relative token times', () => {
+      const waits = []
+      for (let i = 0; i < 40; i++) {
+        const w = ps.waitTime()
+        waits.push(w)
+        ps.onSent()
+        tick(w)
+      }
+      // prettier-ignore
+      expect(waits).toStrictEqual([
+        0*M, 1*M, 1*M, 1*M, 1*M, 1*M, 1*M, 1*M, 1*M, 1*M,
+        0*M, 2*M, 0*M, 2*M, 0*M, 2*M, 0*M, 2*M, 0*M, 2*M,
+        0*M, 0*M, 3*M, 0*M, 0*M, 3*M, 0*M, 0*M, 3*M, 0*M,
+        0*M, 3*M, 0*M, 0*M, 0*M, 4*M, 0*M, 0*M, 0*M, 4*M,
+      ])
+    })
+
+    it('adjusts the wait time', () => {
+      ps.onSent()
+      for (let i = 0; i <= 60; i++) {
+        expect(ps.waitTime()).toBe(M - i * 1000)
+        tick(1000)
+      }
+    })
+
+    it('handles long sending delays', () => {
+      tick(M * 99) // move into the future, so token sending falls behind
+      for (let i = 0; i < 10; i++) {
+        expect(ps.waitTime()).toBe(0)
+        ps.onSent()
+      }
+    })
+  })
+
+  function tick(ms: number): void {
+    time += ms
+    jest.advanceTimersByTime(ms)
+  }
+})

--- a/packages/coil-extension/test/jest/PaymentScheduler.test.ts
+++ b/packages/coil-extension/test/jest/PaymentScheduler.test.ts
@@ -22,7 +22,7 @@ describe('PaymentScheduler', () => {
 
   describe('waitTimeWithJitter', () => {
     it('varies by at most JITTER', () => {
-      ps.onSent()
+      //ps.onSent()
       for (let i = 0; i < 1000; i++) {
         const w = ps.waitTimeWithJitter()
         expect(Math.abs(w - M)).toBeLessThan(5_000)
@@ -43,10 +43,10 @@ describe('PaymentScheduler', () => {
       // correctly-computed delay.
       // prettier-ignore
       expect(waits).toStrictEqual([
-         0*M,  1*M,  2*M,  3*M,  4*M,  5*M,  6*M,  7*M,  8*M,  9*M,  9*M,
-        11*M, 11*M, 13*M, 13*M, 15*M, 15*M, 17*M, 17*M, 19*M, 19*M, 19*M,
-        22*M, 22*M, 22*M, 25*M, 25*M, 25*M, 28*M, 28*M, 28*M, 31*M, 31*M,
-        31*M, 31*M, 35*M, 35*M, 35*M, 35*M, 39*M,
+         1*M,  2*M,  3*M,  4*M,  5*M,  6*M,  7*M,  8*M,  9*M, 10*M, 10*M,
+        12*M, 12*M, 14*M, 14*M, 16*M, 16*M, 18*M, 18*M, 20*M, 20*M, 20*M,
+        23*M, 23*M, 23*M, 26*M, 26*M, 26*M, 29*M, 29*M, 29*M, 32*M, 32*M,
+        32*M, 32*M, 36*M, 36*M, 36*M, 36*M, 40*M,
       ])
     })
 
@@ -60,7 +60,7 @@ describe('PaymentScheduler', () => {
       }
       // prettier-ignore
       expect(waits).toStrictEqual([
-        0*M, 1*M, 1*M, 1*M, 1*M, 1*M, 1*M, 1*M, 1*M, 1*M,
+        1*M, 1*M, 1*M, 1*M, 1*M, 1*M, 1*M, 1*M, 1*M, 1*M,
         0*M, 2*M, 0*M, 2*M, 0*M, 2*M, 0*M, 2*M, 0*M, 2*M,
         0*M, 0*M, 3*M, 0*M, 0*M, 3*M, 0*M, 0*M, 3*M, 0*M,
         0*M, 3*M, 0*M, 0*M, 0*M, 4*M, 0*M, 0*M, 0*M, 4*M,
@@ -68,7 +68,7 @@ describe('PaymentScheduler', () => {
     })
 
     it('adjusts the wait time', () => {
-      ps.onSent()
+      //ps.onSent()
       for (let i = 0; i <= 60; i++) {
         expect(ps.waitTime()).toBe(M - i * 1000)
         tick(1000)

--- a/packages/web-monetization-polyfill-utils/src/lib/AdaptiveBandwidth.ts
+++ b/packages/web-monetization-polyfill-utils/src/lib/AdaptiveBandwidth.ts
@@ -26,10 +26,13 @@ export class AdaptiveBandwidth {
     this._sentAmount += Number(amount) || 0
   }
 
+  getStreamSendMax(): Promise<number> {
+    const elapsed = Date.now() - this._timeStarted
+    return this._getLinearSendMax(elapsed)
+  }
+
   // noinspection DuplicatedCode
-  async getStreamSendMax() {
-    const time = Date.now()
-    const timeElapsed = time - this._timeStarted
+  private async _getLinearSendMax(timeElapsed: number): Promise<number> {
     const secondsElapsed = timeElapsed / 1000
     const bandwidth = await this._tiers.getBandwidth(this._pageUrl)
     const sendAmount = Math.floor(secondsElapsed * bandwidth - this._sentAmount)

--- a/packages/web-monetization-polyfill-utils/test/jest/AdaptiveBandwidth.test.ts
+++ b/packages/web-monetization-polyfill-utils/test/jest/AdaptiveBandwidth.test.ts
@@ -1,0 +1,31 @@
+import { AdaptiveBandwidth } from '../../src/lib/AdaptiveBandwidth'
+
+const URL = 'http://example.com'
+const MS = 1e3
+
+class MockAdaptiveBandwidthTiers {
+  constructor(private bandwidth: number) {}
+  async getBandwidth(url: string): Promise<number> {
+    return this.bandwidth
+  }
+}
+
+describe('AdaptiveBandwidth', () => {
+  describe('_getLinearSendMax', () => {
+    it('uses the bandwidth to compute the sendMax', async () => {
+      const ab = new AdaptiveBandwidth(URL, new MockAdaptiveBandwidthTiers(123))
+      expect(await ab._getLinearSendMax(456)).toStrictEqual(
+        Math.floor((123 * 456) / MS)
+      )
+    })
+
+    it('uses the sent amount to compute the sendMax', async () => {
+      const ab = new AdaptiveBandwidth(URL, new MockAdaptiveBandwidthTiers(123))
+      ab.addSentAmount(12)
+      ab.addSentAmount(34)
+      expect(await ab._getLinearSendMax(456)).toStrictEqual(
+        Math.floor((123 * 456) / MS) - 12 - 34
+      )
+    })
+  })
+})


### PR DESCRIPTION
Instead of gradually paying out a token over 1 minute (via `AdaptiveBandwidth`), prepay entire tokens before each time period. If the user lingers on a page for some time, the tokens will be grouped together.

Description of the scheduling algorithm:

1. The user loads a monetized page.
2. A token is redeemed, and a stream is opened. The extension immediately pays 5 seconds worth of the token.
  - The immediate initial payment is important to ensure the page knows that the user agent is monetized.
  - Unlike subsequent payments, the first payment per page load is not paid ahead of time. This ensures that the user doesn't overpay when quickly navigating through many pages.
3. After 1 minute, the remainder of the initial token is spent. Immediately following, another full token is spent (for the following minute).
4. The extension continues to pay tokens:
  - Initially, it pays one token per minute.
  - After ~10 minutes (from page load), it switches to 2 tokens per 2 minutes.
  - After ~20 minutes (from page load), it switches to 3 tokens per 3 minutes.
  - And so on.

In other words, after the first minute the extension prepays _at most_ `1 minute + (10% of time on page).floor_to_nearest_minute` (the 10% is configurable -- I picked it pretty arbitrarily).

---

This PR depends on a couple of changes to coil's backend that have been merged, but not yet rolled out.