### PR TITLE
feat(coil-extension): support Safari via workarounds

### DIFF
--- a/packages/coil-extension/manifest.json
+++ b/packages/coil-extension/manifest.json
@@ -32,5 +32,10 @@
       "run_at": "document_start"
     }
   ],
-  "permissions": [ "webNavigation", "<all_urls>" ]
+  "permissions": [ "webNavigation", "<all_urls>" ],
+  "$targets" : {
+    "safari": {
+      "permissions" : ["tabs"]
+    }
+  }
 }

--- a/packages/coil-extension/manifest.json
+++ b/packages/coil-extension/manifest.json
@@ -32,5 +32,5 @@
       "run_at": "document_start"
     }
   ],
-  "permissions": [ "webNavigation", "<all_urls>" ]
+  "permissions": [ "webNavigation", "<all_urls>", "tabs" ]
 }

--- a/packages/coil-extension/manifest.json
+++ b/packages/coil-extension/manifest.json
@@ -32,5 +32,5 @@
       "run_at": "document_start"
     }
   ],
-  "permissions": [ "webNavigation", "<all_urls>", "tabs" ]
+  "permissions": [ "webNavigation", "<all_urls>" ]
 }

--- a/packages/coil-extension/src/background/services/BackgroundFramesService.ts
+++ b/packages/coil-extension/src/background/services/BackgroundFramesService.ts
@@ -321,12 +321,40 @@ export class BackgroundFramesService extends EventEmitter {
       }
     }
 
