### PR TITLE
fix(coil-extension): better handle quick change of tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,7 @@ jobs:
             [[ $COIL_DOMAIN = "https://coil.com" ]] && build_cmd="build-prod" || build_cmd="build-staging"
             yarn $build_cmd $BROWSER_TYPE
             xvfb-run -a ./test.sh test/puppeteer/logout-test.ts
+            xvfb-run -a ./test.sh test/puppeteer/multiple-tags-test.ts
       # - run:
       #     name: BROWSER_TYPE=firefox test.sh test/puppeteer/logout-test.ts
       #     command: |
@@ -143,6 +144,7 @@ jobs:
             [[ $COIL_DOMAIN = "https://coil.com" ]] && build_cmd="build-prod" || build_cmd="build-staging"
             BUILD_TS=false TS_LOADER_TRANSPILE_ONLY=true yarn $build_cmd $BROWSER_TYPE
             xvfb-run -a ./test.sh test/puppeteer/logout-test.ts
+            xvfb-run -a ./test.sh test/puppeteer/multiple-tags-test.ts
 
       # - run:
       #     name: BROWSER_TYPE=firefox test.sh test/puppeteer/logout-test.ts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
       - *restore_cache
       - *yarn_install
       - run:
-          name: BROWSER_TYPE=chrome ./test.sh test/puppeteer/logout-test.ts
+          name: BROWSER_TYPE=chrome ./test.sh test/puppeteer/{logout,multiple-tags}-test.ts
           command: |
             cd packages/coil-extension
             export BROWSER_TYPE=chrome
@@ -137,7 +137,7 @@ jobs:
       - *restore_cache
       - *yarn_install
       - run:
-          name: BROWSER_TYPE=chrome ./test.sh test/puppeteer/logout-test.ts
+          name: BROWSER_TYPE=chrome ./test.sh test/puppeteer/{logout,multiple-tags}-test.ts
           command: |
             cd packages/coil-extension
             export BROWSER_TYPE=chrome

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -2834,6 +2834,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["eslint-plugin-react", "virtual:e0cd45c1a19ea8aa89ff35179dd8110081538629e89b121cb83c1fab78c0aab22afae02cd6e5ba8fc350eb38d36b2487d5869c2d2c43c2fbf770269d2f45568e#npm:7.24.0"],
             ["eslint-plugin-react-hooks", "virtual:e0cd45c1a19ea8aa89ff35179dd8110081538629e89b121cb83c1fab78c0aab22afae02cd6e5ba8fc350eb38d36b2487d5869c2d2c43c2fbf770269d2f45568e#npm:4.2.0"],
             ["eslint-plugin-standard", "virtual:e0cd45c1a19ea8aa89ff35179dd8110081538629e89b121cb83c1fab78c0aab22afae02cd6e5ba8fc350eb38d36b2487d5869c2d2c43c2fbf770269d2f45568e#npm:5.0.0"],
+            ["http-server", "npm:0.12.3"],
             ["husky", "npm:7.0.1"],
             ["ilp-plugin-btp", "npm:1.5.0"],
             ["ilp-protocol-stream", "npm:2.7.0"],
@@ -9821,6 +9822,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "linkType": "HARD",
         }]
       ]],
