### PR TITLE
feat(coil-extension): refactor popup

### DIFF
--- a/packages/coil-extension/src/popup/components/AccountBar.tsx
+++ b/packages/coil-extension/src/popup/components/AccountBar.tsx
@@ -8,8 +8,9 @@ import MenuItem from '@material-ui/core/MenuItem'
 import { styled, withStyles } from '@material-ui/core'
 
 import { Colors } from '../../shared-theme/colors'
-import { PopupProps } from '../types'
 import { getMonthAndDay, isXMASPeriod } from '../../util/seasons'
+import { useStore } from '../context/storeContext'
+import { useHost } from '../context/popupHostContext'
 
 const Flex = styled('div')({
   flex: 1
@@ -67,35 +68,36 @@ const MoreButton = styled(IconButton)({
   height: 32
 })
 
-export const AccountBar = (props: PopupProps) => {
+export const AccountBar = () => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
 
   const handleMenuClick = (event: ClickEvent) => {
     setAnchorEl(event.currentTarget)
   }
 
-  const handleMenuClose = (event: ClickEvent) => {
+  const handleMenuClose = () => {
     setAnchorEl(null)
   }
-  const context = props.context
+  const { validToken, user, extensionBuildString } = useStore()
   const {
     coilDomain,
-    store: { loggedIn, user, extensionBuildString },
     runtime: { tabOpener }
-  } = context
+  } = useHost()
 
   const onExploreClick = tabOpener(`${coilDomain}/explore`)
   const onAboutClick = tabOpener(`${coilDomain}/about`)
   const onSettingsClick = tabOpener(`${coilDomain}/settings`)
 
   const onBuildInfoClick = () => {
-    void navigator.clipboard.writeText(extensionBuildString)
+    if (extensionBuildString) {
+      void navigator.clipboard.writeText(extensionBuildString)
+    }
   }
 
   return (
     <CoilToolbar>
       <CoilLogoImg />
-      {loggedIn && user ? (
+      {validToken && user ? (
         <Typography variant='body1'>{user.fullName}</Typography>
       ) : (
         <Muted>Not Logged in</Muted>

--- a/packages/coil-extension/src/popup/components/CoilPopup.tsx
+++ b/packages/coil-extension/src/popup/components/CoilPopup.tsx
@@ -1,18 +1,16 @@
 import React from 'react'
 import { Grid } from '@material-ui/core'
 
-import { PopupProps } from '../types'
+import { useHost } from '../context/popupHostContext'
 
 import { StatusTypography } from './util/StatusTypography'
 import { StatusButton } from './StatusButton'
 
-export const CoilPopup = (props: PopupProps) => {
+export const CoilPopup = () => {
   const {
-    context: {
-      runtime: { tabOpener },
-      coilDomain
-    }
-  } = props
+    runtime: { tabOpener },
+    coilDomain
+  } = useHost()
   const onClick = tabOpener(coilDomain + '/explore')
   return (
     <Grid container justify='center' alignItems='center'>

--- a/packages/coil-extension/src/popup/components/CoilViews.tsx
+++ b/packages/coil-extension/src/popup/components/CoilViews.tsx
@@ -1,17 +1,17 @@
 import React from 'react'
 
-import { PopupProps } from '../types'
+import { useStore } from '../context/storeContext'
 
 import { CoilPopup } from './CoilPopup'
 import { CoilExplore } from './CoilExplore'
 
-export const CoilViews = (props: PopupProps) => {
-  const { coilSite } = props.context.store
-  const { pathname } = new URL(coilSite)
-  console.log('coil url=', coilSite)
-  if (pathname === '/explore') {
-    return <CoilExplore />
-  } else {
-    return <CoilPopup {...props} />
+export const CoilViews = () => {
+  const { coilSite } = useStore()
+  if (coilSite) {
+    const { pathname } = new URL(coilSite)
+    if (pathname === '/explore') {
+      return <CoilExplore />
+    }
   }
+  return <CoilPopup />
 }

--- a/packages/coil-extension/src/popup/components/LoggedOut.tsx
+++ b/packages/coil-extension/src/popup/components/LoggedOut.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Grid } from '@material-ui/core'
 
-import { PopupProps } from '../types'
+import { useHost } from '../context/popupHostContext'
 
 import { Link } from './util/Link'
 import { StatusTypography } from './util/StatusTypography'
@@ -13,11 +13,10 @@ const footerString = "Don't have an account yet?"
 
 // This isn't actually used anymore as the browser action just opens
 // the coil site login page
-// TODO: remove
-export const LoggedOut = (props: PopupProps) => {
-  const {
-    context: { coilDomain }
-  } = props
+// TODO: remove (but check it's not needed in rare case when popup
+//  is left open, and you log out)
+export const LoggedOut = () => {
+  const { coilDomain } = useHost()
 
   return (
     <Grid container justify='center' alignItems='center'>

--- a/packages/coil-extension/src/popup/components/MonetizedPage.tsx
+++ b/packages/coil-extension/src/popup/components/MonetizedPage.tsx
@@ -1,7 +1,8 @@
 import React, { Fragment, useEffect, useState } from 'react'
 import { Grid, styled } from '@material-ui/core'
 
-import { PopupProps } from '../types'
+import { useHost } from '../context/popupHostContext'
+import { useStore } from '../context/storeContext'
 
 import { Link } from './util/Link'
 import { StatusTypography } from './util/StatusTypography'
@@ -19,7 +20,8 @@ const FlexBox = styled('div')(({ theme }) => ({
   width: '100%'
 }))
 
-export function MonetizedPage(props: PopupProps) {
+export function MonetizedPage() {
+  const popupHost = useHost()
   const [limitRefreshDate, setLimitRefreshDate] = useState<string | null>(null)
   const [showControls, onClick] = useShowIfClicked({
     clicksRequired: 9,
@@ -28,7 +30,7 @@ export function MonetizedPage(props: PopupProps) {
   })
 
   useEffect(() => {
-    props.context.runtime.sendMessage(
+    popupHost.runtime.sendMessage(
       {
         command: 'isRateLimited'
       },
@@ -45,33 +47,29 @@ export function MonetizedPage(props: PopupProps) {
       }
     )
   }, [])
-  const context = props.context
   return (
     <>
       <Grid container alignItems='center' justify='center'>
         <div>
           {limitRefreshDate != null ? (
-            <RateLimited
-              context={context}
-              limitRefreshDate={limitRefreshDate}
-            />
+            <RateLimited limitRefreshDate={limitRefreshDate} />
           ) : (
             <div onClick={onClick}>
-              <Donating context={context} />
+              <Donating />
             </div>
           )}
         </div>
       </Grid>
-      {showControls && <StreamControls context={context} />}
+      {showControls && <StreamControls />}
 
       {/* this will only show if user is enabled */}
-      <TipButton context={context} />
+      <TipButton />
     </>
   )
 }
 
-function Donating(props: PopupProps) {
-  const { monetizedTotal, adapted } = props.context.store
+function Donating() {
+  const { monetizedTotal, adapted } = useStore()
   const paymentStarted = monetizedTotal !== 0
 
   return (
@@ -83,23 +81,22 @@ function Donating(props: PopupProps) {
         {adapted
           ? 'Your Coil Membership supports this creator while you are enjoying their content.'
           : 'Your Coil Membership supports this site while you are enjoying its content.'}
-        {!paymentStarted && 'Setting up payment.'}
+        {!paymentStarted && ' Setting up payment.'}
       </StatusTypography>
       <FlexBox>
-        <MonetizeAnimation context={props.context} />
+        <MonetizeAnimation />
       </FlexBox>
     </Fragment>
   )
 }
 
-function RateLimited(props: PopupProps & { limitRefreshDate: string }) {
+function RateLimited(props: { limitRefreshDate: string }) {
   const {
-    context: {
-      coilDomain,
-      runtime: { tabOpener }
-    },
-    limitRefreshDate
-  } = props
+    coilDomain,
+    runtime: { tabOpener }
+  } = useHost()
+
+  const { limitRefreshDate } = props
   const mailOpener = tabOpener('mailto:accountreview@coil.com')
   const termsOpener = tabOpener(`${coilDomain}/terms`)
 

--- a/packages/coil-extension/src/popup/components/PaidViews.tsx
+++ b/packages/coil-extension/src/popup/components/PaidViews.tsx
@@ -1,20 +1,19 @@
 import React from 'react'
 
-import { PopupProps } from '../types'
+import { useStore } from '../context/storeContext'
 
 import { UnmonetizedPage } from './UnmonetizedPage'
 import { MonetizedPage } from './MonetizedPage'
 import { CoilViews } from './CoilViews'
 
-export const PaidViews = (props: PopupProps) => {
-  const context = props.context
-  const { monetized, coilSite } = context.store
+export const PaidViews = () => {
+  const { monetized, coilSite } = useStore()
 
   if (coilSite && !monetized) {
-    return <CoilViews context={context} />
+    return <CoilViews />
   } else if (monetized) {
-    return <MonetizedPage context={context} />
+    return <MonetizedPage />
   } else {
-    return <UnmonetizedPage context={context} />
+    return <UnmonetizedPage />
   }
 }

--- a/packages/coil-extension/src/popup/components/Status.tsx
+++ b/packages/coil-extension/src/popup/components/Status.tsx
@@ -1,25 +1,21 @@
 import React from 'react'
 
-import { PopupProps } from '../types'
+import { useStore } from '../context/storeContext'
 
-import { LoggedOut } from './LoggedOut'
 import { Unsubscribed } from './Unsubscribed'
 import { PaidViews } from './PaidViews'
+import { LoggedOut } from './LoggedOut'
 
-export const Status = (props: PopupProps) => {
-  const context = props.context
-  const { validToken, user } = props.context.store
+export const Status = () => {
+  const { validToken, user } = useStore()
 
   if (validToken && user) {
-    if (
-      !user.subscription ||
-      (user.subscription && !user.subscription.active)
-    ) {
-      return <Unsubscribed context={context} />
+    if (user.subscription?.active) {
+      return <PaidViews />
     } else {
-      return <PaidViews context={context} />
+      return <Unsubscribed />
     }
   } else {
-    return <LoggedOut context={context} />
+    return <LoggedOut />
   }
 }

--- a/packages/coil-extension/src/popup/components/TipButton.tsx
+++ b/packages/coil-extension/src/popup/components/TipButton.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react'
 import { Button } from '@material-ui/core'
 
-import { PopupProps } from '../types'
 import { SendTip, SendTipResult } from '../../types/commands'
+import { useHost } from '../context/popupHostContext'
+import { useStore } from '../context/storeContext'
 
 export enum TipState {
   READY = 0,
@@ -11,8 +12,11 @@ export enum TipState {
   ERROR
 }
 
-export const TipButton = (props: PopupProps) => {
+export const TipButton = () => {
   const [tipState, setTipState] = useState(TipState.READY)
+  const store = useStore()
+  const popupHost = useHost()
+
   const onClickTip = async () => {
     setTipState(TipState.LOADING)
 
@@ -31,22 +35,18 @@ export const TipButton = (props: PopupProps) => {
 
   const sendTip = async () => {
     const message: SendTip = { command: 'sendTip' }
-
     return new Promise(resolve => {
-      props.context.runtime.sendMessage(message, (result: SendTipResult) => {
+      popupHost.runtime.sendMessage(message, (result: SendTipResult) => {
         resolve(result)
       })
     }) as Promise<SendTipResult>
   }
 
-  if (props.context.store.user.canTip) {
+  if (store.user?.canTip) {
     switch (tipState) {
       case TipState.READY:
         return (
-          <Button
-            disabled={props.context.store.monetizedTotal === 0}
-            onClick={onClickTip}
-          >
+          <Button disabled={store.monetizedTotal === 0} onClick={onClickTip}>
             Tip this creator $1!
           </Button>
         )

--- a/packages/coil-extension/src/popup/components/UnmonetizedPage.tsx
+++ b/packages/coil-extension/src/popup/components/UnmonetizedPage.tsx
@@ -1,18 +1,17 @@
 import React from 'react'
 import { Grid } from '@material-ui/core'
 
-import { PopupProps } from '../types'
+import { useHost } from '../context/popupHostContext'
 
 import { LinkUnderlined } from './util/Link'
 import { StatusTypography } from './util/StatusTypography'
 
-export const UnmonetizedPage = (props: PopupProps) => {
+export const UnmonetizedPage = () => {
   const {
-    context: {
-      runtime: { tabOpener }
-    }
-  } = props
-  const onClick = tabOpener(`${props.context.coilDomain}/learn-more`)
+    coilDomain,
+    runtime: { tabOpener }
+  } = useHost()
+  const onClick = tabOpener(`${coilDomain}/learn-more`)
   return (
     <Grid container justify='center' alignItems='center'>
       <div>

--- a/packages/coil-extension/src/popup/components/Unsubscribed.tsx
+++ b/packages/coil-extension/src/popup/components/Unsubscribed.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Grid, styled } from '@material-ui/core'
 
 import { Colors } from '../../shared-theme/colors'
-import { PopupProps } from '../types'
+import { useHost } from '../context/popupHostContext'
 
 import { StatusButton } from './StatusButton'
 import { StatusTypography } from './util/StatusTypography'
@@ -23,13 +23,11 @@ const Button = styled(StatusButton)({
   paddingRight: '29px'
 })
 
-export const Unsubscribed = (props: PopupProps) => {
+export const Unsubscribed = () => {
   const {
-    context: {
-      coilDomain,
-      runtime: { tabOpener }
-    }
-  } = props
+    coilDomain,
+    runtime: { tabOpener }
+  } = useHost()
   const onClick = tabOpener(coilDomain + '/settings/payment')
 
   return (

--- a/packages/coil-extension/src/popup/components/Unverified.tsx
+++ b/packages/coil-extension/src/popup/components/Unverified.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Grid, styled } from '@material-ui/core'
 
-import { PopupProps } from '../types'
+import { useHost } from '../context/popupHostContext'
 
 import { StatusTypography } from './util/StatusTypography'
 import { StatusButton } from './StatusButton'
@@ -25,13 +25,11 @@ const titleString = 'Verify your account'
 const subheading1 =
   'To validate your account and reserve a spot on our waitlist please enter your credit card information.'
 
-export const Unverified = (props: PopupProps) => {
+export const Unverified = () => {
   const {
-    context: {
-      coilDomain,
-      runtime: { tabOpener }
-    }
-  } = props
+    coilDomain,
+    runtime: { tabOpener }
+  } = useHost()
   const onClick = tabOpener(coilDomain + '/card-validation')
 
   return (

--- a/packages/coil-extension/src/popup/components/WebMonetizedBar.tsx
+++ b/packages/coil-extension/src/popup/components/WebMonetizedBar.tsx
@@ -3,7 +3,7 @@ import Typography from '@material-ui/core/Typography'
 import { styled } from '@material-ui/core'
 
 import { Colors } from '../../shared-theme/colors'
-import { PopupProps } from '../types'
+import { useStore } from '../context/storeContext'
 
 const CoilBar = styled('div')({
   display: 'flex',
@@ -25,8 +25,8 @@ const NotMonetizedTypography = styled(Typography)({
   fontWeight: 400
 })
 
-export const WebMonetizedBar = (props: PopupProps) => {
-  const { monetized, coilSite } = props.context.store
+export const WebMonetizedBar = () => {
+  const { monetized, coilSite } = useStore()
   const icon = monetized
     ? '/res/wm-icon-active.svg'
     : '/res/wm-icon-inactive.svg'

--- a/packages/coil-extension/src/popup/context/popupHostContext.ts
+++ b/packages/coil-extension/src/popup/context/popupHostContext.ts
@@ -1,0 +1,27 @@
+import { EventEmitter } from 'events'
+
+import React, { useContext } from 'react'
+
+import { PopupHost } from '../types'
+import { API, COIL_DOMAIN } from '../../webpackDefines'
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/no-explicit-any
+const unimpl = (..._: any[]): any => {
+  throw new Error('unimplemented')
+}
+
+export const defaultPopupHost: PopupHost = {
+  key: 'default',
+  events: new EventEmitter(),
+  coilDomain: COIL_DOMAIN,
+  isExtension: Boolean(API?.runtime?.id),
+  runtime: {
+    sendMessage: unimpl,
+    tabOpener: unimpl
+  }
+}
+export const PopupHostContext = React.createContext<PopupHost>(defaultPopupHost)
+
+export const useHost = () => {
+  return useContext(PopupHostContext)
+}

--- a/packages/coil-extension/src/popup/context/storeContext.ts
+++ b/packages/coil-extension/src/popup/context/storeContext.ts
@@ -1,0 +1,43 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+import { StorageService } from '@web-monetization/wext/services'
+
+import { PopupStateType, STORAGE_KEYS } from '../services/PopupState'
+import { PopupHost } from '../types'
+
+export type StorageEventPartial = Pick<StorageEvent, 'key' | 'newValue'>
+
+export const useStoreState = (
+  storage: Pick<StorageService, 'get'>,
+  host: PopupHost
+): PopupStateType => {
+  const [store, setStore] = useState<PopupStateType>({} as PopupStateType)
+  const [init, setInit] = useState(false)
+  if (!init) {
+    const defaultValue: Record<string, unknown> = {}
+    STORAGE_KEYS.forEach(k => {
+      defaultValue[k] = storage.get(k)
+    })
+    setStore(defaultValue)
+    setInit(true)
+  }
+  useEffect(() => {
+    const events = host.events
+    events.on('storage', (evt: StorageEventPartial) => {
+      if (evt.key && evt.newValue) {
+        const key = evt.key
+        setStore(old => ({
+          ...old,
+          [key]: storage.get(key)
+        }))
+      }
+    })
+  }, [])
+
+  return store
+}
+
+export const StoreContext = createContext<PopupStateType>({})
+
+export const useStore = () => {
+  return useContext(StoreContext)
+}

--- a/packages/coil-extension/src/popup/mocks/loadMockedStates.tsx
+++ b/packages/coil-extension/src/popup/mocks/loadMockedStates.tsx
@@ -5,12 +5,14 @@ import { makeStyles } from '@material-ui/core/styles'
 import Grid from '@material-ui/core/Grid'
 import { Typography } from '@material-ui/core'
 
-import { PopupState, PopupStateType } from '../services/PopupState'
-import { PopupContext, PopupProps, PopupRuntime } from '../types'
+import { PopupStateType } from '../services/PopupState'
+import { PopupHost, PopupRuntime } from '../types'
 import { API } from '../../webpackDefines'
 import { StorageService } from '../../services/storage'
 import { User } from '../../types/user'
-import { LocalStorageUpdate } from '../../types/commands'
+import { defaultPopupHost } from '../context/popupHostContext'
+import { StorageEventPartial } from '../context/storeContext'
+import { Index } from '../Index'
 
 import { StatePanel } from './StatePanel'
 
@@ -256,11 +258,19 @@ const useStyles = makeStyles(theme => {
 })
 
 const mockRuntime: MockRuntime = new MockRuntime()
+const mockHosts = MOCK_STATES.map((mock, i) => {
+  const key = `${i}-${mock.name}`
+  const mockHost: PopupHost = {
+    ...defaultPopupHost,
+    key,
+    // Each popup needs its own set of events
+    events: new EventEmitter(),
+    runtime: mockRuntime
+  }
+  return mockHost
+})
 
-export const mockPopupsPage = (
-  PopupComponent: React.ComponentType<PopupProps>,
-  baseContext: Omit<PopupContext, 'runtime'>
-) => {
+export const mockPopupsPage = () => {
   return function MockPopupsPage() {
     const classes = useStyles()
 
@@ -274,32 +284,24 @@ export const mockPopupsPage = (
     const [initiated, setInitiated] = useState(false)
 
     const popups = MOCK_STATES.map(({ name, state }, i) => {
-      const store = new PopupState(makeStorage(state))
-      store.sync()
-
-      if (name.search(/paying/i) && !initiated) {
+      const storage = makeStorage(state)
+      const key = `${i}-${name}`
+      const mockHost = mockHosts[i]
+      if (name.search(/paying/i) != -1 && !initiated) {
+        let value = 10
         setInterval(() => {
-          console.log('triggering mock message')
-          const message: LocalStorageUpdate = {
-            command: 'localStorageUpdate',
-            key: 'monetizedTotal'
+          const newValue = (value += 10)
+          state.monetizedTotal = newValue
+
+          const message: StorageEventPartial = {
+            key: 'monetizedTotal',
+            newValue: JSON.stringify(newValue)
           }
-          mockRuntime.triggerOnMessage(message)
+          mockHost.events.emit('storage', message)
         }, 1500)
         setInitiated(true)
       }
 
-      const mockContext: PopupContext = {
-        ...baseContext,
-        store: store,
-        runtime: mockRuntime
-      }
-
-      const props: PopupProps = {
-        context: mockContext
-      }
-      const propsAny = props as any
-      const key = `${name}${i}`
       return (
         <Grid
           onClick={() => {
@@ -317,7 +319,7 @@ export const mockPopupsPage = (
           key={key}
         >
           <Typography className={classes.heading}>{name}</Typography>
-          <PopupComponent {...propsAny} />
+          <Index storage={storage} host={mockHost} />
         </Grid>
       )
     })

--- a/packages/coil-extension/src/popup/services/PopupState.ts
+++ b/packages/coil-extension/src/popup/services/PopupState.ts
@@ -1,9 +1,6 @@
 import { LocalStorageProxy } from '../../types/storage'
-import { User } from '../../types/user'
-import { StorageService } from '../../services/storage'
-import { PlayOrPauseState, StickyState } from '../../types/streamControls'
 
-const STORAGE_KEYS = [
+export const STORAGE_KEYS = [
   'adapted',
   'coilSite',
   'monetized',
@@ -18,32 +15,3 @@ const STORAGE_KEYS = [
 ]
 
 export type PopupStateType = Omit<LocalStorageProxy, 'token'>
-
-// TODO: replace this stupid thing with a Proxy that doesn't require maintenance
-// of STORAGE_KEYS lists etc
-export class PopupState implements PopupStateType {
-  readonly adapted!: boolean
-  readonly stickyState!: StickyState
-  readonly playState!: PlayOrPauseState
-  readonly coilSite!: string
-  readonly monetized!: boolean
-  readonly monetizedFavicon!: string
-  readonly monetizedTotal!: number
-  readonly user!: User
-  readonly validToken!: boolean
-  readonly extensionBuildString!: string
-  readonly extensionPopupFooterString!: string
-
-  constructor(private storage: Pick<StorageService, 'get'>) {}
-
-  get loggedIn() {
-    return Boolean(this.validToken)
-  }
-
-  sync(keys = STORAGE_KEYS) {
-    const thisAny = this as any
-    keys.forEach(key => {
-      thisAny[key] = this.storage.get(key)
-    })
-  }
-}

--- a/packages/coil-extension/src/popup/types.ts
+++ b/packages/coil-extension/src/popup/types.ts
@@ -1,21 +1,16 @@
-import { API } from '../webpackDefines'
+import { EventEmitter } from 'events'
 
-import { PopupState } from './services/PopupState'
+import { API } from '../webpackDefines'
 
 export interface PopupRuntime {
   sendMessage: typeof API.runtime.sendMessage
-  onMessageAddListener: typeof API.runtime.onMessage.addListener
-  onMessageRemoveListener: typeof API.runtime.onMessage.removeListener
   tabOpener: (url: string) => () => void
 }
 
-export interface PopupContext {
+export interface PopupHost {
+  key: string
   isExtension: boolean
-  runtime: PopupRuntime
-  store: PopupState
   coilDomain: string
-}
-
-export interface PopupProps {
-  context: PopupContext
+  events: EventEmitter
+  runtime: PopupRuntime
 }


### PR DESCRIPTION
- Refactor popup which passed down a context prop everywhere to use React context providers/consumers. 
- Split PopupContext into PopupHost and Store contexts. 
- Add "events" (EventEmitter) to PopupHost to support multiple instances of a popup in a page (styling aid)
- Remove extension message listeners for `localStorageUpdate` messages (*to support Safari*, as per #1340 )
  - Listen to "storage" event on new "events" bus in PopupHost
     - Extension Host: bind to window "storage" event then proxy to `events` bus
     - Mock Host: emit mock "storage" events directly to trigger payment animation with updated monetizationTotal
- Add useStoreState hook to create Store to pass as prop to StoreContext.Provider
  - Parameterized with get only (JSON parsing) Storage wrapper and PopupHost 
     - listens for "storage" events, updating store accordingly
