### PR TITLE
feat(coil-extension): add accept-payment sketch

### DIFF
--- a/packages/coil-extension/manifest.json
+++ b/packages/coil-extension/manifest.json
@@ -32,5 +32,5 @@
       "run_at": "document_start"
     }
   ],
-  "permissions": [ "webNavigation", "<all_urls>" ]
+  "permissions": [ "webNavigation", "webRequest", "webRequestBlocking", "<all_urls>" ]
 }

--- a/packages/coil-extension/src/types/BuildConfig.ts
+++ b/packages/coil-extension/src/types/BuildConfig.ts
@@ -4,4 +4,5 @@ export interface BuildConfig {
   extensionPopupFooterString?: string
   isCI?: boolean
   isLoggingEnabled?: boolean
+  setPaymentHeaders: boolean
 }


### PR DESCRIPTION
This PR proposes the addition of the `Accept-Payment` header which follows the Content Negotiation pattern used by `Accept`, `Accept-Language`, etc.

If this PR is merged, the following header will be added to web requests from the client:

```
Accept-Payment: webmon/*;q=.8
```

HTTP servers can then choose specialized content for the client, or issue a content negotiation sequence: a 402 status code followed by user-facing instructions on how they might pay for the site.

More on the [Accept-Payment proposal](https://github.com/mankins/accept-payment).

This is opportunistic and doesn't replace the client-side web monetization standard.

This is a signal, not a guarantee. Well behaved clients can get the benefit of individual content without having to wait for detection / complete page load.

# Verify / QA
The see this in action you can build the extension and then inspect the outgoing http headers. There should be a new header:

```
Accept-Payment: webmon/*;q=.8
```

To test how content negotiation might work you can run the express server at [Accept-Payment proposal](https://github.com/mankins/accept-payment) and visit the pages referenced for web monetization.