### PR TITLE
feat(coil-extension): add publish-coildev-chrome-store.sh

### DIFF
--- a/packages/coil-extension/scripts/publish-coildev-chrome-store.sh
+++ b/packages/coil-extension/scripts/publish-coildev-chrome-store.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -u
+# We use set -e and bash with -u to bail on first non zero exit code of any
+# processes launched or upon any unbound variable.
+# We use set -x to print commands before running them to help with
+# debugging.
+set -ex
+
+export WEXT_MANIFEST_VERSION="$COIL_DEV_VERSION"
+export WEXT_MANIFEST_SUFFIX='Dev'
+export WEXT_MANIFEST_SUFFIX_NO_DATE='true'
+export WEXT_BUILD_CONFIG="{\"extensionBuildString\":\"$(git show --no-patch --no-notes --pretty='== %h == %cd == %s ==' )\"}"
+./build.sh prod chrome
+shipit chrome dist

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -71,7 +71,9 @@ export class BackgroundScript {
     private buildConfig: BuildConfig,
     @inject(tokens.WextApi)
     private api = chrome
-  ) {}
+  ) {
+    console.log('BuildConfig', this.buildConfig)
+  }
 
   get activeTab() {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -534,6 +536,10 @@ export class BackgroundScript {
     } else if (state) {
       delete this.store.playState
       delete this.store.stickyState
+    }
+
+    if (this.buildConfig.extensionBuildString) {
+      this.store.extensionBuildString = this.buildConfig.extensionBuildString
     }
 
     if (state) {

--- a/packages/coil-extension/src/popup/components/AccountBar.tsx
+++ b/packages/coil-extension/src/popup/components/AccountBar.tsx
@@ -68,13 +68,17 @@ export const AccountBar = (props: PopupProps) => {
   const context = props.context
   const {
     coilDomain,
-    store: { loggedIn, user },
+    store: { loggedIn, user, extensionBuildString },
     runtime: { tabOpener }
   } = context
 
   const onExploreClick = tabOpener(`${coilDomain}/explore`)
   const onAboutClick = tabOpener(`${coilDomain}/about`)
   const onSettingsClick = tabOpener(`${coilDomain}/settings`)
+
+  const onBuildInfoClick = () => {
+    void navigator.clipboard.writeText(extensionBuildString)
+  }
 
   return (
     <CoilToolbar>
@@ -117,9 +121,27 @@ export const AccountBar = (props: PopupProps) => {
           <Typography variant='caption'>About</Typography>
         </MenuItem>
 
-        <MenuItem dense component='a' onClick={onSettingsClick} target='_blank'>
+        <MenuItem
+          divider
+          dense
+          component='a'
+          onClick={onSettingsClick}
+          target='_blank'
+        >
           <Typography variant='caption'>Settings</Typography>
         </MenuItem>
+
+        {extensionBuildString && (
+          <MenuItem
+            divider
+            dense
+            component='a'
+            onClick={onBuildInfoClick}
+            target='_blank'
+          >
+            <Typography variant='caption'>Copy Build Info</Typography>
+          </MenuItem>
+        )}
       </CoilMenu>
     </CoilToolbar>
   )

--- a/packages/coil-extension/src/popup/services/PopupState.ts
+++ b/packages/coil-extension/src/popup/services/PopupState.ts
@@ -12,11 +12,14 @@ const STORAGE_KEYS = [
   'stickyState',
   'playState',
   'user',
-  'validToken'
+  'validToken',
+  'extensionBuildString'
 ]
 
 export type PopupStateType = Omit<LocalStorageProxy, 'token'>
 
+// TODO: replace this stupid thing with a Proxy that doesn't require maintenance
+// of STORAGE_KEYS lists etc
 export class PopupState implements PopupStateType {
   readonly adapted!: boolean
   readonly stickyState!: StickyState
@@ -27,6 +30,7 @@ export class PopupState implements PopupStateType {
   readonly monetizedTotal!: number
   readonly user!: User
   readonly validToken!: boolean
+  readonly extensionBuildString!: string
 
   constructor(private storage: Pick<StorageService, 'get'>) {}
 

--- a/packages/coil-extension/src/types/BuildConfig.ts
+++ b/packages/coil-extension/src/types/BuildConfig.ts
@@ -1,3 +1,4 @@
 export interface BuildConfig {
   logTabsApiEvents?: boolean
+  extensionBuildString?: string
 }

--- a/packages/coil-extension/src/types/storage.ts
+++ b/packages/coil-extension/src/types/storage.ts
@@ -42,4 +42,6 @@ export interface LocalStorageProxy {
 
   monetizedTotal?: number | null
   monetizedFavicon?: string | null
+
+  extensionBuildString?: string | null
 }

--- a/packages/webexts-build-utils/src/makeWebpackConfig.ts
+++ b/packages/webexts-build-utils/src/makeWebpackConfig.ts
@@ -58,6 +58,7 @@ export function makeWebpackConfig(rootDir: string): webpack.Configuration {
 
   // Possible to override name/version so can publish as different extension
   const WEXT_MANIFEST_SUFFIX = process.env.WEXT_MANIFEST_SUFFIX
+  const WEXT_MANIFEST_SUFFIX_NO_DATE = process.env.WEXT_MANIFEST_SUFFIX_NO_DATE
   const WEXT_MANIFEST_VERSION = process.env.WEXT_MANIFEST_VERSION
   const WEXT_MANIFEST_BROWSER_SPECIFIC_SETTINGS_GECKO_ID =
     process.env.WEXT_MANIFEST_BROWSER_SPECIFIC_SETTINGS_GECKO_ID
@@ -69,8 +70,11 @@ export function makeWebpackConfig(rootDir: string): webpack.Configuration {
       transform: (content: Buffer) => {
         const manifest = JSON.parse(content.toString())
         if (WEXT_MANIFEST_SUFFIX) {
-          const date = new Date().toLocaleString().replace(/(\/|,|\s)+/g, '-')
-          manifest.name += `${WEXT_MANIFEST_SUFFIX}-${date}`
+          manifest.name += WEXT_MANIFEST_SUFFIX
+          if (!WEXT_MANIFEST_SUFFIX_NO_DATE) {
+            const date = new Date().toLocaleString().replace(/(\/|,|\s)+/g, '-')
+            manifest.name += `-${date}`
+          }
         }
         if (WEXT_MANIFEST_VERSION) {
           manifest.version = WEXT_MANIFEST_VERSION


### PR DESCRIPTION
Webpack picks up WEXT_BUILD_CONFIG environment variable, expected to be json, this patch will check for `extensionBuildString` which if present will add a `Copy Build Info` menu item:
![image](https://user-images.githubusercontent.com/525211/105272223-77b87c80-5bcb-11eb-8a5d-00819433a9d0.png)

```
export WEXT_BUILD_CONFIG="{\"extensionBuildString\":\"$(git show --no-patch --no-notes --pretty='== %h == %cd == %s ==' )\"}"
```
