### PR TITLE
fix(coil-extension): set default icon every midnight, closes #1359

### DIFF
--- a/packages/coil-extension/src/background/consts/Icons.ts
+++ b/packages/coil-extension/src/background/consts/Icons.ts
@@ -3,7 +3,10 @@ export const Icons = {
   Inactive: '../res/icn-coil-off.png',
   ActiveXMAS: '../res/icn-coil-on-xmas.png',
   InactiveXMAS: '../res/icn-coil-off-xmas.png',
-  // TODO: add fireworks icons
+  /**
+   * TODO: add fireworks icons
+   * TODO: will need to update {@see PopupBrowserAction#setDefaultInactive}
+   * */
   ActiveNewYears: '../res/icn-coil-on.png',
   InactiveNewYears: '../res/icn-coil-off.png'
 }

--- a/packages/coil-extension/src/background/services/PopupBrowserAction.ts
+++ b/packages/coil-extension/src/background/services/PopupBrowserAction.ts
@@ -75,6 +75,14 @@ export class PopupBrowserAction {
       this.api.browserAction.setIcon({
         path: this.icons.getInactive()
       })
+      const now = new Date()
+      const nextMidnight = new Date()
+      nextMidnight.setHours(24, 0, 0, 0)
+      const msToNextMidnight = nextMidnight.getTime() - now.getTime()
+      const andChange = 10
+      setTimeout(() => {
+        this.setDefaultInactive()
+      }, msToNextMidnight + andChange)
     }
   }
 


### PR DESCRIPTION
The previous fix wasn't quite right. After the xmas period was over, the Santa hat flickered until the extension was restarted, when the default icon was reset.