-    this.api.webNavigation.onHistoryStateUpdated.addListener(
-      makeCallback('onHistoryStateUpdated')
-    )
-    this.api.webNavigation.onReferenceFragmentUpdated.addListener(
-      makeCallback('onReferenceFragmentUpdated')
-    )
+    // Not available on Safari, last checked version 14.1 (16611.1.21.161.6)
+    if (this.api.webNavigation.onHistoryStateUpdated) {
+      this.api.webNavigation.onHistoryStateUpdated.addListener(
+        makeCallback('onHistoryStateUpdated')
+      )
+    } else {
+      this.log(
+        'Using tabs.onUpdated workaround for lack of onHistoryStateUpdated'
+      )
+      this.api.tabs.onUpdated.addListener((tabId, changeInfo) => {
+        if (changeInfo.url) {
+          this.updateOrAddFrame(
+            `tabs.onUpdated.changeInfo.url`,
+            { tabId, frameId: 0 },
+            { href: changeInfo.url }
+          )
+        }
+
+        if (changeInfo.status) {
+          this.updateOrAddFrame(
+            `tabs.onUpdated.changeInfo.url`,
+            { tabId, frameId: 0 },
+            { state: changeInfo.status as 'loading' | 'complete' }
+          )
+        }
+      })
+    }
+
+    // Not available on Safari, last checked version 14.1 (16611.1.21.161.6)
+    if (this.api.webNavigation.onReferenceFragmentUpdated) {
+      this.api.webNavigation.onReferenceFragmentUpdated.addListener(
+        makeCallback('onReferenceFragmentUpdated')
+      )
+    }
 
     // These are required otherwise there's a race between usages of getFrameOrDefault()
     // and the initial `useWebNavigationToUpdateFrames()`

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -129,12 +129,16 @@ export class BackgroundScript {
       this.reloadTabState({ from: 'onActivated' })
     })
     if (this.buildConfig.logTabsApiEvents) {
-      this.api.tabs.onActiveChanged.addListener((tabId, selectInfo) => {
-        this.log('tabs.onActiveChanged %d %o', tabId, selectInfo)
-      })
-      this.api.tabs.onSelectionChanged.addListener((tabId, selectInfo) => {
-        this.log('tabs.onSelectionChanged %d %o', tabId, selectInfo)
-      })
+      if (this.api.tabs.onActiveChanged) {
+        this.api.tabs.onActiveChanged.addListener((tabId, selectInfo) => {
+          this.log('tabs.onActiveChanged %d %o', tabId, selectInfo)
+        })
+      }
+      if (this.api.tabs.onSelectionChanged) {
+        this.api.tabs.onSelectionChanged.addListener((tabId, selectInfo) => {
+          this.log('tabs.onSelectionChanged %d %o', tabId, selectInfo)
+        })
+      }
       this.api.tabs.onCreated.addListener(activeInfo => {
         this.log('tabs.onCreated %o', activeInfo)
       })

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -153,13 +153,14 @@ export class BackgroundScript {
         if (windowId < 0) return
 
         // Close the popup when window has changed
-        const message: ClosePopup = {
-          command: 'closePopup'
+        const close: ClosePopup = {
+          command: 'closePopup',
+          data: {
+            // This will create a storage event with a newValue
+            now: Date.now()
+          }
         }
-        this.api.runtime.sendMessage(message, () => {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const ignored = this.api.runtime.lastError
-        })
+        this.storage.set('$$popupCommand', close)
 
         this.api.tabs.query({ active: true, currentWindow: true }, tabs => {
           if (tabs.length === 0 || tabs[0].id == null) return

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -154,13 +154,15 @@ export class BackgroundScript {
 
         // Close the popup when window has changed
         const close: ClosePopup = {
-          command: 'closePopup',
-          data: {
-            // This will create a storage event with a newValue
-            now: Date.now()
-          }
+          command: 'closePopup'
         }
-        this.storage.set('$$popupCommand', close)
+        // Storage events are only fired if the value actually changes, not
+        // on every localStorage `setItem` call. So we set the first 16
+        // characters of the stored value to the current time.
+        this.storage.setRaw(
+          '$$popupCommand',
+          Date.now().toString().padStart(16, '0') + JSON.stringify(close)
+        )
 
         this.api.tabs.query({ active: true, currentWindow: true }, tabs => {
           if (tabs.length === 0 || tabs[0].id == null) return

--- a/packages/coil-extension/src/popup/popup.tsx
+++ b/packages/coil-extension/src/popup/popup.tsx
@@ -33,7 +33,10 @@ export function run() {
     }
     window.addEventListener('storage', e => {
       if (e.key === '$$popupCommand' && e.newValue) {
-        const cmd: ToPopupMessage = JSON.parse(e.newValue)
+        // Remove the timestamp which will cause a unique string used to trigger
+        // a `storage` event.
+        const command = e.newValue.substring(16)
+        const cmd: ToPopupMessage = JSON.parse(command)
         if (cmd.command === 'closePopup') {
           // window.close() itself actually causes a bad state on safari
           if (isSafari) {

--- a/packages/coil-extension/src/types/commands.ts
+++ b/packages/coil-extension/src/types/commands.ts
@@ -272,8 +272,11 @@ export interface MonetizationStart {
  *  background -> popup
  *  browser.tabs.sendMessage
  */
-export interface ClosePopup {
+export interface ClosePopup extends Command {
   command: 'closePopup'
+  data: {
+    now: number
+  }
 }
 
 /**

--- a/packages/coil-extension/src/types/commands.ts
+++ b/packages/coil-extension/src/types/commands.ts
@@ -274,9 +274,6 @@ export interface MonetizationStart {
  */
 export interface ClosePopup extends Command {
   command: 'closePopup'
-  data: {
-    now: number
-  }
 }
 
 /**

--- a/packages/webexts-build-utils/src/makeWebpackConfig.ts
+++ b/packages/webexts-build-utils/src/makeWebpackConfig.ts
@@ -4,6 +4,9 @@ import * as cp from 'child_process'
 
 import * as webpack from 'webpack'
 import { configureNodePolyfills, getPackageVersion } from '@coil/webpack-utils'
+import exports from 'webpack'
+
+import processArguments = exports.cli.processArguments
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const CopyPlugin = require('copy-webpack-plugin')

--- a/packages/webexts-build-utils/src/makeWebpackConfig.ts
+++ b/packages/webexts-build-utils/src/makeWebpackConfig.ts
@@ -77,6 +77,9 @@ export function makeWebpackConfig(rootDir: string): webpack.Configuration {
       to: 'manifest.json',
       transform: (content: Buffer) => {
         const manifest = JSON.parse(content.toString())
+        // TODO: expand based on build target
+        delete manifest['$targets']
+
         if (WEXT_MANIFEST_SUFFIX) {
           manifest.name += WEXT_MANIFEST_SUFFIX
           if (!WEXT_MANIFEST_SUFFIX_NO_DATE) {

--- a/packages/webexts-build-utils/src/makeWebpackConfig.ts
+++ b/packages/webexts-build-utils/src/makeWebpackConfig.ts
@@ -4,9 +4,8 @@ import * as cp from 'child_process'
 
 import * as webpack from 'webpack'
 import { configureNodePolyfills, getPackageVersion } from '@coil/webpack-utils'
-import exports from 'webpack'
 
-import processArguments = exports.cli.processArguments
+import { applyManifestPermissions } from './manifestPermissions'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const CopyPlugin = require('copy-webpack-plugin')
@@ -96,6 +95,7 @@ export function makeWebpackConfig(rootDir: string): webpack.Configuration {
         } else {
           delete manifest['browser_specific_settings']
         }
+        applyManifestPermissions(manifest)
         return prettyJSON(manifest)
       }
     },

--- a/packages/webexts-build-utils/src/manifestPermissions.ts
+++ b/packages/webexts-build-utils/src/manifestPermissions.ts
@@ -1,0 +1,8 @@
+export interface Manifest {
+  permissions: string[]
+}
+
+export function applyManifestPermissions(manifest: Manifest) {
+  const rules = process.env.WEXT_MANIFEST_PERMISSIONS
+  const parsedRules: string[] = rules ? JSON.parse(rules) : []
+}

--- a/packages/webexts-build-utils/src/manifestPermissions.ts
+++ b/packages/webexts-build-utils/src/manifestPermissions.ts
@@ -2,7 +2,19 @@ export interface Manifest {
   permissions: string[]
 }
 
-export function applyManifestPermissions(manifest: Manifest) {
+export function applyManifestPermissions(manifest: Manifest): void {
   const rules = process.env.WEXT_MANIFEST_PERMISSIONS
   const parsedRules: string[] = rules ? JSON.parse(rules) : []
+  for (const rule of parsedRules) {
+    if (rule.startsWith('-')) {
+      const subtract = rule.substring(1)
+      manifest.permissions = manifest.permissions.filter(s => s !== subtract)
+    } else {
+      const add = rule.startsWith('+') ? rule.substring(1) : rule
+      const already = manifest.permissions.find(p => p === add)
+      if (!already) {
+        manifest.permissions.push(add)
+      }
+    }
+  }
 }


### PR DESCRIPTION
Update of https://github.com/coilhq/web-monetization-projects/pull/1340

* Requires "tabs" permission:
   Chrome (and to a lesser extent, Firefox) grants many "tabs" permissions
   implicitly via "<all_urls>". Safari does not. This is required for using
   chrome.tabs to search for an already open tab via url and select it.
   
   via `export WEXT_MANIFEST_PERMISSIONS='["+tabs"]'`