+      ["basic-auth", [
+        ["npm:1.1.0", {
+          "packageLocation": "./.yarn/cache/basic-auth-npm-1.1.0-8eab57a059-a248a4b125.zip/node_modules/basic-auth/",
+          "packageDependencies": [
+            ["basic-auth", "npm:1.1.0"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
       ["batch", [
         ["npm:0.6.1", {
           "packageLocation": "./.yarn/cache/batch-npm-0.6.1-70e2e81169-61f9934c73.zip/node_modules/batch/",
@@ -11151,6 +11161,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["colors", "npm:1.0.3"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:1.4.0", {
+          "packageLocation": "./.yarn/cache/colors-npm-1.4.0-7e2cf12234-98aa2c2418.zip/node_modules/colors/",
+          "packageDependencies": [
+            ["colors", "npm:1.4.0"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["columnify", [
@@ -12078,6 +12095,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/core-util-is-npm-1.0.2-9fc2b94dc3-7a4c925b49.zip/node_modules/core-util-is/",
           "packageDependencies": [
             ["core-util-is", "npm:1.0.2"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["corser", [
+        ["npm:2.0.1", {
+          "packageLocation": "./.yarn/cache/corser-npm-2.0.1-4dbc602b14-9ff6944eda.zip/node_modules/corser/",
+          "packageDependencies": [
+            ["corser", "npm:2.0.1"]
           ],
           "linkType": "HARD",
         }]
@@ -13263,6 +13289,19 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["ecdsa-sig-formatter", "npm:1.0.11"],
             ["safe-buffer", "npm:5.2.1"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["ecstatic", [
+        ["npm:3.3.2", {
+          "packageLocation": "./.yarn/cache/ecstatic-npm-3.3.2-35099559aa-61787fe020.zip/node_modules/ecstatic/",
+          "packageDependencies": [
+            ["ecstatic", "npm:3.3.2"],
+            ["he", "npm:1.2.0"],
+            ["mime", "npm:1.6.0"],
+            ["minimist", "npm:1.2.5"],
+            ["url-join", "npm:2.0.5"]
           ],
           "linkType": "HARD",
         }]
@@ -16711,6 +16750,25 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["is-glob", "npm:4.0.1"],
             ["lodash", "npm:4.17.21"],
             ["micromatch", "npm:3.1.10"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["http-server", [
+        ["npm:0.12.3", {
+          "packageLocation": "./.yarn/cache/http-server-npm-0.12.3-798b1680fa-fdd8652638.zip/node_modules/http-server/",
+          "packageDependencies": [
+            ["http-server", "npm:0.12.3"],
+            ["basic-auth", "npm:1.1.0"],
+            ["colors", "npm:1.4.0"],
+            ["corser", "npm:2.0.1"],
+            ["ecstatic", "npm:3.3.2"],
+            ["http-proxy", "npm:1.18.1"],
+            ["minimist", "npm:1.2.5"],
+            ["opener", "npm:1.5.2"],
+            ["portfinder", "npm:1.0.28"],
+            ["secure-compare", "npm:3.0.1"],
+            ["union", "npm:0.5.0"]
           ],
           "linkType": "HARD",
         }]
@@ -23188,6 +23246,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["qs", [
+        ["npm:6.10.1", {
+          "packageLocation": "./.yarn/cache/qs-npm-6.10.1-12d3ab7795-00e390dbf9.zip/node_modules/qs/",
+          "packageDependencies": [
+            ["qs", "npm:6.10.1"],
+            ["side-channel", "npm:1.0.4"]
+          ],
+          "linkType": "HARD",
+        }],
         ["npm:6.5.1", {
           "packageLocation": "./.yarn/cache/qs-npm-6.5.1-a174b28564-40967af240.zip/node_modules/qs/",
           "packageDependencies": [
@@ -24501,6 +24567,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/json-schema", "npm:7.0.7"],
             ["ajv", "npm:6.12.6"],
             ["ajv-keywords", "virtual:2cff0d280c4538a5d9bf628a07c6a147d182254ea311e5863bfebba2388656b50f0ceee8aa1f9ef09dc43cf6bce63d8652280f926f9b2127be45428240f32d37#npm:3.5.2"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["secure-compare", [
+        ["npm:3.0.1", {
+          "packageLocation": "./.yarn/cache/secure-compare-npm-3.0.1-5bb9fae9c0-0a8d8d3e54.zip/node_modules/secure-compare/",
+          "packageDependencies": [
+            ["secure-compare", "npm:3.0.1"]
           ],
           "linkType": "HARD",
         }]
@@ -27854,6 +27929,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "linkType": "HARD",
         }]
       ]],
+      ["union", [
+        ["npm:0.5.0", {
+          "packageLocation": "./.yarn/cache/union-npm-0.5.0-6b68db9cf0-021530d023.zip/node_modules/union/",
+          "packageDependencies": [
+            ["union", "npm:0.5.0"],
+            ["qs", "npm:6.10.1"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
       ["union-value", [
         ["npm:1.0.1", {
           "packageLocation": "./.yarn/cache/union-value-npm-1.0.1-76c6e8a88f-a3464097d3.zip/node_modules/union-value/",
@@ -28060,6 +28145,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["url", "npm:0.11.0"],
             ["punycode", "npm:1.3.2"],
             ["querystring", "npm:0.2.0"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["url-join", [
+        ["npm:2.0.5", {
+          "packageLocation": "./.yarn/cache/url-join-npm-2.0.5-30916ff613-5c935cc99e.zip/node_modules/url-join/",
+          "packageDependencies": [
+            ["url-join", "npm:2.0.5"]
           ],
           "linkType": "HARD",
         }]

--- a/packages/coil-extension/package.json
+++ b/packages/coil-extension/package.json
@@ -41,7 +41,7 @@
     "prettier": "prettier --write '*.{ts,tsx,js,html,jsx,md}' '{src,test}/**/*.{ts,tsx,js,html,jsx,md}'",
     "publish:preview": "WEXT_SHIPIT_CHROME_EXTENSION_ID=iehmfkldnblennopinmmagfidpflefkp WEXT_MANIFEST_SUFFIX=Preview ./scripts/publish-coildev-chrome-store.sh",
     "publish:dev": "./scripts/publish-coildev-chrome-store.sh",
-    "serve:fixtures": "python -m http.server 4000 --directory test/fixtures",
+    "serve:fixtures": "http-server -p 4000 test/fixtures",
     "test": "jest --passWithNoTests",
     "test:coverage": "yarn test --verbose --coverage",
     "upkeep": "cd ../.. && yarn upkeep"

--- a/packages/coil-extension/package.json
+++ b/packages/coil-extension/package.json
@@ -114,6 +114,7 @@
     "eslint-plugin-react": "7.24.0",
     "eslint-plugin-react-hooks": "4.2.0",
     "eslint-plugin-standard": "5.0.0",
+    "http-server": "^0.12.3",
     "husky": "7.0.1",
     "jest": "27.0.6",
     "lerna": "4.0.0",

--- a/packages/coil-extension/package.json
+++ b/packages/coil-extension/package.json
@@ -41,6 +41,7 @@
     "prettier": "prettier --write '*.{ts,tsx,js,html,jsx,md}' '{src,test}/**/*.{ts,tsx,js,html,jsx,md}'",
     "publish:preview": "WEXT_SHIPIT_CHROME_EXTENSION_ID=iehmfkldnblennopinmmagfidpflefkp WEXT_MANIFEST_SUFFIX=Preview ./scripts/publish-coildev-chrome-store.sh",
     "publish:dev": "./scripts/publish-coildev-chrome-store.sh",
+    "serve:fixtures": "python -m http.server 4000 --directory test/fixtures",
     "test": "jest --passWithNoTests",
     "test:coverage": "yarn test --verbose --coverage",
     "upkeep": "cd ../.. && yarn upkeep"

--- a/packages/coil-extension/src/background/services/ActiveTabLogger.ts
+++ b/packages/coil-extension/src/background/services/ActiveTabLogger.ts
@@ -4,7 +4,7 @@ import * as tokens from '../../types/tokens'
 
 @injectable()
 export class ActiveTabLogger {
-  sendLogs = false
+  sendLogs = Boolean(localStorage.ACTIVE_TAB_LOGGING)
 
   constructor(
     @inject(tokens.WextApi)

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -723,10 +723,11 @@ export class BackgroundScript {
       this.tabStates.getFrameOrDefault(frame).lastMonetization.requestId !==
       requestId
     ) {
-      // The pending message will have been ignored on the content script side
-      // in this case too, so there's no need to send a stop, as will already
-      // be stopped (for that id). If we sent a stopped message, it would need
-      // to be tagged with requestId, and would only ever be ignored.
+      // The pending message (if sent)  will have been ignored on the content
+      // script side in this case too, so there's no need to send a stop, as
+      // will already be stopped (for that id). If we sent a stopped message,
+      // it would need to be tagged with requestId, and would only ever be
+      // ignored.
       this.activeTabLogger.log(
         `startWebMonetization aborted; stale requestId: ${requestId}`
       )

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -715,19 +715,21 @@ export class BackgroundScript {
       return false
     }
 
-    // Check that this operation is still valid before we go ahead.
-    // Any operation that we `await`d on could have potentially masked state
-    // changes. e.g. `getTokenMaybeRefreshAndStoreState` )which will update
-    // whoami) taking longer than it takes to switch out the monetization tag.
+    // Check that this startWebMonetization invocation is still valid before
+    // we go ahead. Any operation that we `await`d on could have potentially
+    // masked state changes. e.g. `getTokenMaybeRefreshAndStoreState`
+    // (which will update `whoami`) which takes longer than it does to switch
+    // out a monetization tag.
     if (
       this.tabStates.getFrameOrDefault(frame).lastMonetization.requestId !==
       requestId
     ) {
-      // The pending message (if sent)  will have been ignored on the content
+      // The pending message (if sent) will have been ignored on the content
       // script side in this case too, so there's no need to send a stop, as
-      // will already be stopped (for that id). If we sent a stopped message,
-      // it would need to be tagged with requestId, and would only ever be
-      // ignored.
+      // will already have been stopped (for that id).
+      // If we sent a stopped message, it would need to be tagged with
+      // requestId, and would only ever be ignored (
+      // due to the new monetization request implied in the if condition)
       this.activeTabLogger.log(
         `startWebMonetization aborted; stale requestId: ${requestId}`
       )

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -717,8 +717,8 @@ export class BackgroundScript {
 
     // Check that this operation is still valid before we go ahead.
     // Any operation that we `await`d on could have potentially masked state
-    // changes. e.g. `getTokenMaybeRefreshAndStoreState` which will update
-    // whoami taking longer than it takes to switch out the monetization tag.
+    // changes. e.g. `getTokenMaybeRefreshAndStoreState` )which will update
+    // whoami) taking longer than it takes to switch out the monetization tag.
     if (
       this.tabStates.getFrameOrDefault(frame).lastMonetization.requestId !==
       requestId

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -876,7 +876,9 @@ export class BackgroundScript {
 
   private doStopWebMonetization(frame: FrameSpec) {
     const requestId = this.assoc.getStreamId(frame)
-    this.tabStates.logLastMonetizationCommand(frame, 'stop', requestId)
+    if (requestId) {
+      this.tabStates.logLastMonetizationCommand(frame, 'stop', requestId)
+    }
     const closed = this._closeStreams(frame.tabId, frame.frameId)
     // May be noop other side if stop monetization was initiated from
     // ContentScript

--- a/packages/coil-extension/src/background/services/BackgroundScript.ts
+++ b/packages/coil-extension/src/background/services/BackgroundScript.ts
@@ -824,8 +824,8 @@ export class BackgroundScript {
 
   private doPauseWebMonetization(frame: FrameSpec) {
     const id = this.assoc.getStreamId(frame)
-    this.tabStates.logLastMonetizationCommand(frame, 'pause', id)
     if (id) {
+      this.tabStates.logLastMonetizationCommand(frame, 'pause', id)
       this.log('pausing stream', id)
       this.streams.pauseStream(id)
       this.sendSetMonetizationStateMessage(frame, 'stopped')
@@ -835,8 +835,8 @@ export class BackgroundScript {
 
   private doResumeWebMonetization(frame: FrameSpec) {
     const id = this.assoc.getStreamId(frame)
-    this.tabStates.logLastMonetizationCommand(frame, 'resume', id)
     if (id) {
+      this.tabStates.logLastMonetizationCommand(frame, 'resume', id)
       this.log('resuming stream', id)
       this.sendSetMonetizationStateMessage(frame, 'pending')
       this.streams.resumeStream(id)

--- a/packages/coil-extension/src/background/services/TabStates.ts
+++ b/packages/coil-extension/src/background/services/TabStates.ts
@@ -133,11 +133,11 @@ export class TabStates {
   logLastMonetizationCommand(
     frame: FrameSpec,
     command: MonetizationCommand,
-    requestId?: string
+    requestId: string
   ) {
     this.setFrame(frame, {
       lastMonetization: {
-        requestId: requestId ?? null,
+        requestId: requestId,
         command
       }
     })

--- a/packages/coil-extension/src/background/services/TabStates.ts
+++ b/packages/coil-extension/src/background/services/TabStates.ts
@@ -68,9 +68,8 @@ export class TabStates {
       adapted: false,
       total: 0,
       lastMonetization: {
-        index: 0,
-        command: null,
-        timeMs: Date.now()
+        requestId: null,
+        command: null
       }
     }
   }
@@ -131,12 +130,15 @@ export class TabStates {
     }
   }
 
-  logLastMonetizationCommand(frame: FrameSpec, command: MonetizationCommand) {
+  logLastMonetizationCommand(
+    frame: FrameSpec,
+    command: MonetizationCommand,
+    requestId?: string
+  ) {
     this.setFrame(frame, {
       lastMonetization: {
-        index: this.getFrameOrDefault(frame).lastMonetization.index + 1,
-        command,
-        timeMs: Date.now()
+        requestId: requestId ?? null,
+        command
       }
     })
   }

--- a/packages/coil-extension/src/background/services/TabStates.ts
+++ b/packages/coil-extension/src/background/services/TabStates.ts
@@ -62,12 +62,13 @@ export class TabStates {
     return state
   }
 
-  private makeFrameStateDefault() {
+  private makeFrameStateDefault(): FrameState {
     return {
       monetized: false,
       adapted: false,
       total: 0,
       lastMonetization: {
+        index: 0,
         command: null,
         timeMs: Date.now()
       }
@@ -133,6 +134,7 @@ export class TabStates {
   logLastMonetizationCommand(frame: FrameSpec, command: MonetizationCommand) {
     this.setFrame(frame, {
       lastMonetization: {
+        index: this.getFrameOrDefault(frame).lastMonetization.index + 1,
         command,
         timeMs: Date.now()
       }

--- a/packages/coil-extension/src/types/TabState.ts
+++ b/packages/coil-extension/src/types/TabState.ts
@@ -8,9 +8,8 @@ export interface FrameState {
   // Tracks the total amount of `source` money sent (not was received)
   total: number
   lastMonetization: {
-    index: number
+    requestId: string | null
     command: MonetizationCommand | null
-    timeMs: number
   }
 }
 

--- a/packages/coil-extension/src/types/TabState.ts
+++ b/packages/coil-extension/src/types/TabState.ts
@@ -8,6 +8,7 @@ export interface FrameState {
   // Tracks the total amount of `source` money sent (not was received)
   total: number
   lastMonetization: {
+    index: number
     command: MonetizationCommand | null
     timeMs: number
   }

--- a/packages/coil-extension/test/fixtures/multiple-tags-link-first.html
+++ b/packages/coil-extension/test/fixtures/multiple-tags-link-first.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Link Tag</title>
-    <link rel="monetization" href="https://twitter.xrptipbot.com/Coil" />
+    <link rel="monetization" href="https://twitter.xrptipbot.com/sharafian_" />
     <meta name="monetization" content="$twitter.xrptipbot.com/Coil" />
   </head>
   <body>

--- a/packages/coil-extension/test/fixtures/multiple-tags-link-first.html
+++ b/packages/coil-extension/test/fixtures/multiple-tags-link-first.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Link Tag</title>
+    <link rel="monetization" href="https://twitter.xrptipbot.com/Coil" />
+    <meta name="monetization" content="$twitter.xrptipbot.com/Coil" />
+  </head>
+  <body>
+    <p>Page includes a meta AND link tag</p>
+    <p>The meta tag should ignored (and an error logged)</p>
+  </body>
+</html>

--- a/packages/coil-extension/test/fixtures/multiple-tags-link-first.html
+++ b/packages/coil-extension/test/fixtures/multiple-tags-link-first.html
@@ -7,7 +7,10 @@
     <meta name="monetization" content="$twitter.xrptipbot.com/Coil" />
   </head>
   <body>
-    <p>Page includes a meta AND link tag</p>
-    <p>The meta tag should ignored (and an error logged)</p>
+    <p>Page includes a link THEN a meta tag</p>
+    <p>
+      The meta tag should ignored (and an error logged) as affinity with link
+      established
+    </p>
   </body>
 </html>

--- a/packages/coil-extension/test/fixtures/multiple-tags-meta-first.html
+++ b/packages/coil-extension/test/fixtures/multiple-tags-meta-first.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Link Tag</title>
+    <meta name="monetization" content="$twitter.xrptipbot.com/Coil" />
+    <link rel="monetization" href="https://twitter.xrptipbot.com/Coil" />
+  </head>
+  <body>
+    <p>Page includes a meta AND link tag</p>
+    <p>Monetization should be ignored for the meta</p>
+  </body>
+</html>

--- a/packages/coil-extension/test/fixtures/multiple-tags-meta-first.html
+++ b/packages/coil-extension/test/fixtures/multiple-tags-meta-first.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <title>Link Tag</title>
     <meta name="monetization" content="$twitter.xrptipbot.com/Coil" />
-    <link rel="monetization" href="https://twitter.xrptipbot.com/Coil" />
+    <link rel="monetization" href="https://twitter.xrptipbot.com/sharafian_" />
   </head>
   <body>
     <p>Page includes a meta AND link tag</p>

--- a/packages/coil-extension/test/fixtures/multiple-tags-meta-first.html
+++ b/packages/coil-extension/test/fixtures/multiple-tags-meta-first.html
@@ -8,6 +8,9 @@
   </head>
   <body>
     <p>Page includes a meta AND link tag</p>
-    <p>Monetization should be ignored for the meta</p>
+    <p>
+      Monetization should be ignored for the meta ( new monetization request
+      from link tag before any events emitted)
+    </p>
   </body>
 </html>

--- a/packages/coil-extension/test/puppeteer/multiple-tags-test.ts
+++ b/packages/coil-extension/test/puppeteer/multiple-tags-test.ts
@@ -65,6 +65,9 @@ async function run() {
 
     success =
       success &&
+      results.details.events[0].event.detail.paymentPointer.endsWith(
+        'twitter.xrptipbot.com/sharafian_'
+      ) &&
       initialEvents ===
         'monetizationpending, monetizationstart, monetizationprogress' &&
       (trailingEventsSet === 'monetizationprogress' ||

--- a/packages/coil-extension/test/puppeteer/multiple-tags-test.ts
+++ b/packages/coil-extension/test/puppeteer/multiple-tags-test.ts
@@ -39,7 +39,18 @@ async function run() {
   for (const url of testUrls) {
     debug(`testing url ${url}`)
     const results = await testMonetization({ context, url })
-    debug(`results = ${JSON.stringify(results.details)}`)
+    debug(
+      'results.details.statesSeen instanceof Set',
+      results.details.statesSeen instanceof Set
+    )
+    debug(
+      `results = ${JSON.stringify(
+        results.details,
+        (key, value) =>
+          value instanceof Set ? Array.from(value.values()) : value,
+        2
+      )}`
+    )
     success =
       success &&
       results.details.events.map(o => o.event.type).join(', ') ===

--- a/packages/coil-extension/test/puppeteer/multiple-tags-test.ts
+++ b/packages/coil-extension/test/puppeteer/multiple-tags-test.ts
@@ -67,7 +67,8 @@ async function run() {
       success &&
       initialEvents ===
         'monetizationpending, monetizationstart, monetizationprogress' &&
-      trailingEventsSet === 'monetizationprogress' &&
+      (trailingEventsSet === 'monetizationprogress' ||
+        trailingEventsSet === '') &&
       results.details.statesSeen.size === 2 &&
       results.details.statesSeen.has('pending') &&
       results.details.statesSeen.has('started')

--- a/packages/coil-extension/test/puppeteer/multiple-tags-test.ts
+++ b/packages/coil-extension/test/puppeteer/multiple-tags-test.ts
@@ -37,7 +37,9 @@ async function run() {
     'http://localhost:4000/multiple-tags-link-first.html'
   ]
   for (const url of testUrls) {
+    debug(`testing url ${url}`)
     const results = await testMonetization({ context, url })
+    debug(`results = ${JSON.stringify(results)}`)
     success =
       success &&
       results.details.events.map(o => o.event.type).join(', ') ===

--- a/packages/coil-extension/test/puppeteer/multiple-tags-test.ts
+++ b/packages/coil-extension/test/puppeteer/multiple-tags-test.ts
@@ -60,6 +60,9 @@ async function run() {
       new Set(results.details.events.slice(3).map(o => o.event.type))
     ).join(', ')
 
+    debug('initialEvents', initialEvents)
+    debug('trailingEventsSet', trailingEventsSet)
+
     success =
       success &&
       initialEvents ===

--- a/packages/coil-extension/test/puppeteer/multiple-tags-test.ts
+++ b/packages/coil-extension/test/puppeteer/multiple-tags-test.ts
@@ -1,0 +1,60 @@
+import * as cp from 'child_process'
+import * as pathMod from 'path'
+
+import {
+  debug,
+  initBrowserAndLoginFromEnv,
+  testMonetization
+} from '@coil/puppeteer-utils'
+
+class Server {
+  serverHandle?: cp.ChildProcess
+
+  constructor(private cmd: string, private args: string[]) {}
+
+  async start() {
+    this.serverHandle = cp.spawn(this.cmd, this.args, { stdio: 'pipe' })
+    return new Promise(resolve => {
+      this.serverHandle?.stdout?.once('data', resolve)
+    })
+  }
+
+  stop() {
+    this.serverHandle?.kill()
+  }
+}
+
+async function run() {
+  const { context } = await initBrowserAndLoginFromEnv()
+  debug('logged in')
+  const fixturesDir = pathMod.resolve(__dirname, '../fixtures')
+  const server = new Server('yarn', ['http-server', fixturesDir, '-p', '4000'])
+  await server.start()
+  debug('server.started')
+  let success = true
+  const testUrls = [
+    'http://localhost:4000/multiple-tags-meta-first.html',
+    'http://localhost:4000/multiple-tags-link-first.html'
+  ]
+  for (const url of testUrls) {
+    const results = await testMonetization({ context, url })
+    success =
+      success &&
+      results.details.events.map(o => o.event.type).join(', ') ===
+        'monetizationpending, monetizationstart, monetizationprogress' &&
+      results.details.statesSeen.size === 2 &&
+      results.details.statesSeen.has('pending') &&
+      results.details.statesSeen.has('started')
+    if (!success) {
+      break
+    }
+  }
+
+  await server.stop()
+  process.exit(success ? 0 : 1)
+}
+
+run().catch(e => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/coil-extension/test/puppeteer/multiple-tags-test.ts
+++ b/packages/coil-extension/test/puppeteer/multiple-tags-test.ts
@@ -51,10 +51,20 @@ async function run() {
         2
       )}`
     )
+    const initialEvents = results.details.events
+      .slice(0, 3)
+      .map(o => o.event.type)
+      .join(', ')
+
+    const trailingEventsSet = Array.from(
+      new Set(results.details.events.slice(3).map(o => o.event.type))
+    ).join(', ')
+
     success =
       success &&
-      results.details.events.map(o => o.event.type).join(', ') ===
+      initialEvents ===
         'monetizationpending, monetizationstart, monetizationprogress' &&
+      trailingEventsSet === 'monetizationprogress' &&
       results.details.statesSeen.size === 2 &&
       results.details.statesSeen.has('pending') &&
       results.details.statesSeen.has('started')

--- a/packages/coil-extension/test/puppeteer/multiple-tags-test.ts
+++ b/packages/coil-extension/test/puppeteer/multiple-tags-test.ts
@@ -39,7 +39,7 @@ async function run() {
   for (const url of testUrls) {
     debug(`testing url ${url}`)
     const results = await testMonetization({ context, url })
-    debug(`results = ${JSON.stringify(results)}`)
+    debug(`results = ${JSON.stringify(results.details)}`)
     success =
       success &&
       results.details.events.map(o => o.event.type).join(', ') ===

--- a/packages/coil-puppeteer-utils/src/lib/testMonetization.ts
+++ b/packages/coil-puppeteer-utils/src/lib/testMonetization.ts
@@ -30,7 +30,12 @@ export interface TestPageResults {
   page: Page
   url: string
   stoppedPromise: Promise<OnMonetizationEvent>
-  details: any
+  details: {
+    statesSeen: Set<string>
+    eventsSeen: Set<string>
+    state: string | null
+    events: Array<{ event: MonetizationEvent; monetizationState: string }>
+  }
 }
 
 export interface TestPageParameters {
@@ -175,8 +180,8 @@ export async function testMonetization({
     success: success && state === 'started',
     url,
     details: {
-      statesSeen: statesSeen.values(),
-      eventsSeen: eventsSeen.values(),
+      statesSeen: statesSeen,
+      eventsSeen: eventsSeen,
       state,
       events
     }

--- a/packages/webmonetization-polyfill-utils/src/lib/MonetizationTagObserver.ts
+++ b/packages/webmonetization-polyfill-utils/src/lib/MonetizationTagObserver.ts
@@ -1,6 +1,7 @@
 import { v4 as uuid } from 'uuid'
 
 import { whenDocumentReady } from './whenDocumentReady'
+import { CustomError } from './CustomError'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function,@typescript-eslint/no-unused-vars
 const debug = (..._: unknown[]) => {}
@@ -38,6 +39,8 @@ export type TagType = 'meta' | 'link'
 export function getTagType(tag: MonetizationTag): TagType {
   return tag instanceof HTMLMetaElement ? 'meta' : 'link'
 }
+
+export class DeprecatedMetaTagIgnoredError extends CustomError {}
 
 export class MonetizationTagObserver {
   /**
@@ -154,11 +157,12 @@ export class MonetizationTagObserver {
           this.onRemovedTag(tag)
         }
       } else {
-        throw new Error(
+        // TODO: just console.warn and return early ?
+        throw new DeprecatedMetaTagIgnoredError(
           'Web-Monetization Error: ' +
-            'A <link rel="monetization"> tag has been seen, ' +
-            'ignoring deprecated <meta name="monetization"> tag, ' +
-            'using only monetization <link rel="monetization"> tags consistently'
+            'A `<link rel="monetization">` tag has been seen so ' +
+            'ignoring deprecated `<meta name="monetization">` tag and ' +
+            'using only `<link rel="monetization">` tags consistently'
         )
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1542,6 +1542,7 @@ __metadata:
     eslint-plugin-react: 7.24.0
     eslint-plugin-react-hooks: 4.2.0
     eslint-plugin-standard: 5.0.0
+    http-server: ^0.12.3
     husky: 7.0.1
     ilp-plugin-btp: 1.5.0
     ilp-protocol-stream: 2.7.0
@@ -6679,6 +6680,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"basic-auth@npm:^1.0.3":
+  version: 1.1.0
+  resolution: "basic-auth@npm:1.1.0"
+  checksum: a248a4b125e91a188748011ce7583c8d40f55ce222196190e76ae8c3280fbdf6914f509d66123084e549f41f5b36c6fe09e5e8ec72951f5c32b50e9aa7f08b64
+  languageName: node
+  linkType: hard
+
 "batch@npm:0.6.1":
   version: 0.6.1
   resolution: "batch@npm:0.6.1"
@@ -7924,6 +7932,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"colors@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "colors@npm:1.4.0"
+  checksum: 98aa2c2418ad87dedf25d781be69dc5fc5908e279d9d30c34d8b702e586a0474605b3a189511482b9d5ed0d20c867515d22749537f7bc546256c6014f3ebdcec
+  languageName: node
+  linkType: hard
+
 "columnify@npm:1.5.4, columnify@npm:^1.5.4":
   version: 1.5.4
   resolution: "columnify@npm:1.5.4"
@@ -8377,6 +8392,13 @@ __metadata:
   version: 1.0.2
   resolution: "core-util-is@npm:1.0.2"
   checksum: 7a4c925b497a2c91421e25bf76d6d8190f0b2359a9200dbeed136e63b2931d6294d3b1893eda378883ed363cd950f44a12a401384c609839ea616befb7927dab
+  languageName: node
+  linkType: hard
+
+"corser@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "corser@npm:2.0.1"
+  checksum: 9ff6944eda760c8c3118747a636afc3ede53b41e7b9960513a15b88032209a728e630ae4b41e20a941e34da129fe9094d1f5d95123ef64ac2e16cdad8dce9c87
   languageName: node
   linkType: hard
 
@@ -9401,6 +9423,20 @@ __metadata:
   dependencies:
     safe-buffer: ^5.0.1
   checksum: 207f9ab1c2669b8e65540bce29506134613dd5f122cccf1e6a560f4d63f2732d427d938f8481df175505aad94583bcb32c688737bb39a6df0625f903d6d93c03
+  languageName: node
+  linkType: hard
+
+"ecstatic@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "ecstatic@npm:3.3.2"
+  dependencies:
+    he: ^1.1.1
+    mime: ^1.6.0
+    minimist: ^1.1.0
+    url-join: ^2.0.5
+  bin:
+    ecstatic: ./lib/ecstatic.js
+  checksum: 61787fe020a3344b3750fa95fa38f8e5810d6b8cb2626f084a7283c11dde641d204ef19a5e29926d6f0189b2d14780bb6910493b49f9f1e2a0aa39297cc6b1b9
   languageName: node
   linkType: hard
 
@@ -12242,7 +12278,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"he@npm:^1.2.0":
+"he@npm:^1.1.1, he@npm:^1.2.0":
   version: 1.2.0
   resolution: "he@npm:1.2.0"
   bin:
@@ -12483,7 +12519,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"http-proxy@npm:^1.17.0":
+"http-proxy@npm:^1.17.0, http-proxy@npm:^1.18.0":
   version: 1.18.1
   resolution: "http-proxy@npm:1.18.1"
   dependencies:
@@ -12491,6 +12527,27 @@ fsevents@^1.2.7:
     follow-redirects: ^1.0.0
     requires-port: ^1.0.0
   checksum: f5bd96bf83e0b1e4226633dbb51f8b056c3e6321917df402deacec31dd7fe433914fc7a2c1831cf7ae21e69c90b3a669b8f434723e9e8b71fd68afe30737b6a5
+  languageName: node
+  linkType: hard
+
+"http-server@npm:^0.12.3":
+  version: 0.12.3
+  resolution: "http-server@npm:0.12.3"
+  dependencies:
+    basic-auth: ^1.0.3
+    colors: ^1.4.0
+    corser: ^2.0.1
+    ecstatic: ^3.3.2
+    http-proxy: ^1.18.0
+    minimist: ^1.2.5
+    opener: ^1.5.1
+    portfinder: ^1.0.25
+    secure-compare: 3.0.1
+    union: ~0.5.0
+  bin:
+    hs: bin/http-server
+    http-server: bin/http-server
+  checksum: fdd8652638937940ce3e2c2a36f2b92cee57967aaba40552f0d422ba01cbb86c2645aabc73ba89035651ae0e5a02df28f81adce93cf3188236ced7d426b0b036
   languageName: node
   linkType: hard
 
@@ -15796,7 +15853,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"mime@npm:1.6.0":
+"mime@npm:1.6.0, mime@npm:^1.6.0":
   version: 1.6.0
   resolution: "mime@npm:1.6.0"
   bin:
@@ -15906,7 +15963,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.1.1, minimist@npm:^1.1.3, minimist@npm:^1.2.0, minimist@npm:^1.2.5":
+"minimist@npm:^1.1.0, minimist@npm:^1.1.1, minimist@npm:^1.1.3, minimist@npm:^1.2.0, minimist@npm:^1.2.5":
   version: 1.2.5
   resolution: "minimist@npm:1.2.5"
   checksum: 86706ce5b36c16bfc35c5fe3dbb01d5acdc9a22f2b6cc810b6680656a1d2c0e44a0159c9a3ba51fb072bb5c203e49e10b51dcd0eec39c481f4c42086719bae52
@@ -17003,7 +17060,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"opener@npm:^1.5.2":
+"opener@npm:^1.5.1, opener@npm:^1.5.2":
   version: 1.5.2
   resolution: "opener@npm:1.5.2"
   bin:
@@ -17868,7 +17925,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"portfinder@npm:^1.0.26":
+"portfinder@npm:^1.0.25, portfinder@npm:^1.0.26":
   version: 1.0.28
   resolution: "portfinder@npm:1.0.28"
   dependencies:
@@ -18362,6 +18419,15 @@ fsevents@^1.2.7:
   version: 6.7.0
   resolution: "qs@npm:6.7.0"
   checksum: dfd5f6adef50e36e908cfa70a6233871b5afe66fbaca37ecc1da352ba29eb2151a3797991948f158bb37fccde51bd57845cb619a8035287bfc24e4591172c347
+  languageName: node
+  linkType: hard
+
+"qs@npm:^6.4.0":
+  version: 6.10.1
+  resolution: "qs@npm:6.10.1"
+  dependencies:
+    side-channel: ^1.0.4
+  checksum: 00e390dbf98eff4d8ff121b61ab2fe32106852290de99ecd0e40fc76651c4101f43fc6cc8313cb69423563876fc532951b11dda55d2917def05f292258263480
   languageName: node
   linkType: hard
 
@@ -19537,6 +19603,13 @@ resolve@^2.0.0-next.3:
     ajv: ^6.12.5
     ajv-keywords: ^3.5.2
   checksum: 39b4f4601af6f7e92eca2ed700783fcc70e8feb5914588921d3f38e642d1d3726f3e91d250be70112210638768f5da134af64a8fc12abf812f4f1af6780dfb3b
+  languageName: node
+  linkType: hard
+
+"secure-compare@npm:3.0.1":
+  version: 3.0.1
+  resolution: "secure-compare@npm:3.0.1"
+  checksum: 0a8d8d3e54d5772d2cf1c02325f01fc7366d0bd33f964a08a84fe3ee5f34d46435a6ae729c1d239c750e160ef9b58c764d3efb945a1d07faf47978a8e4161594
   languageName: node
   linkType: hard
 
@@ -21822,6 +21895,15 @@ sjcl@sublimator/sjcl:
   languageName: node
   linkType: hard
 
+"union@npm:~0.5.0":
+  version: 0.5.0
+  resolution: "union@npm:0.5.0"
+  dependencies:
+    qs: ^6.4.0
+  checksum: 021530d02363fb7470ce45d4cb06ae28a97d5a245666e6d0fca6bab0673bea8c7988e7d2f8046acfbab120908cedcb099ca216b357d4483bcd96518b39101be0
+  languageName: node
+  linkType: hard
+
 "uniq@npm:^1.0.1":
   version: 1.0.1
   resolution: "uniq@npm:1.0.1"
@@ -21988,6 +22070,13 @@ sjcl@sublimator/sjcl:
   version: 0.1.0
   resolution: "urix@npm:0.1.0"
   checksum: 4c076ecfbf3411e888547fe844e52378ab5ada2d2f27625139011eada79925e77f7fbf0e4016d45e6a9e9adb6b7e64981bd49b22700c7c401c5fc15f423303b3
+  languageName: node
+  linkType: hard
+
+"url-join@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "url-join@npm:2.0.5"
+  checksum: 5c935cc99e5bfd7150302420db4eff9830d117be5ea3edf4b2d9e30a51484bc422e94fd9f2fba78192a75cebe2663735af716e07ec094b9a5f24c75046644c73
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Handles case where tags are seen in quick succession such as (but not limited to) :
* page load, where there is a <meta> tag, then a <link> tag

When this happens, stopMonetization is called on the content script side BEFORE the background page has a chance to send the initial optimistic `pending` event. With this change, the pending event from the background page will be tagged with a requestId and ignored on the content script side when it finally arrives.

https://github.com/coilhq/web-monetization-projects/blob/d3c533c84d5565875432fae5db2894b3f4a3305e/packages/coil-extension/src/content/services/ContentScript.ts#L79-L84
 
https://github.com/coilhq/web-monetization-projects/blob/d3c533c84d5565875432fae5db2894b3f4a3305e/packages/coil-extension/src/content/services/ContentScript.ts#L65-L75

https://github.com/coilhq/web-monetization-projects/blob/d3c533c84d5565875432fae5db2894b3f4a3305e/packages/webmonetization-wext/src/content/DocumentMonetization.ts#L68-L71