### PR TITLE
chore(coil-extension): bump version to 0.0.56

### DIFF
--- a/packages/coil-extension/CHANGELOG.md
+++ b/packages/coil-extension/CHANGELOG.md
@@ -1,4 +1,12 @@
-<a name="coil-extension@0.0.55"></a>
+<a name="coil-extension@0.0.56"></a>
+
+# [coil-extension@0.0.56](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.55...coil-extension@0.0.56) (2021-07-20)
+
+### Bug Fixes
+
+- Fix race condition caused by concurrent startWebMonetization [#2149](https://github.com/coilhq/web-monetization-projects/pull/2149) [#2144](https://github.com/coilhq/web-monetization-projects/issues/2144)
+
+- <a name="coil-extension@0.0.55"></a>
 
 # [coil-extension@0.0.55](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.54...coil-extension@0.0.55) (2021-07-09)
 

--- a/packages/coil-extension/docs/release-checklist.md
+++ b/packages/coil-extension/docs/release-checklist.md
@@ -55,33 +55,34 @@ make sense.
 
   - ![image](https://user-images.githubusercontent.com/525211/71150879-28d04300-2265-11ea-96da-7d720c101575.png)
 
-- [ ] [example.com](http://example.com/) should say "This website is not supported"
+- [ ] [example.com](http://example.com/) should say "This site isn't supported yet"
 
-  - ![image](https://user-images.githubusercontent.com/525211/66626576-f4b42280-ec22-11e9-9f77-4a95be08643e.png)
+  - ![image](https://user-images.githubusercontent.com/525211/126276057-30b8285f-84a5-4e01-ae0e-85b7592883e6.png)
 
 - [ ] [xrptipbot.com](https://www.xrptipbot.com/) should monetize
 
-  - ![image](https://user-images.githubusercontent.com/525211/66626655-3c3aae80-ec23-11e9-981a-0e317ab80b42.png)
+  - ![image](https://user-images.githubusercontent.com/525211/126276225-62af2025-3f43-4a36-a3bc-e141c9a569de.png)
 
+-
 - [ ] [twitch.tv](https://twitch.tv/vinesauce) works
 
-  - ![image](https://user-images.githubusercontent.com/525211/66626721-815ee080-ec23-11e9-8139-59a563822eb0.png)
+  - ![image](https://user-images.githubusercontent.com/525211/126276355-63815894-47e6-4f69-8308-8ceeb43cb73b.png)
 
 - [ ] [monetized youtube video](https://www.youtube.com/watch?v=-QMbZx_w2_Y)
 
-  - ![image](https://user-images.githubusercontent.com/525211/66626878-0a761780-ec24-11e9-8015-19bf8348807b.png)
+  - ![image](https://user-images.githubusercontent.com/525211/126276573-a27425ab-884a-4612-99cb-ef12d452e75e.png)
 
 - Coil welcome and welcome to explore pages
 
   - [ ] Go to coil.com, the browser action popup should show welcome to coil
-    - ![image](https://user-images.githubusercontent.com/525211/66626988-6b9deb00-ec24-11e9-86c3-b55c17e891c2.png)
-  - [ ] Should have a link to coil.com/explore page
+    - ![image](https://user-images.githubusercontent.com/525211/126276719-692355e3-f571-4b08-8816-9b0715688d71.png)
+  - [ ] Should have a link to coil.com/discover page
   - [ ] Once on explore page should show `Discover Now` with a rocket-ship graphic
-    - ![image](https://user-images.githubusercontent.com/525211/66627053-a2740100-ec24-11e9-8759-76f40c46d6fa.png)
+    - ![image](https://user-images.githubusercontent.com/525211/126276807-f39ac03f-6c2b-419c-8a79-e2f2859b44a9.png)
 
 - [ ] Check the monetization animation works properly
 
-  - ![image](https://user-images.githubusercontent.com/525211/66627467-04813600-ec26-11e9-855a-517700af4e26.png)
+  - ![image](https://user-images.githubusercontent.com/525211/126277022-48e139b6-871a-4ed4-8d45-58e194855ff8.png)
   - Only required on desktop browsers
   - Should animate when monetized and packets received
   - Should stop animation when network disconnected
@@ -101,16 +102,16 @@ make sense.
 
   - Log out from \$coildomain.com
   - Check that icon is in 'unavailable' state
-    - ![image](https://user-images.githubusercontent.com/525211/66627206-2a5a0b00-ec25-11e9-9c0c-74dc34370e13.png)
+    - ![image](https://user-images.githubusercontent.com/525211/126277431-a7ae73a2-14a6-41b4-90f4-69f2b9be6df5.png)
   - Click on browser action
   - Check that routed to login page
-    - ![image](https://user-images.githubusercontent.com/525211/66627301-6beab600-ec25-11e9-8045-a4e35686dc34.png)
+    - ![image](https://user-images.githubusercontent.com/525211/126277570-77da3644-9950-465d-bac0-4afbd33a70e4.png)
 
 - [ ] Popup icon should show if page is monetized even when logged out
 
   - Log out from extension
   - Go to a monetized page and check that the icon "monetized" black and in 'unavailable' state
-    - ![image](https://user-images.githubusercontent.com/525211/70715784-8f150d00-1d1d-11ea-8f82-fe116b2e9a16.png)
+    - ![image](https://user-images.githubusercontent.com/525211/126277839-d482fea3-63bc-42d8-9dae-6eca318cdc63.png)
 
 - [ ] Run the puppeteer [tests](./test.sh) (look at the [circle jobs](../../../.circleci/config.yml))
 
@@ -125,13 +126,13 @@ make sense.
 
 - [ ] Go to [xrptipbot.com](https://www.xrptipbot.com/) and as page
       is loading very quickly open the popup.
-      It should show "This page is Web-Monetized" even before streaming
+      It should show "Thanks for your support" even before streaming
       starts. Should show 'setting up payment' then 'coil is paying creator'
       [#120][i120]
 
 - [ ] Open the [reloading-every-15s.html](../test/fixtures/reloading-every-15s.html) file:
 
-  - Use a localhost server so WM works (e.g. with `python -m http.server 4000`)
+  - Use a localhost server so WM works (e.g. with `yarn serve:fixtures`)
   - Open the developer tools console undocked so can view while **PAGE IS BACKGROUNDED**
     - Note the `Reloading page` logging
   - Open the extension background page developer tools and look at the stream logging

--- a/packages/coil-extension/manifest.json
+++ b/packages/coil-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Coil",
   "description": "Support websites and creators with Web Monetization",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "manifest_version": 2,
   "content_security_policy": "script-src 'self' 'sha256-ZB4S3fpmqhkYmY2fAkJhOuCiCW9xtnSo9QaJPSzPH7Q='; object-src 'self'",
   "browser_specific_settings": {

--- a/packages/coil-extension/package.json
+++ b/packages/coil-extension/package.json
@@ -41,7 +41,9 @@
     "prettier": "prettier --write '*.{ts,tsx,js,html,jsx,md}' '{src,test}/**/*.{ts,tsx,js,html,jsx,md}'",
     "publish:preview": "WEXT_SHIPIT_CHROME_EXTENSION_ID=iehmfkldnblennopinmmagfidpflefkp WEXT_MANIFEST_SUFFIX=Preview ./scripts/publish-coildev-chrome-store.sh",
     "publish:dev": "./scripts/publish-coildev-chrome-store.sh",
+    "serve:dist": "http-server -p 4000 dist",
     "serve:fixtures": "http-server -p 4000 test/fixtures",
+    "serve:fixtures-iframes": "http-server -p 4000 test/fixtures/iframes",
     "test": "jest --passWithNoTests",
     "test:coverage": "yarn test --verbose --coverage",
     "upkeep": "cd ../.. && yarn upkeep"

--- a/packages/coil-extension/package.json
+++ b/packages/coil-extension/package.json
@@ -1,10 +1,10 @@
 {
   "$schema": "../coil-monorepo-upkeep/resources/package-json-schema-nested-overrides.json",
   "$overRideUpKeep": {
-    "version": "0.0.55"
+    "version": "0.0.56"
   },
   "name": "@coil/extension",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "keywords": [
     "ilp",
     "web-monetization"

--- a/packages/coil-extension/six-apktool-decoded/apktool.yml
+++ b/packages/coil-extension/six-apktool-decoded/apktool.yml
@@ -18,5 +18,5 @@ usesFramework:
   tag: null
 version: 2.4.1
 versionInfo:
-  versionCode: '56'
-  versionName: 0.0.55
+  versionCode: '57'
+  versionName: 0.0.56

--- a/packages/coil-extension/src/background/services/ActiveTabLogger.ts
+++ b/packages/coil-extension/src/background/services/ActiveTabLogger.ts
@@ -1,6 +1,7 @@
 import { inject, injectable } from 'inversify'
 
 import * as tokens from '../../types/tokens'
+import { FrameSpec } from '../../types/FrameSpec'
 
 @injectable()
 export class ActiveTabLogger {
@@ -11,7 +12,7 @@ export class ActiveTabLogger {
     private api = chrome
   ) {}
 
-  log(log: string) {
+  log(log: string, frame?: FrameSpec) {
     if (!this.sendLogs) {
       return
     }
@@ -24,7 +25,7 @@ export class ActiveTabLogger {
             log: log
           }
         }
-        this.api.tabs.sendMessage(tab.id, message)
+        this.api.tabs.sendMessage(frame?.tabId ?? tab.id, message)
       }
     })
   }

--- a/packages/coil-extension/src/background/services/TabStates.ts
+++ b/packages/coil-extension/src/background/services/TabStates.ts
@@ -133,11 +133,11 @@ export class TabStates {
   logLastMonetizationCommand(
     frame: FrameSpec,
     command: MonetizationCommand,
-    requestId: string
+    requestId?: string
   ) {
     this.setFrame(frame, {
       lastMonetization: {
-        requestId: requestId,
+        requestId: requestId || null,
         command
       }
     })

--- a/packages/coil-extension/src/content/services/ContentScript.ts
+++ b/packages/coil-extension/src/content/services/ContentScript.ts
@@ -238,7 +238,10 @@ export class ContentScript {
       pause: (reason: string) => {
         this.paused = true
         const pause: PauseWebMonetization = {
-          command: 'pauseWebMonetization'
+          command: 'pauseWebMonetization',
+          data: {
+            requestId: this.monetization.getMonetizationRequest()?.requestId
+          }
         }
         runtime.sendMessage(pause)
       },
@@ -246,7 +249,10 @@ export class ContentScript {
         debug(`resumeWebMonetization reason ${reason}`)
         this.paused = false
         const resume: ResumeWebMonetization = {
-          command: 'resumeWebMonetization'
+          command: 'resumeWebMonetization',
+          data: {
+            requestId: this.monetization.getMonetizationRequest()?.requestId
+          }
         }
         runtime.sendMessage(resume)
       }
@@ -262,7 +268,10 @@ export class ContentScript {
         this.doStartMonetization().then(() => {
           if (this.paused) {
             const pause: PauseWebMonetization = {
-              command: 'pauseWebMonetization'
+              command: 'pauseWebMonetization',
+              data: {
+                requestId: monetizationRequest.requestId
+              }
             }
             this.runtime.sendMessage(pause)
           }

--- a/packages/coil-extension/src/types/commands.ts
+++ b/packages/coil-extension/src/types/commands.ts
@@ -65,6 +65,9 @@ export interface AdaptedPageDetails extends Command {
  */
 export interface PauseWebMonetization extends Command {
   command: 'pauseWebMonetization'
+  data: {
+    requestId?: string
+  }
 }
 
 /**
@@ -73,6 +76,9 @@ export interface PauseWebMonetization extends Command {
  */
 export interface ResumeWebMonetization extends Command {
   command: 'resumeWebMonetization'
+  data: {
+    requestId?: string
+  }
 }
 
 /**

--- a/packages/coil-extension/test/fixtures/event-logger.html
+++ b/packages/coil-extension/test/fixtures/event-logger.html
@@ -5,7 +5,7 @@
     <meta
       id="money"
       name="monetization"
-      content="$twitter.xrptipbot.com/Coil"
+      content="$ilp.uphold.com/gRa4mXFEMYrL"
     />
     <script>
       if (document.monetization) {
@@ -51,7 +51,7 @@
             const meta = document.createElement('meta')
             meta.id = 'money'
             meta.name = 'monetization'
-            meta.content = '$twitter.xrptipbot.com/Coil'
+            meta.content = '$ilp.uphold.com/gRa4mXFEMYrL'
             document.head.appendChild(meta)
             document.getElementById('remove').disabled = false
             document.getElementById('add').disabled = true
@@ -64,7 +64,7 @@
             setTimeout(() => {
               remove()
               add()
-            }, 5000)
+            }, 10000)
           }
         // removeThenAddQuicklyToCheckStoppedEventHasCorrectRequestId()
 

--- a/packages/coil-oauth-scripts/src/bin/coil-it.ts
+++ b/packages/coil-oauth-scripts/src/bin/coil-it.ts
@@ -36,7 +36,8 @@ async function getPaymentDetails(
 
 function startStream(
   id: number | string,
-  connection: IlpStream.Connection
+  connection: IlpStream.Connection,
+  dbg: typeof console.log
 ): IlpStream.DataAndMoneyStream {
   const startedAt = Date.now()
   let last = startedAt
@@ -93,6 +94,14 @@ async function main(): Promise<void> {
     throw new Error('Must set COIL_USER and COIL_PASSWORD env vars')
   }
 
+  const startedAt = Date.now()
+  let latest = startedAt
+  const dbg = (...args: any[]) => {
+    const now = Date.now()
+    console.log(`(t=${now - startedAt}ms, d=${now - latest}ms)`, ...args)
+    latest = now
+  }
+
   const argv = process.argv.slice(2)
   const paymentPointer = argv[0] || '$twitter.xrptipbot.com/nfcpasses'
   const { token, btpToken } = await login()
@@ -108,6 +117,7 @@ async function main(): Promise<void> {
     btpToken
   })
   const monetizationId = uuid.v4()
+  dbg('Getting payment details')
   const details = await getPaymentDetails(spspUrl, monetizationId)
   dbg({ details })
 
@@ -131,7 +141,7 @@ async function main(): Promise<void> {
   dbg('Creating connection')
   await connection.connect()
   dbg('Connected')
-  startStream(`main`, connection)
+  startStream(`main`, connection, dbg)
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## Chores

- [x] Make sure the manifest version was bumped but doesn't skip versions

- [x] Update the [apktool.yml](../six-apktool-decoded/apktool.yml) versionCode/versionName
      and commit it to the repository.

- [x] Update the [CHANGELOG.md](../CHANGELOG.md)

  - You can compare with latest commit before tagging via something like:
    `https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.48...8f359e45f843a4f9a01c090a02e73519413d900b`

## MacOS Chrome

- [x] Build for prod with release settings

  - e.g. `yarn build-prod chrome -p --run-prod --devtool=none`
    - as per [package.sh](../package.sh)

- [x] Import unpacked/temporary extension/add-on

  - For Firefox, go to `about:debugging`
    - Enable add-on debugging
    - Load Temporary Add-on...
  - For Chrome or MS Edge, go to `chrome://extensions` (or `edge://extensions`) and `Load Unpacked`
  - Use `adb` to install Samsung Internet Extensions
    - be sure to kill the browser and delete shared settings to be sure correct addon is tested
    - see code in `scripts/reinstall-six.sh`

- [x] Ensure that you are [logged in with a user with valid subscription](https://coil.com/settings/membership)

  - ![image](https://user-images.githubusercontent.com/525211/71150879-28d04300-2265-11ea-96da-7d720c101575.png)

- [x] [example.com](http://example.com/) should say "This site isn't supported yet"

  - ![image](https://user-images.githubusercontent.com/525211/126276057-30b8285f-84a5-4e01-ae0e-85b7592883e6.png)

- [x] [xrptipbot.com](https://www.xrptipbot.com/) should monetize

  - ![image](https://user-images.githubusercontent.com/525211/126276225-62af2025-3f43-4a36-a3bc-e141c9a569de.png)

- [x] [twitch.tv](https://twitch.tv/vinesauce) works

  - ![image](https://user-images.githubusercontent.com/525211/126276355-63815894-47e6-4f69-8308-8ceeb43cb73b.png)

- [x] [monetized youtube video](https://www.youtube.com/watch?v=-QMbZx_w2_Y)

  - ![image](https://user-images.githubusercontent.com/525211/126276573-a27425ab-884a-4612-99cb-ef12d452e75e.png)

- Coil welcome and welcome to explore pages

  - [x] Go to coil.com, the browser action popup should show welcome to coil
    - ![image](https://user-images.githubusercontent.com/525211/126276719-692355e3-f571-4b08-8816-9b0715688d71.png)
  - [x] Should have a link to coil.com/explore page
  - [x] Once on explore page should show `Discover Now` with a rocket-ship graphic
    - ![image](https://user-images.githubusercontent.com/525211/126276807-f39ac03f-6c2b-419c-8a79-e2f2859b44a9.png)

- [x] Check the monetization animation works properly

  - ![image](https://user-images.githubusercontent.com/525211/126277022-48e139b6-871a-4ed4-8d45-58e194855ff8.png)
  - Only required on desktop browsers
  - Should animate when monetized and packets received
  - Should stop animation when network disconnected
    - Note that on Firefox/MacOS the popup automatically closes when the
      tab loses focus so can use something like this in terminal:
      - `sudo sleep 10 && sudo ifconfig en0 down && sleep 10 && sudo ifconfig en0 up`

- [x] Check monetization works consistently

  - In the same tab, go to http://www.travisvcrist.com/gatehub
    - refresh and make sure streaming works 10 times in a row
      - should not get 'stuck' in 'setting up payment' state
  - Issue: [coil/coilhq#3038][ci3038]
  - Fix PRs: [#242][np242]

- [x] Will route to \$coildomain.com/login rather than open popup if logged out

  - Log out from \$coildomain.com
  - Check that icon is in 'unavailable' state
    - ![image](https://user-images.githubusercontent.com/525211/126277431-a7ae73a2-14a6-41b4-90f4-69f2b9be6df5.png)
  - Click on browser action
  - Check that routed to login page
    - ![image](https://user-images.githubusercontent.com/525211/126277570-77da3644-9950-465d-bac0-4afbd33a70e4.png)

- [x] Popup icon should show if page is monetized even when logged out

  - Log out from extension
  - Go to a monetized page and check that the icon "monetized" black and in 'unavailable' state
    - ![image](https://user-images.githubusercontent.com/525211/126277839-d482fea3-63bc-42d8-9dae-6eca318cdc63.png)

- [x] Go to a [youtube video](https://www.youtube.com/watch?v=l1btEwwRePs),
      manually skip to near end of video, and when autoplay of a video from
      another channel starts, check that monetization has stopped.

  - Issues: [#33][i33]
  - PRs: [#213][np213]

- [x] Go to [xrptipbot.com](https://www.xrptipbot.com/) and as page
      is loading very quickly open the popup.
      It should show "This page is Web-Monetized" even before streaming
      starts. Should show 'setting up payment' then 'coil is paying creator'
      [#120][i120]

- [x] Open the [reloading-every-15s.html](../test/fixtures/reloading-every-15s.html) file:

  - Use a localhost server so WM works (e.g. with `python -m http.server 4000`)
  - Open the developer tools console undocked so can view while **PAGE IS BACKGROUNDED**
    - Note the `Reloading page` logging
  - Open the extension background page developer tools and look at the stream logging
  - SHOULD NOT initiate a stream or SPSP request
    [#144][i144]
  - *TESTERS NOTE* This fails

- [x] Open the [event-logger.html](../test/fixtures/event-logger.html) file:

  - Use a localhost server so WM works (e.g. with `python -m http.server 4000`)
  - Look for unusual timings, check that pending state is emitted nearly
    immediately after page load or meta tag added
  - Issue: [#63][ni63]
  - Fix PR: [#69][np69]

- [x] Check started event fires when quickly switching between tabs

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Switch to another (non-monetized) tab. The payments stop. Quickly switch back to the first tab.
  - The payments restart. Make sure there is a monetizationstart event
  - Issue: [#105][ni105]
  - Fix PR: [#117][np117]

- [x] Check stopped event fires with correct requestId

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Induce a stop/start in same js 'tick'
  - Check that the stopped event has the correct requestId
  - Issue: [#127][ni127]
  - Fix PR: [#128][np128]

- [x] Check tip event fires when clicked on in the popup

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Open the extension popup and click on "Tip this creator \$1!"
  - Check that the tip event occurs

- [x] Run a local web server (e.g. with `python -m http.server 4000`) serving
      the dist folder, then open [static/popup.html](static/popup.html) in a
      normal tab and check the popup rendering in various states.

- [x] On MacOS Chromium browsers (Chrome/Edge) check that the monetized animation is working
      on non primary monitors.

  - Issue: [#312][i312]
  - Fix PR: [#317][p317]

- [x] Check that popup closes when another window is focused

  - Open two Browser windows, open the popup in one window
  - Focus on second window
  - Ensure that popup is closed

  - Issue: [#313][i313]
  - Fix PR: [#332][p332]

- [x] Check SPA apps keep streaming when url changed, meta stays

  - Go to e.g. https://www.wevolver.com/
  - Change other pages which uses HTML5 history.pushState
  - Check that streaming is maintained throughout

    - if not, use browser devtools to check if meta exists
      - `document.head.querySelector('meta[name="monetization"]')`

  - Issue: [#507][i507]
  - Fix PR: [#508][p508]

- [x] Check extension doesn't attempt to stream when unsubscribed

  - Log in with coil user that doesn't have active subscription
  - Open the developer tools and check the logging
  - SHOULD NOT even attempt to stream
  - ![image](https://user-images.githubusercontent.com/525211/66631124-c9840000-ec2f-11e9-95a4-3bebe7fdebd6.png)
  - Issue: [#213][i213]
  - Fix PR: [#222][p222]

- [x] Check no stop event is fired when logged out

  - Open and console and set `localStorage.WM_DEBUG = true`
  - Go to a web monetized page when logged out
  - Check that no events are logged

  - Issue: [#1947][ni1947]
  - Fix PR: [#1964][np1964]

[i33]: https://github.com/coilhq/web-monetization/issues/33
[i120]: https://github.com/coilhq/web-monetization/issues/120
[i144]: https://github.com/coilhq/web-monetization/issues/144
[p166]: https://github.com/coilhq/web-monetization/pull/166
[i213]: https://github.com/coilhq/web-monetization/issues/213
[p222]: https://github.com/coilhq/web-monetization/pull/222
[p295]: https://github.com/coilhq/web-monetization/pull/295
[ci2084]: https://github.com/coilhq/coil/issues/2084
[ci3038]: https://github.com/coilhq/coil/issues/3038
[i312]: https://github.com/coilhq/web-monetization/issues/312
[p317]: https://github.com/coilhq/web-monetization/pull/317
[i313]: https://github.com/coilhq/web-monetization/issues/313
[p332]: https://github.com/coilhq/web-monetization/pull/332
[i507]: https://github.com/coilhq/web-monetization/issues/507
[p508]: https://github.com/coilhq/web-monetization/pull/508
[np28]: https://github.com/coilhq/web-monetization-projects/pull/28
[ni21]: https://github.com/coilhq/web-monetization-projects/issue/21
[ni63]: https://github.com/coilhq/web-monetization-projects/issue/63
[np69]: https://github.com/coilhq/web-monetization-projects/pull/69
[ni105]: https://github.com/coilhq/web-monetization-projects/issue/105
[np117]: https://github.com/coilhq/web-monetization-projects/pull/117
[ni127]: https://github.com/coilhq/web-monetization-projects/issue/127
[np128]: https://github.com/coilhq/web-monetization-projects/pull/128
[ni184]: https://github.com/coilhq/web-monetization-projects/issue/184
[np185]: https://github.com/coilhq/web-monetization-projects/pull/185
[np213]: https://github.com/coilhq/web-monetization-projects/pull/213
[np242]: https://github.com/coilhq/web-monetization-projects/pull/242
[np1964]: https://github.com/coilhq/web-monetization-projects/pull/1964
[ni1947]: https://github.com/coilhq/web-monetization-projects/issue/1947
