### PR TITLE
feat(coil-extension): add GPCService sketch

### DIFF
--- a/packages/coil-extension/manifest.json
+++ b/packages/coil-extension/manifest.json
@@ -32,5 +32,5 @@
       "run_at": "document_start"
     }
   ],
-  "permissions": [ "webNavigation", "<all_urls>" ]
+  "permissions": [ "webNavigation", "<all_urls>", "webRequest", "webRequestBlocking" ]
 }

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -46,6 +46,8 @@ import MessageSender = chrome.runtime.MessageSender
 import { BuildConfig } from '../../types/BuildConfig'
 import { debug } from '../../content/util/logging'
 
+import { GPCService } from './GPCService'
+
 @injectable()
 export class BackgroundScript {
   constructor(
@@ -59,6 +61,7 @@ export class BackgroundScript {
     private store: LocalStorageProxy,
     private auth: AuthService,
     private youtube: YoutubeService,
+    private gpcService: GPCService,
     private framesService: BackgroundFramesService,
 
     @logger('BackgroundScript')
@@ -98,6 +101,7 @@ export class BackgroundScript {
     this.routeStreamsMoneyEventsToContentScript()
     this.handleStreamsAbortEvent()
     this.framesService.monitor()
+    this.gpcService.enable()
     // noinspection ES6MissingAwait
     void this.auth.getTokenMaybeRefreshAndStoreState()
   }

--- a/packages/coil-extension/src/background/services/GPCService.ts
+++ b/packages/coil-extension/src/background/services/GPCService.ts
@@ -1,0 +1,45 @@
+import { inject, injectable } from 'inversify'
+import * as tokens from '@web-monetization/wext/tokens'
+
+@injectable()
+export class GPCService {
+  constructor(
+    @inject(tokens.WextApi)
+    private api = chrome
+  ) {}
+
+  enable() {
+    const filter = { urls: ['<all_urls>'] }
+    const optExtraInfoSpec = ['requestHeaders', 'blocking']
+    this.api.webRequest.onBeforeSendHeaders.addListener(
+      details => {
+        const requestHeaders = details.requestHeaders
+        if (requestHeaders) {
+          requestHeaders.push({ name: 'Sec-GPC', value: '1' })
+          return { requestHeaders }
+        }
+      },
+      filter,
+      optExtraInfoSpec
+    )
+
+    // declarativeWebRequest code Doesn't work (condition is bunk)
+    // and wouldn't anyway on FF/Safari
+    // see: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions
+    /*// eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const declarativeWebRequest: any = chrome.declarativeWebRequest
+    this.api.declarativeWebRequest.onRequest.addRules([
+      {
+        conditions: [
+          {}
+        ],
+        actions: [
+          new declarativeWebRequest.SetRequestHeader({
+            name: 'Sec-GPC',
+            value: '1'
+          })
+        ]
+      }
+    ])*/
+  }
+}

--- a/packages/coil-extension/src/content/services/ContentScript.ts
+++ b/packages/coil-extension/src/content/services/ContentScript.ts
@@ -6,7 +6,8 @@ import {
 } from '@web-monetization/polyfill-utils'
 import {
   DocumentMonetization,
-  IdleDetection
+  IdleDetection,
+  ScriptInjection
 } from '@web-monetization/wext/content'
 import { MonetizationProgressEvent, TipEvent } from '@web-monetization/types'
 
@@ -52,6 +53,7 @@ export class ContentScript {
     private adaptedContent: AdaptedContentService,
     private frames: Frames,
     private idle: IdleDetection,
+    private scripts: ScriptInjection,
     private monetization: DocumentMonetization,
     private auth: ContentAuthService
   ) {}
@@ -178,6 +180,8 @@ export class ContentScript {
   }
 
   init() {
+    this.injectGPC()
+
     if (this.frames.isMonetizableFrame) {
       this.frames.monitor()
     }
@@ -272,5 +276,9 @@ export class ContentScript {
         this.runtime.sendMessage(message)
       }
     }
+  }
+
+  private injectGPC() {
+    this.scripts.inject('navigator.globalPrivacyControl = true;')
   }
 }


### PR DESCRIPTION
I had a look at the list of extensions at https://globalprivacycontrol.org/.

Two things struck me:
* Most of them do extracurricular activities too, blocking ads/"trackers" etc
* I looked at a few in detail and they request a whole raft of permissions
  * No qualms using the blocking apis - performance can't be that bad

It seems like the sort of thing that the average Coil user would most likely be happy to opt-out of, rather than opt-in, so:
* just send the header by default
  * opt-out setting in the extension
  * add to coil.com unified settings page as time permits

- [x] Try [declarativeNetRequest](https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/):
  - https://github.com/coilhq/web-monetization-projects/pull/1659

