### PR TITLE
feat(ci): add publish-packages job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,9 +278,17 @@ workflows:
       - packages-build-scripts
       - hold-publish-packages:
           type: approval
+          filters:
+            branches:
+              only:
+                - main
       - publish-packages:
           requires:
             - hold-publish-packages
+          filters:
+            branches:
+              only:
+                - main
       - jest-all:
           context: web-monetization-tests
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,29 @@ jobs:
             yarn addons-linter coilfirefoxextension@coil.com.xpi
       - *save_cache
 
+  publish-packages:
+    docker:
+      - image: circleci/node:14-buster-browsers
+    steps:
+      - checkout
+      - *restore_cache
+      - *yarn_install
+      - run:
+          name: Configure NPM authentication
+          command: |
+            yarn config set "npmRegistries['https://registry.yarnpkg.com'].npmAuthToken" "$NPM_AUTH_TOKEN" -H
+      - run:
+          name: Build the web-monetization-types package
+          command: |
+            cd packages/web-monetization-types
+            yarn build:ts:verbose
+      - run:
+          name: Publish the web-monetization-types package
+          command: |
+            cd packages/web-monetization-types
+            yarn npm publish --access public
+      - *save_cache
+
   coil-extension-puppeteer:
     docker:
       - image: circleci/node:14-buster-browsers
@@ -253,6 +276,11 @@ workflows:
       - build-root-tsconfig
       - coil-extension-package
       - packages-build-scripts
+      - hold-publish-packages:
+          type: approval
+      - publish-packages:
+          requires:
+            - hold-publish-packages
       - jest-all:
           context: web-monetization-tests
           filters:

--- a/packages/web-monetization-types/package.json
+++ b/packages/web-monetization-types/package.json
@@ -7,9 +7,6 @@
     "ilp",
     "web-monetization"
   ],
-  "files": [
-    "build/*"
-  ],
   "homepage": "https://github.com/coilhq/web-monetization-projects/tree/main/packages/web-monetization-types",
   "repository": {
     "type": "git",
@@ -19,6 +16,9 @@
   "author": "Coil Team <info@coil.com>",
   "main": "./build",
   "types": "./build",
+  "files": [
+    "build/*"
+  ],
   "scripts": {
     "build:ts": "tsc --build tsconfig.build.json",
     "build:ts:verbose": "yarn build:ts --verbose",

--- a/packages/web-monetization-types/package.json
+++ b/packages/web-monetization-types/package.json
@@ -7,6 +7,9 @@
     "ilp",
     "web-monetization"
   ],
+  "files": [
+    "build/*"
+  ],
   "homepage": "https://github.com/coilhq/web-monetization-projects/tree/main/packages/web-monetization-types",
   "repository": {
     "type": "git",


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/525211/121473985-9fc74180-c9ed-11eb-9768-20a9809f53a5.png)

Closes #1960 

Add a job to publish web-monetization-types behind an approval job.
Requires NPM_AUTH_TOKEN env var to be set securely in Circle UI

