### PR TITLE
feat(coil-extension): disable monetization for own paymentPointer

### DIFF
--- a/packages/coil-client/src/queries/whoAmI.ts
+++ b/packages/coil-client/src/queries/whoAmI.ts
@@ -11,6 +11,7 @@ export const whoamiQuery = `{
     fullName
     customerId
     canTip
+    paymentPointer
 
     subscription {
       active

--- a/packages/coil-extension/res/stream_inactive.svg
+++ b/packages/coil-extension/res/stream_inactive.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     viewBox="0 0 172 22" shape-rendering="geometricPrecision" text-rendering="geometricPrecision">
+  <circle r="2" transform="matrix(1 0 0 1 36 11)" fill="rgb(234,234,234)" stroke="none"
+          stroke-width="1"/>
+  <circle r="2" transform="matrix(1 0 0 1 61 11)" fill="rgb(234,234,234)" stroke="none"
+          stroke-width="1"/>
+  <circle r="2" transform="matrix(1 0 0 1 86 11)" fill="rgb(234,234,234)" stroke="none"
+          stroke-width="1"/>
+  <circle r="2" transform="matrix(1 0 0 1 111 11)" fill="rgb(234,234,234)" stroke="none"
+          stroke-width="1"/>
+  <circle r="2" transform="matrix(1 0 0 1 136 11)" fill="rgb(234,234,234)" stroke="none"
+          stroke-width="1"/>
+  <circle r="2" transform="matrix(1 0 0 1 161 11)" fill="rgb(234,234,234)" stroke="none"
+          stroke-width="1"/>
+
+  <circle r="2" transform="matrix(1 0 0 1 11 11)" fill="rgb(234,234,234)" stroke="none"
+          stroke-width="1"/>
+</svg>

--- a/packages/coil-extension/src/popup/components/MonetizedPage.tsx
+++ b/packages/coil-extension/src/popup/components/MonetizedPage.tsx
@@ -46,6 +46,7 @@ export function MonetizedPage(props: PopupProps) {
     )
   }, [])
   const context = props.context
+  const ownPP = Boolean(props.context.store.disabledOwnPaymentPointer)
   return (
     <>
       <Grid container alignItems='center' justify='center'>
@@ -55,10 +56,12 @@ export function MonetizedPage(props: PopupProps) {
               context={context}
               limitRefreshDate={limitRefreshDate}
             />
-          ) : (
+          ) : !ownPP ? (
             <div onClick={onClick}>
               <Donating context={context} />
             </div>
+          ) : (
+            <DisabledOwnPaymentPointer></DisabledOwnPaymentPointer>
           )}
         </div>
       </Grid>
@@ -88,6 +91,27 @@ function Donating(props: PopupProps) {
       </StatusTypography>
       <FlexBox>
         <MonetizeAnimation context={props.context} />
+      </FlexBox>
+    </Fragment>
+  )
+}
+
+function DisabledOwnPaymentPointer() {
+  return (
+    <Fragment>
+      <StatusTypography variant='h6' align='center'>
+        Monetization Disabled
+      </StatusTypography>
+      <StatusTypography variant='subtitle1' align='center'>
+        Own payment pointer
+      </StatusTypography>
+      <FlexBox>
+        <img
+          src={'/res/stream_inactive.svg'}
+          alt='animation'
+          width='171'
+          height='22'
+        />
       </FlexBox>
     </Fragment>
   )

--- a/packages/coil-extension/src/popup/mocks/loadMockedStates.tsx
+++ b/packages/coil-extension/src/popup/mocks/loadMockedStates.tsx
@@ -28,6 +28,7 @@ const user = {
   id: 'cjmbxifo0leaf0711ilgecwdb',
   fullName: 'Nicholas Dudfield',
   customerId: 'cus_EmQtvoQVyJgZ75',
+  paymentPointer: '$twitter.xrptipbot.com/nfcpasses',
   subscription: { active: true },
   invitation: { usedAt: '2018-09-22T00:28:32.714Z' },
   currencyPreferences: { code: 'USD', scale: 9 }
@@ -42,6 +43,7 @@ function mockState(partial: Partial<PopupStateType>): PopupStateType {
     stickyState: null,
     playState: null,
     monetizedFavicon: null,
+    disabledOwnPaymentPointer: null,
     monetizedTotal: null,
     coilSite: null
   }
@@ -107,6 +109,16 @@ const payingNonCoilSite = mockState({
   adapted: false
 })
 
+const payingOwnPaymentPointer = mockState({
+  monetized: true,
+  monetizedTotal: 0,
+  monetizedFavicon: '/res/icon-page.svg',
+  disabledOwnPaymentPointer: true,
+  user: user,
+  validToken: true,
+  adapted: false
+})
+
 const welcomeToCoil = mockState({
   coilSite: 'https://coil.com/',
   monetizedTotal: 0,
@@ -138,6 +150,7 @@ const MOCK_STATES = [
   { name: 'Not Supported', state: notSupported },
   { name: 'Start Exploring', state: startExploring },
   { name: 'Paying', state: payingNonCoilSite },
+  { name: 'Monetized Own Payment Pointer', state: payingOwnPaymentPointer },
   { name: 'Welcome To Coil', state: welcomeToCoil },
   { name: 'Alice Unsubscribed', state: aliceUnsubscribed },
   { name: 'Paying Youtube', state: payingYouTube },

--- a/packages/coil-extension/src/popup/services/PopupState.ts
+++ b/packages/coil-extension/src/popup/services/PopupState.ts
@@ -9,6 +9,7 @@ const STORAGE_KEYS = [
   'monetized',
   'monetizedFavicon',
   'monetizedTotal',
+  'disabledOwnPaymentPointer',
   'stickyState',
   'playState',
   'user',
@@ -27,10 +28,11 @@ export class PopupState implements PopupStateType {
   readonly monetizedTotal!: number
   readonly user!: User
   readonly validToken!: boolean
+  readonly disabledOwnPaymentPointer!: boolean
 
   constructor(private storage: Pick<StorageService, 'get'>) {}
 
-  get loggedIn() {
+  get loggedIn(): boolean {
     return Boolean(this.validToken)
   }
 

--- a/packages/coil-extension/src/types/TabState.ts
+++ b/packages/coil-extension/src/types/TabState.ts
@@ -7,6 +7,7 @@ export interface FrameState {
   monetized: boolean
   // Tracks the total amount of `source` money sent (not was received)
   total: number
+  disabledOwnPaymentPointer?: boolean
   lastMonetization: {
     command: MonetizationCommand | null
     timeMs: number

--- a/packages/coil-extension/src/types/storage.ts
+++ b/packages/coil-extension/src/types/storage.ts
@@ -42,4 +42,6 @@ export interface LocalStorageProxy {
 
   monetizedTotal?: number | null
   monetizedFavicon?: string | null
+
+  disabledOwnPaymentPointer?: boolean | null
 }

--- a/packages/coil-extension/src/types/user.ts
+++ b/packages/coil-extension/src/types/user.ts
@@ -3,6 +3,7 @@ export interface User {
   fullName: string
   customerId?: string
   canTip?: boolean
+  paymentPointer?: string
   subscription?: {
     active: boolean
     endDate?: string

--- a/packages/coil-oauth-scripts/src/bin/coil-it.ts
+++ b/packages/coil-oauth-scripts/src/bin/coil-it.ts
@@ -95,8 +95,10 @@ async function main(): Promise<void> {
 
   const argv = process.argv.slice(2)
   const paymentPointer = argv[0] || '$twitter.xrptipbot.com/nfcpasses'
-  const { token, btpToken } = await login()
+  const { token, btpToken, client } = await login()
   dbg({ token, btpToken })
+
+  dbg(await client.whoAmI(token))
 
   const spspUrl = pointerToUrl(paymentPointer)
   dbg({ spspUrl })


### PR DESCRIPTION
TODO:
- [x] Looks pretty empty without anim
   - [x] Get an svg of the payment animation where it's doing nothing, just empty dots?    
     - @fruehle ?
- [ ] Get product/design input on copy
- [x] Can a Coil user configure more than one payment pointer ?
  - soon this will be the case

Thoughts:

> A point to consider: people probably often test monetization on their own pages using the extension.  We could add an enable button

@adrianhopebailie feedback:

> My suggestion would be a client side list of site’s chosen to be not monetized. We’ll likely need a way to edit it in future (i.e. the ability to change it without visiting the sites on it and toggling the switch)

> instead of automatically trying to disable WM on a user’s own site just give them a switch to disable WM on any site they are on the same way most of the ad-block extensions do

coil-creators team:
> This won't be the same pp that the user will be using on their site in the near future with the changes we're bringing in to the creators settings. Mainly because we're letting creators create payment pointers for their different sites, which are unrelated to their payout pp.

Related issues: #1159 

![image](https://user-images.githubusercontent.com/525211/95966658-99200480-0e35-11eb-8c97-552beee52871.png)

With empty dots:
![image](https://user-images.githubusercontent.com/525211/96223903-e4165500-0fb8-11eb-8138-0ab04c870fc8.png)
