### PR TITLE
feat(coil-extension): safari workaround for missing webNavigation apis

### DIFF
--- a/packages/coil-extension/manifest.json
+++ b/packages/coil-extension/manifest.json
@@ -32,5 +32,5 @@
       "run_at": "document_start"
     }
   ],
-  "permissions": [ "webNavigation", "<all_urls>" ]
+  "permissions": [ "webNavigation", "<all_urls>", "tabs" ]
 }

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -112,12 +112,16 @@ export class BackgroundScript {
       this.reloadTabState({ from: 'onActivated' })
     })
     if (this.buildConfig.logTabsApiEvents) {
-      this.api.tabs.onActiveChanged.addListener((tabId, selectInfo) => {
-        this.log('tabs.onActiveChanged %d %o', tabId, selectInfo)
-      })
-      this.api.tabs.onSelectionChanged.addListener((tabId, selectInfo) => {
-        this.log('tabs.onSelectionChanged %d %o', tabId, selectInfo)
-      })
+      if (this.api.tabs.onActiveChanged) {
+        this.api.tabs.onActiveChanged.addListener((tabId, selectInfo) => {
+          this.log('tabs.onActiveChanged %d %o', tabId, selectInfo)
+        })
+      }
+      if (this.api.tabs.onSelectionChanged) {
+        this.api.tabs.onSelectionChanged.addListener((tabId, selectInfo) => {
+          this.log('tabs.onSelectionChanged %d %o', tabId, selectInfo)
+        })
+      }
       this.api.tabs.onCreated.addListener(activeInfo => {
         this.log('tabs.onCreated %o', activeInfo)
       })

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -29,6 +29,7 @@ import { LocalStorageProxy } from '../../types/storage'
 import { TabState } from '../../types/TabState'
 import { getFrameSpec, getTab } from '../../util/tabs'
 import { FrameSpec } from '../../types/FrameSpec'
+import { BuildConfig } from '../../types/BuildConfig'
 
 import { StreamMoneyEvent } from './Stream'
 import { AuthService } from './AuthService'
@@ -40,11 +41,9 @@ import { Logger, logger } from './utils'
 import { YoutubeService } from './YoutubeService'
 import { BackgroundFramesService } from './BackgroundFramesService'
 import { StreamAssociations } from './StreamAssociations'
+import { PopupPorts } from './PopupPorts'
 
 import MessageSender = chrome.runtime.MessageSender
-
-import { BuildConfig } from '../../types/BuildConfig'
-import { debug } from '../../content/util/logging'
 
 @injectable()
 export class BackgroundScript {
@@ -54,6 +53,7 @@ export class BackgroundScript {
     private assoc: StreamAssociations,
     private streams: Streams,
     private tabStates: TabStates,
+    private ports: PopupPorts,
     private storage: StorageService,
     @inject(tokens.LocalStorageProxy)
     private store: LocalStorageProxy,
@@ -100,6 +100,7 @@ export class BackgroundScript {
     this.framesService.monitor()
     // noinspection ES6MissingAwait
     void this.auth.getTokenMaybeRefreshAndStoreState()
+    this.ports.setup()
   }
 
   private setTabsOnActivatedListener() {

--- a/packages/coil-extension/src/background/services/BackgroundStorageService.ts
+++ b/packages/coil-extension/src/background/services/BackgroundStorageService.ts
@@ -4,11 +4,14 @@ import { StorageService } from '../../services/storage'
 import * as tokens from '../../types/tokens'
 import { LocalStorageUpdate } from '../../types/commands'
 
+import { PopupPorts } from './PopupPorts'
+
 @injectable()
 export class BackgroundStorageService extends StorageService {
   constructor(
     storage: Storage,
-    @inject(tokens.WextApi) private api: typeof window.chrome
+    private popupPorts: PopupPorts,
+    @inject(tokens.WextApi) private api = chrome
   ) {
     super(storage, (key: string) => {
       const message: LocalStorageUpdate = {
@@ -19,6 +22,7 @@ export class BackgroundStorageService extends StorageService {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const ignored = this.api.runtime.lastError
       })
+      this.popupPorts.sendMessage(message)
     })
   }
 }

--- a/packages/coil-extension/src/background/services/PopupPorts.ts
+++ b/packages/coil-extension/src/background/services/PopupPorts.ts
@@ -1,0 +1,24 @@
+import { inject, injectable } from 'inversify'
+import * as tokens from '@web-monetization/wext/tokens'
+
+@injectable()
+export class PopupPorts {
+  private ports = new Set<chrome.runtime.Port>()
+
+  constructor(@inject(tokens.WextApi) private api = chrome) {}
+
+  setup() {
+    this.api.runtime.onConnect.addListener(port => {
+      this.ports.add(port)
+      port.onDisconnect.addListener(port => {
+        this.ports.delete(port)
+      })
+    })
+  }
+
+  sendMessage(message: unknown) {
+    for (const port of this.ports.values()) {
+      port.postMessage(message)
+    }
+  }
+}

--- a/packages/coil-extension/src/popup/Index.tsx
+++ b/packages/coil-extension/src/popup/Index.tsx
@@ -33,13 +33,30 @@ export function Index(props: PopupProps) {
     setLastMonetizationProgress(Date.now())
   }
 
-  function bindMessageListener(): void {
-    props.context.runtime.onMessageAddListener((message: ToPopupMessage) => {
-      if (message.command === 'localStorageUpdate') {
+  // function bindMessageListener() {
+  //   console.log('bindMessageListener')
+  //   const listener = (message: ToPopupMessage) => {
+  //     console.log('Index', 'props.context.runtime.onMessageAddListener')
+  //     if (message.command === 'localStorageUpdate') {
+  //       syncStoreAndSetState()
+  //     }
+  //     return false
+  //   }
+  //   props.context.runtime.onMessageAddListener(listener)
+  //   return () => {
+  //     props.context.runtime.onMessageRemoveListener(listener)
+  //   }
+
+  function bindMessageListener() {
+    const listener = (event: StorageEvent) => {
+      if (event.storageArea === localStorage) {
         syncStoreAndSetState()
       }
-      return false
-    })
+    }
+    window.addEventListener('storage', listener)
+    return () => {
+      window.removeEventListener('storage', listener)
+    }
   }
 
   useEffect(bindMessageListener, [])

--- a/packages/coil-extension/src/popup/components/MonetizationAnimation.tsx
+++ b/packages/coil-extension/src/popup/components/MonetizationAnimation.tsx
@@ -28,10 +28,23 @@ export const MonetizeAnimation = (props: PopupProps) => {
       }
     }
 
-    const listener = (msg: ToPopupMessage) => {
+    // const listener = (msg: ToPopupMessage) => {
+    //   if (
+    //     msg.command === 'localStorageUpdate' &&
+    //     msg.key === 'monetizedTotal' &&
+    //     props.context.store.monetizedTotal > 0
+    //   ) {
+    //     setLastPacket(new Date())
+    //     setAnimated(true)
+    //     if (!animateTimeout) {
+    //       window.setTimeout(loopHandler, ANIMATION_INTERVAL)
+    //     }
+    //   }
+    // }
+    // props.context.runtime.onMessageAddListener(listener)
+    const listener = (event: StorageEvent) => {
       if (
-        msg.command === 'localStorageUpdate' &&
-        msg.key === 'monetizedTotal' &&
+        event.key === 'monetizedTotal' &&
         props.context.store.monetizedTotal > 0
       ) {
         setLastPacket(new Date())
@@ -41,9 +54,10 @@ export const MonetizeAnimation = (props: PopupProps) => {
         }
       }
     }
-    props.context.runtime.onMessageAddListener(listener)
+    window.addEventListener('storage', listener)
     return () => {
-      props.context.runtime.onMessageRemoveListener(listener)
+      window.removeEventListener('storage', listener)
+      // props.context.runtime.onMessageRemoveListener(listener)
       if (animateTimeout != null) {
         window.clearTimeout(animateTimeout)
       }

--- a/packages/coil-extension/src/popup/components/StreamControls.tsx
+++ b/packages/coil-extension/src/popup/components/StreamControls.tsx
@@ -9,6 +9,7 @@ import {
   StickyState,
   ToggleControlsAction
 } from '../../types/streamControls'
+import { useStorage } from '../hooks/useStorage'
 
 const ControlBar = styled('div')({
   display: 'flex',
@@ -153,11 +154,13 @@ interface SetStreamControlsParams {
 }
 
 export const StreamControls = (props: PopupProps) => {
-  const [stickyState, setStickyState] = useState<StickyState>(
-    props.context.store.stickyState || 'auto'
+  const [stickyState, setStickyState] = useStorage<StickyState>(
+    'stickyState',
+    'auto'
   )
-  const [playOrPauseState, setPlayOrPauseState] = useState<PlayOrPauseState>(
-    props.context.store.playState || 'playing'
+  const [playOrPauseState, setPlayOrPauseState] = useStorage<PlayOrPauseState>(
+    'playState',
+    'playing'
   )
 
   const setStreamControls = (data: SetStreamControlsParams) => {
@@ -168,22 +171,22 @@ export const StreamControls = (props: PopupProps) => {
     props.context.runtime.sendMessage(message)
   }
 
-  useEffect(() => {
-    const listener = (message: ToPopupMessage) => {
-      if (message.command === 'localStorageUpdate') {
-        if (message.key === 'stickyState') {
-          const sticky = props.context.store.stickyState
-          // TODO: document why have and why need to ignore null changes
-          sticky != null && setStickyState(sticky)
-        } else if (message.key === 'playState') {
-          const play = props.context.store.playState
-          play != null && setPlayOrPauseState(play)
-        }
-      }
-    }
-    props.context.runtime.onMessageAddListener(listener)
-    return () => props.context.runtime.onMessageRemoveListener(listener)
-  }, [])
+  // useEffect(() => {
+  //   const listener = (message: ToPopupMessage) => {
+  //     if (message.command === 'localStorageUpdate') {
+  //       if (message.key === 'stickyState') {
+  //         const sticky = props.context.store.stickyState
+  //         // TODO: document why have and why need to ignore null changes
+  //         sticky != null && setStickyState(sticky)
+  //       } else if (message.key === 'playState') {
+  //         const play = props.context.store.playState
+  //         play != null && setPlayOrPauseState(play)
+  //       }
+  //     }
+  //   }
+  //   props.context.runtime.onMessageAddListener(listener)
+  //   return () => props.context.runtime.onMessageRemoveListener(listener)
+  // }, [])
 
   const stickyTooltip =
     stickyState === 'sticky'

--- a/packages/coil-extension/src/popup/hooks/useStorage.ts
+++ b/packages/coil-extension/src/popup/hooks/useStorage.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+
+export const useStorage = <T>(key: string, defaultValue: T) => {
+  // TODO: useContext, with overrideable storage
+  const storage = localStorage
+
+  const [value, setValue] = useState<string | null>(storage.getItem(key))
+  useEffect(() => {
+    const listener = (event: StorageEvent) => {
+      if (event.key === key && event.storageArea === storage) {
+        setValue(event.newValue)
+      }
+    }
+    window.addEventListener('storage', listener)
+    return () => {
+      window.removeEventListener('storage', listener)
+    }
+  }, [key])
+  return [value ?? defaultValue, setValue] as [T, typeof setValue]
+}

--- a/packages/coil-extension/src/popup/popup.tsx
+++ b/packages/coil-extension/src/popup/popup.tsx
@@ -13,10 +13,34 @@ import { isExtension, mockPopupsPage } from './mocks/loadMockedStates'
 import { Index } from './Index'
 
 const IndexWithRoot = withSharedTheme(Index)
+let runs = 0
 
 export function run() {
-  const store = new PopupState(new StorageService())
+  console.log('localStorage == null', localStorage == null)
+  if (localStorage == null && runs < 10) {
+    runs++
+    chrome.runtime.getBackgroundPage(w => {
+      if (w) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ;(window as any).localStorage = w.localStorage
+        console.log('w.localStorage == null', w.localStorage == null)
+        run()
+      } else {
+        console.log('wtf')
+      }
+    })
+    return
+  }
 
+  const dummy = {
+    getItem(key: string): string | null {
+      return null
+    },
+    setItem(key: string, value: string) {},
+    clear() {},
+    removeItem(key: string) {}
+  }
+  const store = new PopupState(new StorageService())
   store.sync()
 
   const context: Omit<PopupContext, 'runtime'> = {
@@ -26,26 +50,36 @@ export function run() {
   }
 
   const rootEl = document.getElementById('root')
+  const dummyFunction: any = () => null
 
   if (isExtension) {
-    API.runtime.onMessage.addListener((message: ToPopupMessage) => {
+    const listener = (message: ToPopupMessage) => {
+      // console.log('message received on port', message)
       if (message.command === 'closePopup') {
         window.close()
       }
+    }
+
+    const port = chrome.runtime.connect()
+    port.onDisconnect.addListener(() => {
+      console.log('port disconnected!')
     })
+    port.onMessage.addListener(listener)
     ReactDOM.render(
       <IndexWithRoot
         context={{
           ...context,
           runtime: {
             tabOpener: (url: string) => openTab.bind(null, API, url),
-            onMessageRemoveListener: API.runtime.onMessage.removeListener.bind(
-              API.runtime.onMessage
-            ),
-            sendMessage: API.runtime.sendMessage.bind(API.runtime),
-            onMessageAddListener: API.runtime.onMessage.addListener.bind(
-              API.runtime.onMessage
-            )
+            // onMessageRemoveListener:
+            // // dummyFunction,
+            //   port.onMessage.removeListener.bind(port.onMessage) as any,
+            sendMessage:
+              // dummyFunction,
+              port.postMessage.bind(port)
+            // onMessageAddListener:
+            // // dummyFunction,
+            //   port.onMessage.addListener.bind(port.onMessage) as any
           }
         }}
       />,
@@ -61,3 +95,12 @@ export function run() {
 }
 
 run()
+
+console.log('popup loaded')
+let n = 0
+setInterval(() => {
+  n++
+  if (localStorage == null) {
+    console.log(n, 'localStorage == null', localStorage == null, Date.now())
+  }
+}, 100)

--- a/packages/coil-extension/src/popup/types.ts
+++ b/packages/coil-extension/src/popup/types.ts
@@ -4,8 +4,8 @@ import { PopupState } from './services/PopupState'
 
 export interface PopupRuntime {
   sendMessage: typeof API.runtime.sendMessage
-  onMessageAddListener: typeof API.runtime.onMessage.addListener
-  onMessageRemoveListener: typeof API.runtime.onMessage.removeListener
+  // onMessageAddListener: typeof API.runtime.onMessage.addListener
+  // onMessageRemoveListener: typeof API.runtime.onMessage.removeListener
   tabOpener: (url: string) => () => void
 }
 


### PR DESCRIPTION
TODO:
- [x] workarounds missing 
- [x] use window storage event 
   - Solve the `localStorage==null` issue #1077  
- [ ] refactor to use some kind of contextual event bus 
   -  should support multiple instances of the popup in one window