### PR TITLE
feat(ext): polyfill via document events rather than posting window messages

### DIFF
--- a/packages/coil-extension/src/content/services/ContentScript.ts
+++ b/packages/coil-extension/src/content/services/ContentScript.ts
@@ -142,10 +142,10 @@ export class ContentScript {
             paymentPointer: request.data.paymentPointer,
             requestId: request.data.requestId
           }
-          this.monetization.postMonetizationProgressWindowMessage(detail)
+          this.monetization.dispatchMonetizationProgressEvent(detail)
         } else if (request.command === 'monetizationStart') {
           debug('monetizationStart event')
-          this.monetization.postMonetizationStartWindowMessageAndSetMonetizationState(
+          this.monetization.dispatchMonetizationStartEventAndSetMonetizationState(
             request.data
           )
         } else if (request.command === 'checkIFrameIsAllowedFromBackground') {
@@ -167,7 +167,7 @@ export class ContentScript {
             assetScale: request.data.assetScale,
             paymentPointer: request.data.paymentPointer
           }
-          this.monetization.postTipWindowMessage(detail)
+          this.monetization.dispatchTipEvent(detail)
         } else if (request.command === 'clearToken') {
           this.storage.removeItem('token')
         }

--- a/packages/web-monetization-wext/src/content/DocumentMonetization.ts
+++ b/packages/web-monetization-wext/src/content/DocumentMonetization.ts
@@ -27,6 +27,13 @@ type DefaultView = WindowProxy & typeof globalThis
 type CloneInto = (obj: unknown, window: DefaultView | null) => typeof obj
 declare const cloneInto: CloneInto | undefined
 
+let cloneIntoRef: CloneInto | undefined
+try {
+  cloneIntoRef = cloneInto
+} catch (e) {
+  cloneIntoRef = undefined
+}
+
 @injectable()
 export class DocumentMonetization {
   private finalized = true
@@ -102,7 +109,7 @@ export class DocumentMonetization {
     }
     this.doc.dispatchEvent(
       new CustomEvent(MONETIZATION_DOCUMENT_EVENT_NAME, {
-        detail: cloneInto ? cloneInto(obj, this.doc.defaultView) : obj
+        detail: cloneIntoRef ? cloneIntoRef(obj, this.doc.defaultView) : obj
       })
     )
   }

--- a/packages/web-monetization-wext/src/content/DocumentMonetization.ts
+++ b/packages/web-monetization-wext/src/content/DocumentMonetization.ts
@@ -23,6 +23,12 @@ type MonetizationRequest = PaymentDetails
 // Name of event dispatched on document
 const MONETIZATION_DOCUMENT_EVENT_NAME = 'monetization-v1'
 
+type DefaultView = WindowProxy & typeof globalThis
+declare const cloneInto: (
+  obj: unknown,
+  window: DefaultView | null
+) => typeof obj | undefined
+
 @injectable()
 export class DocumentMonetization {
   private finalized = true
@@ -96,12 +102,9 @@ export class DocumentMonetization {
       type,
       detail
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const anyWin = window as any
-    const clone = anyWin.cloneInto && anyWin.cloneInto(obj, window)
     this.doc.dispatchEvent(
       new CustomEvent(MONETIZATION_DOCUMENT_EVENT_NAME, {
-        detail: clone ? clone : obj
+        detail: cloneInto ? cloneInto(obj, this.doc.defaultView) : obj
       })
     )
   }

--- a/packages/web-monetization-wext/src/content/DocumentMonetization.ts
+++ b/packages/web-monetization-wext/src/content/DocumentMonetization.ts
@@ -74,12 +74,12 @@ export class DocumentMonetization {
       if (changedState) {
         this.doc.dispatchEvent(
           new CustomEvent(COIL_EXTENSION_MONETIZATION, {
-            detail: {
+            detail: JSON.stringify({
               type: 'monetizationstatechange',
               detail: {
                 state
               }
-            }
+            })
           })
         )
       }
@@ -123,10 +123,10 @@ export class DocumentMonetization {
     }
     this.doc.dispatchEvent(
       new CustomEvent(COIL_EXTENSION_MONETIZATION, {
-        detail: {
+        detail: JSON.stringify({
           type,
           detail
-        }
+        })
       })
     )
   }
@@ -146,10 +146,10 @@ export class DocumentMonetization {
     const detail = { ...detailSource }
     this.doc.dispatchEvent(
       new CustomEvent(COIL_EXTENSION_MONETIZATION, {
-        detail: {
+        detail: JSON.stringify({
           type,
           detail
-        }
+        })
       })
     )
   }

--- a/packages/web-monetization-wext/src/content/DocumentMonetization.ts
+++ b/packages/web-monetization-wext/src/content/DocumentMonetization.ts
@@ -21,7 +21,7 @@ interface SetStateParams {
 type MonetizationRequest = PaymentDetails
 
 // Name of event dispatched on document
-const COIL_EXTENSION_MONETIZATION = 'monetization'
+const MONETIZATION_DOCUMENT_EVENT_NAME = 'monetization-v1'
 
 @injectable()
 export class DocumentMonetization {
@@ -72,16 +72,9 @@ export class DocumentMonetization {
 
     if (changed) {
       if (changedState) {
-        this.doc.dispatchEvent(
-          new CustomEvent(COIL_EXTENSION_MONETIZATION, {
-            detail: JSON.stringify({
-              type: 'monetizationstatechange',
-              detail: {
-                state
-              }
-            })
-          })
-        )
+        this.emitEvent('monetizationstatechange', {
+          state
+        })
       }
       if (this.request && (state === 'stopped' || state === 'pending')) {
         this.dispatchMonetizationEvent(
@@ -95,6 +88,18 @@ export class DocumentMonetization {
       }
     }
     return changed
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private emitEvent(type: string, detail: any) {
+    this.doc.dispatchEvent(
+      new CustomEvent(MONETIZATION_DOCUMENT_EVENT_NAME, {
+        detail: JSON.stringify({
+          type,
+          detail
+        })
+      })
+    )
   }
 
   dispatchMonetizationStartEventAndSetMonetizationState(
@@ -121,14 +126,7 @@ export class DocumentMonetization {
       const stop = detail as MonetizationStopEvent['detail']
       stop.finalized = Boolean(finalized)
     }
-    this.doc.dispatchEvent(
-      new CustomEvent(COIL_EXTENSION_MONETIZATION, {
-        detail: JSON.stringify({
-          type,
-          detail
-        })
-      })
-    )
+    this.emitEvent(type, detail)
   }
 
   dispatchMonetizationProgressEvent(
@@ -144,14 +142,7 @@ export class DocumentMonetization {
 
   doDispatchTipEvent(type: TipEvent['type'], detailSource: TipEvent['detail']) {
     const detail = { ...detailSource }
-    this.doc.dispatchEvent(
-      new CustomEvent(COIL_EXTENSION_MONETIZATION, {
-        detail: JSON.stringify({
-          type,
-          detail
-        })
-      })
-    )
+    this.emitEvent(type, detail)
   }
 
   dispatchTipEvent(detail: TipEvent['detail']) {

--- a/packages/web-monetization-wext/src/content/DocumentMonetization.ts
+++ b/packages/web-monetization-wext/src/content/DocumentMonetization.ts
@@ -98,11 +98,10 @@ export class DocumentMonetization {
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const anyWin = window as any
+    const clone = anyWin.cloneInto && anyWin.cloneInto(obj, window)
     this.doc.dispatchEvent(
       new CustomEvent(MONETIZATION_DOCUMENT_EVENT_NAME, {
-        detail: anyWin.cloneInto
-          ? anyWin.cloneInto(obj, this.doc.defaultView)
-          : obj
+        detail: clone ? clone : obj
       })
     )
   }

--- a/packages/web-monetization-wext/src/content/DocumentMonetization.ts
+++ b/packages/web-monetization-wext/src/content/DocumentMonetization.ts
@@ -92,12 +92,17 @@ export class DocumentMonetization {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private emitEvent(type: string, detail: any) {
+    const obj = {
+      type,
+      detail
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const anyWin = window as any
     this.doc.dispatchEvent(
       new CustomEvent(MONETIZATION_DOCUMENT_EVENT_NAME, {
-        detail: JSON.stringify({
-          type,
-          detail
-        })
+        detail: anyWin.cloneInto
+          ? anyWin.cloneInto(obj, this.doc.defaultView)
+          : obj
       })
     )
   }

--- a/packages/web-monetization-wext/src/content/DocumentMonetization.ts
+++ b/packages/web-monetization-wext/src/content/DocumentMonetization.ts
@@ -24,10 +24,8 @@ type MonetizationRequest = PaymentDetails
 const MONETIZATION_DOCUMENT_EVENT_NAME = 'monetization-v1'
 
 type DefaultView = WindowProxy & typeof globalThis
-declare const cloneInto: (
-  obj: unknown,
-  window: DefaultView | null
-) => typeof obj | undefined
+type CloneInto = (obj: unknown, window: DefaultView | null) => typeof obj
+declare const cloneInto: CloneInto | undefined
 
 @injectable()
 export class DocumentMonetization {

--- a/packages/web-monetization-wext/src/content/wmPolyfill.ts
+++ b/packages/web-monetization-wext/src/content/wmPolyfill.ts
@@ -25,7 +25,7 @@ export const wmPolyFillMinimal = `
   document.monetization = document.createElement('div')
   document.monetization.state = 'stopped'
   document.addEventListener('monetization-v1', function(event) {
-    const {type, detail} = JSON.parse(event.detail)
+    const {type, detail} = event.detail
     if (type === 'monetizationstatechange') {
       document.monetization.state = detail.state
     } else {

--- a/packages/web-monetization-wext/src/content/wmPolyfill.ts
+++ b/packages/web-monetization-wext/src/content/wmPolyfill.ts
@@ -24,16 +24,15 @@ const eventLoggingCode = events
 export const wmPolyFillMinimal = `
   document.monetization = document.createElement('div')
   document.monetization.state = 'stopped'
-  window.addEventListener('message', function(event) {
-    if (event.source === window && event.data.webMonetization) {
-      if (event.data.type === 'monetizationstatechange') {
-        document.monetization.state = event.data.detail.state
-      } else {
-        document.monetization.dispatchEvent(
-          new CustomEvent(event.data.type, {
-            detail: event.data.detail
-          }))
-      }
+  document.addEventListener('monetization', function(event) {
+    const {type, detail} = event.detail
+    if (type === 'monetizationstatechange') {
+      document.monetization.state = detail.state
+    } else {
+      document.monetization.dispatchEvent(
+        new CustomEvent(type, {
+          detail: detail
+        }))
     }
   })
 `

--- a/packages/web-monetization-wext/src/content/wmPolyfill.ts
+++ b/packages/web-monetization-wext/src/content/wmPolyfill.ts
@@ -24,7 +24,7 @@ const eventLoggingCode = events
 export const wmPolyFillMinimal = `
   document.monetization = document.createElement('div')
   document.monetization.state = 'stopped'
-  document.addEventListener('monetization', function(event) {
+  document.addEventListener('monetization-v1', function(event) {
     const {type, detail} = JSON.parse(event.detail)
     if (type === 'monetizationstatechange') {
       document.monetization.state = detail.state

--- a/packages/web-monetization-wext/src/content/wmPolyfill.ts
+++ b/packages/web-monetization-wext/src/content/wmPolyfill.ts
@@ -25,7 +25,7 @@ export const wmPolyFillMinimal = `
   document.monetization = document.createElement('div')
   document.monetization.state = 'stopped'
   document.addEventListener('monetization', function(event) {
-    const {type, detail} = event.detail
+    const {type, detail} = JSON.parse(event.detail)
     if (type === 'monetizationstatechange') {
       document.monetization.state = detail.state
     } else {


### PR DESCRIPTION
CI *was* failing due to the `detail` property being restricted on CustomEvents on Firefox 
![image](https://user-images.githubusercontent.com/525211/105472681-d0bd0900-5cce-11eb-9be4-04cbc407cd0a.png)

There seems to be potential workarounds listed here:
https://stackoverflow.com/questions/18744224/triggering-a-custom-event-with-attributes-from-a-firefox-extension

Simply sending detail as a string (JSON serialized object) seems to be simpler than using the cloneInto mentioned on SO

Using cloneInto regardless as it's less "work" done in the content script thread