### PR TITLE
feat: update tipping views

### DIFF
--- a/packages/coil-extension/src/popup/Index.tsx
+++ b/packages/coil-extension/src/popup/Index.tsx
@@ -20,7 +20,7 @@ export function Index(props: {
     <PopupHostContext.Provider value={props.host}>
       <StoreContext.Provider value={store}>
         <RouterProvider>
-          <TipProvider>
+          <TipProvider storage={props.storage}>
             {/* should replace ViewRouter with  NewExtension when done -> rename the NewExtension to something like App */}
             <ViewRouter />
           </TipProvider>

--- a/packages/coil-extension/src/popup/Index.tsx
+++ b/packages/coil-extension/src/popup/Index.tsx
@@ -8,6 +8,7 @@ import { PopupHostContext } from './context/popupHostContext'
 import { StoreContext, useStoreState } from './context/storeContext'
 import { ViewRouter } from './components/views/ViewRouter'
 import { RouterProvider } from './context/routerContext'
+import { TipProvider } from './context/tipContext'
 
 export function Index(props: {
   storage: Pick<StorageService, 'get'>
@@ -19,8 +20,10 @@ export function Index(props: {
     <PopupHostContext.Provider value={props.host}>
       <StoreContext.Provider value={store}>
         <RouterProvider>
-          {/* should replace ViewRouter with  NewExtension when done -> rename the NewExtension to something like App */}
-          <ViewRouter />
+          <TipProvider>
+            {/* should replace ViewRouter with  NewExtension when done -> rename the NewExtension to something like App */}
+            <ViewRouter />
+          </TipProvider>
         </RouterProvider>
       </StoreContext.Provider>
     </PopupHostContext.Provider>

--- a/packages/coil-extension/src/popup/NewExtension.tsx
+++ b/packages/coil-extension/src/popup/NewExtension.tsx
@@ -9,8 +9,8 @@ import { Router } from './components/views/Router'
 const AppContainer = styled('div')({
   width: '308px',
   maxWidth: '308px',
-  height: '455px',
-  maxHeight: '455px',
+  height: '457px',
+  maxHeight: '457px',
   position: 'relative',
   overflow: 'hidden',
   background: '#FFFFFF',

--- a/packages/coil-extension/src/popup/components/AmountInput.tsx
+++ b/packages/coil-extension/src/popup/components/AmountInput.tsx
@@ -2,9 +2,10 @@ import React, { useState, useRef, useEffect } from 'react'
 import { styled } from '@material-ui/core'
 
 import { Colors } from '../../shared-theme/colors'
+import { useStore } from '../context/storeContext'
+import { useTip } from '../context/tipContext'
 
 import { IncDecButton, IncDec } from './IncDecButton'
-import { ITipView } from './views/TipRouter'
 
 //
 // Styles
@@ -59,17 +60,9 @@ const Input = styled('input')({
 })
 
 //
-// Models
-//
-interface IAmountInput extends Omit<ITipView, 'context' | 'setTipProcessStep'> {
-  minimumTipLimit: number
-  remainingDailyAmount: number
-}
-
-//
 // Component
 //
-export const AmountInput = (props: IAmountInput): React.ReactElement => {
+export const AmountInput = (): React.ReactElement => {
   const defaultFontSize = 64
   const characterSpacing = 0.6
   const maxAmountWidth = 160
@@ -79,12 +72,10 @@ export const AmountInput = (props: IAmountInput): React.ReactElement => {
   const [isUserInput, setIsUserInput] = useState<boolean>(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const {
-    currentTipAmount,
-    setCurrentTipAmount,
-    minimumTipLimit,
-    remainingDailyAmount
-  } = props
+  const { user } = useStore()
+  const { remainingDailyAmount = 0, minimumTipLimit = 1 } =
+    user?.tipSettings || {}
+  const { currentTipAmount, setCurrentTipAmount } = useTip()
 
   // set focus to the input field when it loads. Cannot use 'autoFocus' because eslint-plugin-jsx-a11y
   useEffect(() => {
@@ -120,7 +111,7 @@ export const AmountInput = (props: IAmountInput): React.ReactElement => {
       containsDecimal = true
     }
 
-    // handle if the value is above the minimum
+    // handle if the value is below the minimum
     let value = Number(e.target.value)
     if (value < minimumTipLimit || isNaN(value)) {
       value = minimumTipLimit
@@ -176,13 +167,7 @@ export const AmountInput = (props: IAmountInput): React.ReactElement => {
 
   return (
     <CurrentAmountWrapper>
-      <IncDecButton
-        type={IncDec.Dec}
-        currentTipAmount={currentTipAmount}
-        setCurrentTipAmount={setCurrentTipAmount}
-        minimumTipLimit={minimumTipLimit}
-        remainingDailyAmount={remainingDailyAmount}
-      />
+      <IncDecButton type={IncDec.Dec} />
       {isUserInput ? (
         // render tip manual input
         <InputWrapper size={displayFontSize}>
@@ -208,13 +193,7 @@ export const AmountInput = (props: IAmountInput): React.ReactElement => {
             : currentTipAmount.toFixed(2)}
         </Amount>
       )}
-      <IncDecButton
-        type={IncDec.Inc}
-        currentTipAmount={currentTipAmount}
-        setCurrentTipAmount={setCurrentTipAmount}
-        minimumTipLimit={minimumTipLimit}
-        remainingDailyAmount={remainingDailyAmount}
-      />
+      <IncDecButton type={IncDec.Inc} />
     </CurrentAmountWrapper>
   )
 }

--- a/packages/coil-extension/src/popup/components/AmountInput.tsx
+++ b/packages/coil-extension/src/popup/components/AmountInput.tsx
@@ -12,7 +12,7 @@ import { ITipView } from './views/TipRouter'
 const CurrentAmountWrapper = styled('div')({
   display: 'flex',
   alignItems: 'center',
-  justifyContent: 'space-around',
+  justifyContent: 'space-between',
   height: '62px'
 })
 

--- a/packages/coil-extension/src/popup/components/Header.tsx
+++ b/packages/coil-extension/src/popup/components/Header.tsx
@@ -34,7 +34,7 @@ export const Header: React.FC = props => {
     <HeaderContainer>
       <CoilLogo />
       <HeaderTitle>{props.children}</HeaderTitle>
-      <CloseButton>
+      <CloseButton onClick={() => window.close()}>
         <CloseRoundedIcon />
       </CloseButton>
     </HeaderContainer>

--- a/packages/coil-extension/src/popup/components/HotkeyAmountButtons.tsx
+++ b/packages/coil-extension/src/popup/components/HotkeyAmountButtons.tsx
@@ -5,7 +5,7 @@ import { Colors } from '../../shared-theme/colors'
 import { useStore } from '../context/storeContext'
 import { useTip } from '../context/tipContext'
 import { useRouter } from '../context/routerContext'
-import { ROUTES } from '../contants'
+import { ROUTES } from '../constants'
 
 import { TipProcessStep } from './views/TipRouter'
 

--- a/packages/coil-extension/src/popup/components/HotkeyAmountButtons.tsx
+++ b/packages/coil-extension/src/popup/components/HotkeyAmountButtons.tsx
@@ -16,9 +16,9 @@ const HotkeyButtonsWrapper = styled('div')({
 const HotkeyButton = styled('button')({
   cursor: 'pointer',
   border: 'none',
-  borderRadius: '10px',
-  backgroundColor: Colors.Grey100,
-  color: Colors.Grey500,
+  borderRadius: '100px',
+  backgroundColor: Colors.Violet10,
+  color: Colors.Violet700,
   fontFamily: 'CircularStd',
   fontWeight: 'bold',
   fontSize: '16px',
@@ -28,7 +28,11 @@ const HotkeyButton = styled('button')({
   width: '54px',
   flex: '1',
   '&:hover': {
-    backgroundColor: Colors.Grey800,
+    backgroundColor: Colors.Violet400,
+    color: '#FFFFFF'
+  },
+  '&:active': {
+    backgroundColor: Colors.Violet700,
     color: '#FFFFFF'
   },
   '&:disabled': {

--- a/packages/coil-extension/src/popup/components/HotkeyAmountButtons.tsx
+++ b/packages/coil-extension/src/popup/components/HotkeyAmountButtons.tsx
@@ -2,8 +2,13 @@ import React from 'react'
 import { styled } from '@material-ui/core'
 
 import { Colors } from '../../shared-theme/colors'
+import { useStore } from '../context/storeContext'
+import { useTip } from '../context/tipContext'
+import { useRouter } from '../context/routerContext'
+import { ROUTES } from '../contants'
 
 import { TipProcessStep } from './views/TipRouter'
+
 //
 // Styles
 //
@@ -46,31 +51,17 @@ const HotkeyButton = styled('button')({
 })
 
 //
-// Models
-//
-interface IHotkeyAmountButtons {
-  hotkeyTipAmounts: Array<number>
-  remainingDailyAmount: number
-  setCurrentTipAmount: (amount: number) => void
-  setTipProcessStep: (step: TipProcessStep) => void
-}
-
-//
 // Component
 //
-export const HotkeyAmountButtons = (
-  props: IHotkeyAmountButtons
-): React.ReactElement => {
-  const {
-    setCurrentTipAmount,
-    setTipProcessStep,
-    hotkeyTipAmounts,
-    remainingDailyAmount
-  } = props
+export const HotkeyAmountButtons = (): React.ReactElement => {
+  const router = useRouter()
+  const { user } = useStore()
+  const { hotkeyTipAmounts, remainingDailyAmount } = user?.tipSettings || {}
+  const { setCurrentTipAmount } = useTip()
 
   const handleSelectAmount = (amount: number) => {
     setCurrentTipAmount(amount)
-    setTipProcessStep(TipProcessStep.TIP_CONFIRM)
+    router.to(ROUTES.tippingConfirm)
   }
   return (
     <HotkeyButtonsWrapper>

--- a/packages/coil-extension/src/popup/components/HotkeyAmountButtons.tsx
+++ b/packages/coil-extension/src/popup/components/HotkeyAmountButtons.tsx
@@ -56,7 +56,7 @@ const HotkeyButton = styled('button')({
 export const HotkeyAmountButtons = (): React.ReactElement => {
   const router = useRouter()
   const { user } = useStore()
-  const { hotkeyTipAmounts, remainingDailyAmount } = user?.tipSettings || {}
+  const { hotkeyTipAmounts, remainingDailyAmount = 0 } = user?.tipSettings || {}
   const { setCurrentTipAmount } = useTip()
 
   const handleSelectAmount = (amount: number) => {
@@ -65,7 +65,7 @@ export const HotkeyAmountButtons = (): React.ReactElement => {
   }
   return (
     <HotkeyButtonsWrapper>
-      {hotkeyTipAmounts.map((amount: number, index: number) => {
+      {hotkeyTipAmounts?.map((amount: number, index: number) => {
         return (
           <HotkeyButton
             key={`pdt-${index}`}

--- a/packages/coil-extension/src/popup/components/IncDecButton.tsx
+++ b/packages/coil-extension/src/popup/components/IncDecButton.tsx
@@ -12,20 +12,23 @@ const IncDecButtonWrapper = styled('button')({
   height: '32px',
   border: 'none',
   borderRadius: '32px',
-  backgroundColor: Colors.Grey100,
-  color: Colors.Grey500,
+  backgroundColor: 'transparent',
+  color: Colors.Grey800,
   flexShrink: 0,
   display: 'flex',
   alignItems: 'center',
   outline: 'none',
   justifyContent: 'center',
   '&:hover': {
-    backgroundColor: Colors.Grey800,
-    color: '#FFFFFF'
+    backgroundColor: Colors.Violet10,
+    color: Colors.Violet700
+  },
+  '&:active': {
+    backgroundColor: Colors.Violet200,
+    color: Colors.Violet700
   },
   '&:disabled': {
     color: Colors.Grey100,
-    backgroundColor: Colors.Grey50,
     cursor: 'not-allowed'
   }
 })

--- a/packages/coil-extension/src/popup/components/RandomThankYouMessage.tsx
+++ b/packages/coil-extension/src/popup/components/RandomThankYouMessage.tsx
@@ -17,11 +17,21 @@ const RandomMessageWrapper = styled('div')({
 export const RandomThankYouMessage = () => {
   const [random, setRandom] = useState<number>(0)
 
+  // const messagesArray = [
+  //   'Thanks for your support! \n ❤️💸❤️',
+  //   'You are a rockstar 🤘\n Thank you for your support.',
+  //   'Woohoo!!! You made my day.',
+  //   'Make it rain!'
+  // ]
+
   const messagesArray = [
-    'Thanks for your support! \n ❤️💸❤️',
-    'You are a rockstar 🤘\n Thank you for your support.',
-    'Woohoo!!! You made my day.',
-    'Make it rain!'
+    'Thanks for the tip!',
+    'Thanks for tipping',
+    'Thanks for your support!',
+    'Thanks so much',
+    'Thanks for your generosity',
+    "You're too kind!",
+    "You're awesome!"
   ]
 
   useEffect(() => {

--- a/packages/coil-extension/src/popup/components/TipWarning.tsx
+++ b/packages/coil-extension/src/popup/components/TipWarning.tsx
@@ -24,7 +24,7 @@ const WarningWrapper = styled('div')({
 //
 export const TipWarning = (): React.ReactElement => {
   const { user } = useStore()
-  const { remainingDailyAmount } = user?.tipSettings || {}
+  const { remainingDailyAmount = 0 } = user?.tipSettings || {}
   const { currentTipAmount } = useTip()
 
   return (

--- a/packages/coil-extension/src/popup/components/TipWarning.tsx
+++ b/packages/coil-extension/src/popup/components/TipWarning.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { styled } from '@material-ui/core'
 
 import { Colors } from '../../shared-theme/colors'
+import { useStore } from '../context/storeContext'
+import { useTip } from '../context/tipContext'
 
 //
 // Styles
@@ -18,20 +20,13 @@ const WarningWrapper = styled('div')({
 })
 
 //
-// Models
-//
-interface ITipWarning {
-  currentTipAmount: number
-  remainingDailyAmount: number
-}
-
-//
 // Component
 //
-export const TipWarning = (props: ITipWarning): React.ReactElement => {
-  const { currentTipAmount, remainingDailyAmount } = props
+export const TipWarning = (): React.ReactElement => {
+  const { user } = useStore()
+  const { remainingDailyAmount } = user?.tipSettings || {}
+  const { currentTipAmount } = useTip()
 
-  //todo - update link once billing infrastructure is complete and we have a view for changing the limit
   return (
     <WarningWrapper>
       {currentTipAmount >= remainingDailyAmount ? (

--- a/packages/coil-extension/src/popup/components/views/Router.tsx
+++ b/packages/coil-extension/src/popup/components/views/Router.tsx
@@ -5,7 +5,6 @@ import React from 'react'
 import { useRouter } from '../../context/routerContext'
 import { useStore } from '../../context/storeContext'
 import { ROUTES } from '../../constants'
-import { NewHeaderFooterLayout } from '../NewHeaderFooterLayout'
 
 import { SettingsView } from './SettingsView'
 import { StreamingWebMonetizedView } from './StreamingWebMonitizedView'

--- a/packages/coil-extension/src/popup/components/views/Router.tsx
+++ b/packages/coil-extension/src/popup/components/views/Router.tsx
@@ -14,8 +14,9 @@ import { StreamingNoMembershipView } from './StreamingNoMembershipView'
 import { StreamingCoilView } from './StreamingCoilView'
 import { StreamingCoilDiscoverView } from './StreamingCoilDiscoverView'
 import { TipView } from './TipView'
-import { TipRouter } from './TipRouter'
 import { TipConfirmView } from './TipConfirmView'
+import { TipCompleteView } from './TipCompleteView'
+import { TipRouter } from './TipRouter'
 
 //
 // Component
@@ -37,16 +38,12 @@ export const Router = () => {
     // /tipping/confirm
     case ROUTES.tippingConfirm: {
       // /tipping/confirm
-      return <TipRouter />
+      return <TipConfirmView />
     }
     // /tipping/complete
     case ROUTES.tippingComplete: {
-      return (
-        <NewHeaderFooterLayout>
-          <div>tipping complete</div>
-          <button onClick={() => router.to(ROUTES.streaming)}>home</button>
-        </NewHeaderFooterLayout>
-      )
+      // /tipping/complete
+      return <TipRouter />
     }
     // /streaming
     case ROUTES.streaming:

--- a/packages/coil-extension/src/popup/components/views/Router.tsx
+++ b/packages/coil-extension/src/popup/components/views/Router.tsx
@@ -13,6 +13,7 @@ import { StreamingNotWebMonetizedView } from './StreamingNotWebMonetizedView'
 import { StreamingNoMembershipView } from './StreamingNoMembershipView'
 import { StreamingCoilView } from './StreamingCoilView'
 import { StreamingCoilDiscoverView } from './StreamingCoilDiscoverView'
+import { TipRouter } from './TipRouter'
 
 //
 // Component
@@ -28,12 +29,8 @@ export const Router = () => {
     }
     // /tipping
     case ROUTES.tipping: {
-      return (
-        <NewHeaderFooterLayout title='Tip This Site'>
-          <div>Tipping</div>
-          <button onClick={() => router.to(ROUTES.tippingConfirm)}>next</button>
-        </NewHeaderFooterLayout>
-      )
+      // /tipping
+      return <TipRouter />
     }
     // /tipping/confirm
     case ROUTES.tippingConfirm: {

--- a/packages/coil-extension/src/popup/components/views/Router.tsx
+++ b/packages/coil-extension/src/popup/components/views/Router.tsx
@@ -13,7 +13,9 @@ import { StreamingNotWebMonetizedView } from './StreamingNotWebMonetizedView'
 import { StreamingNoMembershipView } from './StreamingNoMembershipView'
 import { StreamingCoilView } from './StreamingCoilView'
 import { StreamingCoilDiscoverView } from './StreamingCoilDiscoverView'
+import { TipView } from './TipView'
 import { TipRouter } from './TipRouter'
+import { TipConfirmView } from './TipConfirmView'
 
 //
 // Component
@@ -30,18 +32,12 @@ export const Router = () => {
     // /tipping
     case ROUTES.tipping: {
       // /tipping
-      return <TipRouter />
+      return <TipView />
     }
     // /tipping/confirm
     case ROUTES.tippingConfirm: {
-      return (
-        <div>
-          tipping confirm
-          <button onClick={() => router.to(ROUTES.tippingComplete)}>
-            next
-          </button>
-        </div>
-      )
+      // /tipping/confirm
+      return <TipRouter />
     }
     // /tipping/complete
     case ROUTES.tippingComplete: {

--- a/packages/coil-extension/src/popup/components/views/Router.tsx
+++ b/packages/coil-extension/src/popup/components/views/Router.tsx
@@ -16,7 +16,6 @@ import { StreamingCoilDiscoverView } from './StreamingCoilDiscoverView'
 import { TipView } from './TipView'
 import { TipConfirmView } from './TipConfirmView'
 import { TipCompleteView } from './TipCompleteView'
-import { TipRouter } from './TipRouter'
 
 //
 // Component
@@ -43,7 +42,7 @@ export const Router = () => {
     // /tipping/complete
     case ROUTES.tippingComplete: {
       // /tipping/complete
-      return <TipRouter />
+      return <TipCompleteView />
     }
     // /streaming
     case ROUTES.streaming:

--- a/packages/coil-extension/src/popup/components/views/SettingsView.tsx
+++ b/packages/coil-extension/src/popup/components/views/SettingsView.tsx
@@ -70,6 +70,7 @@ export const SettingsView = () => {
     coilDomain,
     runtime: { tabOpener }
   } = useHost()
+
   return (
     <NewHeaderFooterLayout title='Settings'>
       <SettingsPageContainer>
@@ -98,23 +99,21 @@ export const SettingsView = () => {
           </div>
         </ProfileContainer>
 
-        <SettingsButton
-          onClick={() => tabOpener(`${coilDomain}/settings/acount`)}
-        >
+        <SettingsButton onClick={tabOpener(`${coilDomain}/settings/acount`)}>
           <PersonIcon />
           <span className='title'>Account</span>
           <span className='icon-open'>
             <ChevronRightRoundedIcon />
           </span>
         </SettingsButton>
-        <SettingsButton onClick={() => tabOpener(`${coilDomain}/discover`)}>
+        <SettingsButton onClick={tabOpener(`${coilDomain}/discover`)}>
           <ExploreIcon />
           <span className='title'>Discover</span>
           <span className='icon-open'>
             <ChevronRightRoundedIcon />
           </span>
         </SettingsButton>
-        <SettingsButton onClick={() => tabOpener(`${coilDomain}/about`)}>
+        <SettingsButton onClick={tabOpener(`${coilDomain}/about`)}>
           <HelpOutlineIcon />
           <span className='title'>About</span>
           <span className='icon-open'>

--- a/packages/coil-extension/src/popup/components/views/TipCompleteView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipCompleteView.tsx
@@ -5,6 +5,7 @@ import { NewHeaderFooterLayout } from '../NewHeaderFooterLayout'
 import { Colors } from '../../../shared-theme/colors'
 import { FitTextWrapper } from '../FitTextWrapper'
 import { RandomThankYouMessage } from '../RandomThankYouMessage'
+import { useTip } from '../../context/tipContext'
 
 //
 // Styles
@@ -31,10 +32,8 @@ const BodyWrapper = styled('div')(({ url }: { url: string }) => ({
 //
 // Component
 //
-export const TipCompleteView = (props: {
-  currentTipAmount: number
-}): React.ReactElement => {
-  const { currentTipAmount } = props
+export const TipCompleteView = (): React.ReactElement => {
+  const { currentTipAmount } = useTip()
 
   const getBackgroundImageUrl = () => {
     let ImgUrl = '/res/Level1.gif'

--- a/packages/coil-extension/src/popup/components/views/TipCompleteView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipCompleteView.tsx
@@ -1,13 +1,7 @@
-/*
-    TipCompleteView
-
-    responsible for rendering the final tip view for users to see how much they just tipped as well as be presented with the 'undo' option.
-*/
-
 import React from 'react'
 import { styled, Box } from '@material-ui/core'
-import CloseIcon from '@material-ui/icons/Close'
 
+import { NewHeaderFooterLayout } from '../NewHeaderFooterLayout'
 import { Colors } from '../../../shared-theme/colors'
 import { FitTextWrapper } from '../FitTextWrapper'
 import { RandomThankYouMessage } from '../RandomThankYouMessage'
@@ -16,12 +10,11 @@ import { RandomThankYouMessage } from '../RandomThankYouMessage'
 // Styles
 //
 
-const ExtensionBodyWrapper = styled('div')(({ url }: { url: string }) => ({
+const BodyWrapper = styled('div')(({ url }: { url: string }) => ({
+  flex: 1,
   display: 'flex',
   flexDirection: 'column',
-  padding: '14px 24px 0px 24px',
-  minHeight: '457px', // based on the first views body height to keep consistent
-  maxHeight: '457px', // based on the first views body height to keep consistent
+  padding: '0px 24px',
   backgroundImage: `url("${url}")`, //* the 'random' prop is needed so the gif animation replays every load
   backgroundSize: '105% 105%',
   backgroundRepeat: 'no-repeat',
@@ -35,19 +28,6 @@ const ExtensionBodyWrapper = styled('div')(({ url }: { url: string }) => ({
   }
 }))
 
-const IconButton = styled('button')({
-  cursor: 'pointer',
-  background: 'transparent',
-  border: 'none',
-  lineHeight: '0px',
-  padding: '0px',
-  marginRight: '-10px',
-  color: Colors.Grey500,
-  '&:hover': {
-    color: Colors.Grey800
-  }
-})
-
 //
 // Component
 //
@@ -55,10 +35,6 @@ export const TipCompleteView = (props: {
   currentTipAmount: number
 }): React.ReactElement => {
   const { currentTipAmount } = props
-
-  const handleClose = () => {
-    window.close()
-  }
 
   const getBackgroundImageUrl = () => {
     let ImgUrl = '/res/Level1.gif'
@@ -79,15 +55,9 @@ export const TipCompleteView = (props: {
   }
 
   return (
-    <div>
-      <ExtensionBodyWrapper url={getBackgroundImageUrl()}>
-        <Box textAlign='right' mb='25px'>
-          <IconButton onClick={handleClose}>
-            <CloseIcon />
-          </IconButton>
-        </Box>
-        <RandomThankYouMessage />
-        <Box my='30px'>
+    <NewHeaderFooterLayout>
+      <BodyWrapper url={getBackgroundImageUrl()}>
+        <Box mt={5} mb={3}>
           <FitTextWrapper defaultFontSize={80}>
             $
             {Number.isInteger(currentTipAmount)
@@ -95,7 +65,8 @@ export const TipCompleteView = (props: {
               : currentTipAmount.toFixed(2)}
           </FitTextWrapper>
         </Box>
-      </ExtensionBodyWrapper>
-    </div>
+        <RandomThankYouMessage />
+      </BodyWrapper>
+    </NewHeaderFooterLayout>
   )
 }

--- a/packages/coil-extension/src/popup/components/views/TipConfirmView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipConfirmView.tsx
@@ -15,7 +15,7 @@ import {
 import { useHost } from '../../context/popupHostContext'
 import { useTip } from '../../context/tipContext'
 import { useRouter } from '../../context/routerContext'
-import { ROUTES } from '../../contants'
+import { ROUTES } from '../../constants'
 
 //
 // Style

--- a/packages/coil-extension/src/popup/components/views/TipConfirmView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipConfirmView.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react'
 import { styled, Box } from '@material-ui/core'
-import { motion } from 'framer-motion'
 
 import { Header } from '../Header'
 import { FitTextWrapper } from '../FitTextWrapper'

--- a/packages/coil-extension/src/popup/components/views/TipConfirmView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipConfirmView.tsx
@@ -13,8 +13,9 @@ import {
   TipPreviewResult
 } from '../../../types/commands'
 import { useHost } from '../../context/popupHostContext'
-
-import { TipProcessStep, ITipView } from './TipRouter'
+import { useTip } from '../../context/tipContext'
+import { useRouter } from '../../context/routerContext'
+import { ROUTES } from '../../contants'
 
 //
 // Style
@@ -59,7 +60,7 @@ const CancelButton = styled('button')({
   backgroundColor: 'transparent',
   color: Colors.Grey500,
   border: 'none',
-  borderRadius: '10px',
+  borderRadius: '100px',
   fontFamily: 'CircularStd',
   fontWeight: 'bold',
   fontSize: '16px',
@@ -76,13 +77,14 @@ const CancelButton = styled('button')({
 //
 // Component
 //
-export const TipConfirmView = (
-  props: Omit<ITipView, 'setCurrentTipAmount'>
-): React.ReactElement => {
+export const TipConfirmView = (): React.ReactElement => {
   const [tipCreditCharge, setTipCreditCharge] = useState(0)
   const [creditCardCharge, setCreditCardCharge] = useState(0)
+
   const { runtime } = useHost()
-  const { currentTipAmount, setTipProcessStep } = props
+
+  const { currentTipAmount } = useTip()
+  const router = useRouter()
 
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
@@ -122,7 +124,7 @@ export const TipConfirmView = (
   }
 
   const handleSubmit = async () => {
-    // setTipProcessStep(TipProcessStep.TIP_COMPLETE)
+    // router.to(ROUTES.tippingComplete)
 
     setSubmitError(null)
     setIsSubmitting(true)
@@ -130,7 +132,7 @@ export const TipConfirmView = (
       const { success } = await sendTip(currentTipAmount)
 
       if (success) {
-        setTipProcessStep(TipProcessStep.TIP_COMPLETE)
+        router.to(ROUTES.tippingComplete)
       } else {
         throw new Error('Something went wrong')
       }
@@ -142,7 +144,7 @@ export const TipConfirmView = (
 
   const handleUndo = () => {
     // reset to tip view
-    setTipProcessStep(TipProcessStep.TIP)
+    router.to(ROUTES.tipping)
   }
 
   useEffect(() => {

--- a/packages/coil-extension/src/popup/components/views/TipConfirmView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipConfirmView.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react'
 import { styled, Box } from '@material-ui/core'
-import CloseIcon from '@material-ui/icons/Close'
 import { motion } from 'framer-motion'
 
+import { Header } from '../Header'
 import { FitTextWrapper } from '../FitTextWrapper'
 import { Colors } from '../../../shared-theme/colors'
 import { TipPaymentDebits } from '../TipPaymentDebits'
@@ -19,13 +19,11 @@ import { TipProcessStep, ITipView } from './TipRouter'
 //
 // Style
 //
-const ExtensionBodyWrapper = styled('div')({
-  padding: '14px 24px 16px 24px',
-  minHeight: '457px', // based on the first views body height to keep consistent
-  maxHeight: '457px', // based on the first views body height to keep consistent
-  background: 'linear-gradient(180deg, #FCFCFC 86.53%, #FFFFFF 97.24%)',
+const ComponentWrapper = styled('div')({
+  flex: '1',
   display: 'flex',
-  flexDirection: 'column'
+  flexDirection: 'column',
+  padding: '0px 24px'
 })
 
 const Button = styled('button')({
@@ -41,7 +39,7 @@ const Button = styled('button')({
   fontSize: '16px',
   letterSpacing: '.5px',
   border: 'none',
-  borderRadius: '10px',
+  borderRadius: '100px',
   '&:hover': {
     backgroundColor: '#000000'
   },
@@ -75,19 +73,6 @@ const CancelButton = styled('button')({
   }
 })
 
-const IconButton = styled('button')({
-  cursor: 'pointer',
-  background: 'transparent',
-  border: 'none',
-  lineHeight: '0px',
-  padding: '0px',
-  marginRight: '-10px',
-  color: Colors.Grey500,
-  '&:hover': {
-    color: Colors.Grey800
-  }
-})
-
 //
 // Component
 //
@@ -99,7 +84,6 @@ export const TipConfirmView = (
   const { runtime } = useHost()
   const { currentTipAmount, setTipProcessStep } = props
 
-  const [animateForward, setAnimateForward] = useState<boolean>(true)
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
 
@@ -138,6 +122,8 @@ export const TipConfirmView = (
   }
 
   const handleSubmit = async () => {
+    // setTipProcessStep(TipProcessStep.TIP_COMPLETE)
+
     setSubmitError(null)
     setIsSubmitting(true)
     try {
@@ -156,45 +142,7 @@ export const TipConfirmView = (
 
   const handleUndo = () => {
     // reset to tip view
-    setAnimateForward(false)
     setTipProcessStep(TipProcessStep.TIP)
-  }
-
-  const handleClose = () => {
-    window.close()
-  }
-
-  // Animation Settings
-  const progressExitAnimation = {
-    opacity: 0,
-    transition: {
-      type: 'tween',
-      duration: 0.2
-    }
-  }
-
-  const regressExitAnimation = {
-    translateX: '308px',
-    transition: {
-      type: 'tween',
-      duration: 0.5
-    }
-  }
-
-  const bodyVariants = {
-    hidden: {
-      translateX: '308px'
-    },
-    visible: {
-      translateX: '0px',
-      opacity: 1,
-      transition: {
-        type: 'tween',
-        duration: 0.5
-      }
-    },
-    exit: (custom: boolean) =>
-      custom ? progressExitAnimation : regressExitAnimation
   }
 
   useEffect(() => {
@@ -203,72 +151,62 @@ export const TipConfirmView = (
 
   // Render
   return (
-    <Box style={{ position: 'absolute', width: '100%' }}>
-      <motion.div
-        initial='hidden'
-        animate='visible'
-        exit='exit'
-        custom={animateForward}
-        variants={bodyVariants}
-        key='pending'
-      >
-        <ExtensionBodyWrapper>
-          <Box textAlign='right' mb='42px'>
-            <IconButton aria-label='Close' onClick={handleClose}>
-              <CloseIcon />
-            </IconButton>
-          </Box>
-          <Box
-            mb='24px'
-            textAlign='center'
-            color={Colors.Grey800}
-            fontWeight='normal'
-            fontSize='18px'
-            pt='5px'
-          >
-            You will send
-          </Box>
-          <FitTextWrapper defaultFontSize={64}>
-            $
-            {Number.isInteger(currentTipAmount)
-              ? currentTipAmount
-              : currentTipAmount.toFixed(2)}
-          </FitTextWrapper>
-          <Box
-            mt='24px'
-            textAlign='center'
-            color={Colors.Grey800}
-            fontWeight='normal'
-            fontSize='18px'
-            pt='5px'
-          >
-            Pay with
-          </Box>
-          <Box mt='10px' flex='1' display='flex'>
-            {submitError ? (
-              <Box
-                width='100%'
-                textAlign='center'
-                color={Colors.Red400}
-                alignSelf='center'
-              >
-                Something went wrong.
-              </Box>
-            ) : (
-              <TipPaymentDebits
-                tipCreditCharge={tipCreditCharge}
-                creditCardCharge={creditCardCharge}
-              />
-            )}
-          </Box>
+    <>
+      <Header />
+      <ComponentWrapper>
+        <Box
+          mt='9px'
+          mb={2}
+          textAlign='center'
+          color={Colors.Grey800}
+          fontWeight='normal'
+          fontSize='18px'
+        >
+          You will send
+        </Box>
+        <FitTextWrapper defaultFontSize={64}>
+          $
+          {Number.isInteger(currentTipAmount)
+            ? currentTipAmount
+            : currentTipAmount.toFixed(2)}
+        </FitTextWrapper>
+        <Box
+          mt={5}
+          textAlign='center'
+          color={Colors.Grey800}
+          fontWeight='normal'
+          fontSize='18px'
+        >
+          Pay with
+        </Box>
+        <Box mt={2} flex='1' display='flex'>
+          {submitError ? (
+            <Box
+              width='100%'
+              textAlign='center'
+              color={Colors.Red400}
+              alignSelf='center'
+            >
+              Something went wrong.
+            </Box>
+          ) : (
+            <TipPaymentDebits
+              tipCreditCharge={tipCreditCharge}
+              creditCardCharge={creditCardCharge}
+            />
+          )}
+        </Box>
+        <Box mt={1}>
           <Button onClick={handleSubmit} disabled={isSubmitting}>
             {isSubmitting ? 'Sending...' : submitError ? 'Retry' : 'Confirm'}
           </Button>
+        </Box>
+        <Box mt='10px' mb='20px'>
           <CancelButton onClick={handleUndo} disabled={isSubmitting}>
             Cancel
           </CancelButton>
-        </ExtensionBodyWrapper>
-      </motion.div>
-    </Box>
+        </Box>
+      </ComponentWrapper>
+    </>
   )
 }

--- a/packages/coil-extension/src/popup/components/views/TipRouter.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipRouter.tsx
@@ -66,28 +66,32 @@ export const TipRouter = () => {
   const [currentTipAmount, setCurrentTipAmount] =
     useState<number>(defaultTipAmount)
 
-  return (
-    <OuterDiv>
-      <AnimatePresence initial={false}>
-        {tipProcessStep === TipProcessStep.TIP && (
-          <TipView
-            key='tip'
-            currentTipAmount={currentTipAmount}
-            setCurrentTipAmount={setCurrentTipAmount}
-            setTipProcessStep={setTipProcessStep}
-          />
-        )}
-        {tipProcessStep === TipProcessStep.TIP_CONFIRM && (
-          <TipConfirmView
-            key='confirm'
-            currentTipAmount={currentTipAmount}
-            setTipProcessStep={setTipProcessStep}
-          />
-        )}
-        {tipProcessStep === TipProcessStep.TIP_COMPLETE && (
-          <TipCompleteView key='complete' currentTipAmount={currentTipAmount} />
-        )}
-      </AnimatePresence>
-    </OuterDiv>
-  )
+  if (tipProcessStep === TipProcessStep.TIP) {
+    return (
+      <TipView
+        key='tip'
+        currentTipAmount={currentTipAmount}
+        setCurrentTipAmount={setCurrentTipAmount}
+        setTipProcessStep={setTipProcessStep}
+      />
+    )
+  }
+
+  if (tipProcessStep === TipProcessStep.TIP_CONFIRM) {
+    return (
+      <TipConfirmView
+        key='confirm'
+        currentTipAmount={currentTipAmount}
+        setTipProcessStep={setTipProcessStep}
+      />
+    )
+  }
+
+  if (tipProcessStep === TipProcessStep.TIP_COMPLETE) {
+    return (
+      <TipCompleteView key='complete' currentTipAmount={currentTipAmount} />
+    )
+  }
+
+  return null
 }

--- a/packages/coil-extension/src/popup/components/views/TipRouter.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipRouter.tsx
@@ -50,7 +50,7 @@ export interface ITipView {
 //
 export const TipRouter = () => {
   const [tipProcessStep, setTipProcessStep] = useState<TipProcessStep>(
-    TipProcessStep.TIP_CONFIRM
+    TipProcessStep.TIP_COMPLETE
   )
   const { user } = useStore()
   const { minimumTipLimit, lastTippedAmountUSD } = user?.tipSettings || {}

--- a/packages/coil-extension/src/popup/components/views/TipRouter.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipRouter.tsx
@@ -50,7 +50,7 @@ export interface ITipView {
 //
 export const TipRouter = () => {
   const [tipProcessStep, setTipProcessStep] = useState<TipProcessStep>(
-    TipProcessStep.TIP
+    TipProcessStep.TIP_CONFIRM
   )
   const { user } = useStore()
   const { minimumTipLimit, lastTippedAmountUSD } = user?.tipSettings || {}

--- a/packages/coil-extension/src/popup/components/views/TipRouter.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipRouter.tsx
@@ -67,30 +67,15 @@ export const TipRouter = () => {
     useState<number>(defaultTipAmount)
 
   if (tipProcessStep === TipProcessStep.TIP) {
-    return (
-      <TipView
-        key='tip'
-        currentTipAmount={currentTipAmount}
-        setCurrentTipAmount={setCurrentTipAmount}
-        setTipProcessStep={setTipProcessStep}
-      />
-    )
+    return <TipView key='tip' />
   }
 
   if (tipProcessStep === TipProcessStep.TIP_CONFIRM) {
-    return (
-      <TipConfirmView
-        key='confirm'
-        currentTipAmount={currentTipAmount}
-        setTipProcessStep={setTipProcessStep}
-      />
-    )
+    return <TipConfirmView key='confirm' />
   }
 
   if (tipProcessStep === TipProcessStep.TIP_COMPLETE) {
-    return (
-      <TipCompleteView key='complete' currentTipAmount={currentTipAmount} />
-    )
+    return <TipCompleteView key='complete' />
   }
 
   return null

--- a/packages/coil-extension/src/popup/components/views/TipView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipView.tsx
@@ -8,8 +8,9 @@ import { HotkeyAmountButtons } from '../HotkeyAmountButtons'
 import { TipWarning } from '../TipWarning'
 import { Colors } from '../../../shared-theme/colors'
 import { useStore } from '../../context/storeContext'
-
-import { TipProcessStep, ITipView } from './TipRouter'
+import { useTip } from '../../context/tipContext'
+import { useRouter } from '../../context/routerContext'
+import { ROUTES } from '../../contants'
 
 //
 // Styles
@@ -48,16 +49,14 @@ const Button = styled('button')({
 //
 // Component
 //
-export const TipView: React.FC<ITipView> = (
-  props: React.PropsWithChildren<ITipView>
-) => {
+export const TipView: React.FC = () => {
   const { user } = useStore()
-  const { hotkeyTipAmounts, remainingDailyAmount, minimumTipLimit } =
-    user?.tipSettings || {}
-  const { currentTipAmount, setCurrentTipAmount, setTipProcessStep } = props
+  const { remainingDailyAmount } = user?.tipSettings || {}
+  const { currentTipAmount } = useTip()
+  const router = useRouter()
 
   const handleTip = () => {
-    setTipProcessStep(TipProcessStep.TIP_CONFIRM)
+    router.to(ROUTES.tippingConfirm)
   }
 
   // Render
@@ -65,26 +64,13 @@ export const TipView: React.FC<ITipView> = (
     <NewHeaderFooterLayout title='Support This Site'>
       <ComponentWrapper>
         <Box mt={6}>
-          <AmountInput
-            currentTipAmount={currentTipAmount}
-            setCurrentTipAmount={setCurrentTipAmount}
-            remainingDailyAmount={remainingDailyAmount || 0}
-            minimumTipLimit={minimumTipLimit || 1}
-          />
+          <AmountInput />
         </Box>
         <Box mt={5}>
-          <HotkeyAmountButtons
-            hotkeyTipAmounts={hotkeyTipAmounts || []}
-            remainingDailyAmount={remainingDailyAmount || 0}
-            setCurrentTipAmount={setCurrentTipAmount}
-            setTipProcessStep={setTipProcessStep}
-          />
+          <HotkeyAmountButtons />
         </Box>
         <Box mt={4} flex='1'>
-          <TipWarning
-            currentTipAmount={currentTipAmount}
-            remainingDailyAmount={remainingDailyAmount || 0}
-          />
+          <TipWarning />
         </Box>
         <Box mb={2}>
           <Button

--- a/packages/coil-extension/src/popup/components/views/TipView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipView.tsx
@@ -10,7 +10,7 @@ import { Colors } from '../../../shared-theme/colors'
 import { useStore } from '../../context/storeContext'
 import { useTip } from '../../context/tipContext'
 import { useRouter } from '../../context/routerContext'
-import { ROUTES } from '../../contants'
+import { ROUTES } from '../../constants'
 
 //
 // Styles

--- a/packages/coil-extension/src/popup/components/views/TipView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipView.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { styled, Box } from '@material-ui/core'
-import { motion } from 'framer-motion'
 
 import { NewHeaderFooterLayout } from '../NewHeaderFooterLayout'
 import { AmountInput } from '../AmountInput'

--- a/packages/coil-extension/src/popup/components/views/TipView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipView.tsx
@@ -1,19 +1,10 @@
-/*
-    TipView
-
-    responsible for rendering the initial tip view for users to select the amount they would like to tip to the current site.
-*/
-
-// todo: Currently the AccountBar and WebMonetizedBar are done in the Index, need to extract those into a Layout component so views can handle their own layouts
-
 import React from 'react'
 import { styled, Box } from '@material-ui/core'
 import { motion } from 'framer-motion'
 
+import { NewHeaderFooterLayout } from '../NewHeaderFooterLayout'
 import { AmountInput } from '../AmountInput'
 import { HotkeyAmountButtons } from '../HotkeyAmountButtons'
-import { AccountBar } from '../AccountBar'
-import { WebMonetizedBar } from '../WebMonetizedBar'
 import { TipWarning } from '../TipWarning'
 import { Colors } from '../../../shared-theme/colors'
 import { useStore } from '../../context/storeContext'
@@ -23,10 +14,11 @@ import { TipProcessStep, ITipView } from './TipRouter'
 //
 // Styles
 //
-const ExtensionBodyWrapper = styled('div')({
-  padding: '24px 24px 16px 24px',
-  minHeight: '352px', // based on the first views body height to keep consistent
-  background: 'linear-gradient(180deg, #FCFCFC 86.53%, #FFFFFF 97.24%)'
+const ComponentWrapper = styled('div')({
+  padding: '0px 24px',
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column'
 })
 
 const Button = styled('button')({
@@ -42,7 +34,7 @@ const Button = styled('button')({
   fontSize: '16px',
   letterSpacing: '.5px',
   border: 'none',
-  borderRadius: '10px',
+  borderRadius: '100px',
   '&:hover': {
     backgroundColor: '#000000'
   },
@@ -68,98 +60,33 @@ export const TipView: React.FC<ITipView> = (
     setTipProcessStep(TipProcessStep.TIP_CONFIRM)
   }
 
-  // Animation Settings
-  const transitionDetails = {
-    type: 'tween',
-    duration: 0.5
-  }
-
-  const bodyVariants = {
-    hidden: { translateX: '-308px' },
-    visible: {
-      translateX: '0px',
-      transition: { ...transitionDetails }
-    },
-    exit: {
-      translateX: '-308px',
-      transition: { ...transitionDetails }
-    }
-  }
-
-  const headerVariants = {
-    hidden: { translateY: '-56px' },
-    visible: {
-      translateY: '0px',
-      transition: { ...transitionDetails }
-    },
-    exit: {
-      zIndex: 0,
-      translateY: '-56px',
-      transition: { ...transitionDetails }
-    }
-  }
-  const footerVariants = {
-    hidden: { translateY: '40px' },
-    visible: {
-      translateY: '0px',
-      transition: { ...transitionDetails }
-    },
-    exit: {
-      translateY: '40px',
-      transition: { ...transitionDetails }
-    }
-  }
-
   // Render
   return (
-    <Box style={{ position: 'absolute', width: '100%' }}>
-      <motion.div
-        initial='hidden'
-        animate='visible'
-        exit='exit'
-        variants={headerVariants}
-        key='header'
-      >
-        <AccountBar />
-      </motion.div>
-      <motion.div
-        initial='hidden'
-        animate='visible'
-        exit='exit'
-        variants={bodyVariants}
-        key='tip'
-      >
-        <ExtensionBodyWrapper>
-          <Box
-            mb='24px'
-            textAlign='center'
-            color={Colors.Grey800}
-            fontWeight='normal'
-            fontSize='18px'
-            pt='5px'
-          >
-            Support to this site
-          </Box>
+    <NewHeaderFooterLayout title='Support This Site'>
+      <ComponentWrapper>
+        <Box mt={6}>
           <AmountInput
             currentTipAmount={currentTipAmount}
             setCurrentTipAmount={setCurrentTipAmount}
             remainingDailyAmount={remainingDailyAmount || 0}
             minimumTipLimit={minimumTipLimit || 1}
           />
-          <Box m='20px 0px 35px 0px'>
-            <HotkeyAmountButtons
-              hotkeyTipAmounts={hotkeyTipAmounts || []}
-              remainingDailyAmount={remainingDailyAmount || 0}
-              setCurrentTipAmount={setCurrentTipAmount}
-              setTipProcessStep={setTipProcessStep}
-            />
-          </Box>
-          <Box mb='35px'>
-            <TipWarning
-              currentTipAmount={currentTipAmount}
-              remainingDailyAmount={remainingDailyAmount || 0}
-            />
-          </Box>
+        </Box>
+        <Box mt={5}>
+          <HotkeyAmountButtons
+            hotkeyTipAmounts={hotkeyTipAmounts || []}
+            remainingDailyAmount={remainingDailyAmount || 0}
+            setCurrentTipAmount={setCurrentTipAmount}
+            setTipProcessStep={setTipProcessStep}
+          />
+        </Box>
+        <Box mt={4} flex='1'>
+          <TipWarning
+            currentTipAmount={currentTipAmount}
+            remainingDailyAmount={remainingDailyAmount || 0}
+          />
+        </Box>
+        <Box mb={2}>
           <Button
             onClick={handleTip}
             disabled={currentTipAmount > (remainingDailyAmount || 0)}
@@ -169,17 +96,8 @@ export const TipView: React.FC<ITipView> = (
               ? currentTipAmount
               : currentTipAmount.toFixed(2)}
           </Button>
-        </ExtensionBodyWrapper>
-      </motion.div>
-      <motion.div
-        initial='hidden'
-        animate='visible'
-        exit='exit'
-        variants={footerVariants}
-        key='footer'
-      >
-        <WebMonetizedBar />
-      </motion.div>
-    </Box>
+        </Box>
+      </ComponentWrapper>
+    </NewHeaderFooterLayout>
   )
 }

--- a/packages/coil-extension/src/popup/components/views/ViewRouter.tsx
+++ b/packages/coil-extension/src/popup/components/views/ViewRouter.tsx
@@ -18,7 +18,6 @@ export function ViewRouter(): React.ReactElement {
 
   // Testing the new View structure
   // The NewExtension will replace ViewRouter in index.tsx -> should change name to App or Extension
-  // if (user?.newUi) {
   if (user?.tipSettings?.inTippingBeta) {
     return <NewExtension />
   }

--- a/packages/coil-extension/src/popup/components/views/ViewRouter.tsx
+++ b/packages/coil-extension/src/popup/components/views/ViewRouter.tsx
@@ -9,7 +9,6 @@ import { CoilDiscoverView } from './CoilDiscoverView'
 import { CoilPopupView } from './CoilPopupView'
 import { MonetizedRouter } from './MonetizedRouter'
 import { UnmonetizedPageView } from './UnmonetizedPageView'
-import { TipRouter } from './TipRouter'
 
 export function ViewRouter(): React.ReactElement {
   const { validToken, user, monetized, coilSite } = useStore()
@@ -19,9 +18,14 @@ export function ViewRouter(): React.ReactElement {
 
   // Testing the new View structure
   // The NewExtension will replace ViewRouter in index.tsx -> should change name to App or Extension
-  if (user?.newUi) {
+  // if (user?.newUi) {
+  if (user?.tipSettings?.inTippingBeta) {
     return <NewExtension />
   }
+
+  //
+  // Legacy Views
+  //
 
   //
   // Invalid user views
@@ -51,12 +55,8 @@ export function ViewRouter(): React.ReactElement {
 
   // Monetized views
   if (monetized) {
-    const showNewTipUi = user?.tipSettings?.inTippingBeta
-    if (showNewTipUi) {
-      return <TipRouter /> // handles the tip views based on local state
-    } else {
-      return <MonetizedRouter /> // handles the monetized views based on local state
-    }
+    // Monetized Page
+    return <MonetizedRouter /> // handles the monetized views based on local state
   } else {
     // Non Monetized Page
     return <UnmonetizedPageView />

--- a/packages/coil-extension/src/popup/context/tipContext.tsx
+++ b/packages/coil-extension/src/popup/context/tipContext.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, useContext, useState } from 'react'
+
+import { useStore } from './storeContext'
+
+//
+// Models
+//
+interface ITipContext {
+  currentTipAmount: number
+  setCurrentTipAmount: (amount: number) => void
+}
+
+// Context
+const TipContext = createContext({} as ITipContext)
+
+// Provider
+export const TipProvider: React.FC = props => {
+  const store = useStore()
+  const [currentTipAmount, setCurrentTipAmount] = useState<number>(0)
+
+  const providerValue = {
+    currentTipAmount: currentTipAmount,
+    setCurrentTipAmount: setCurrentTipAmount
+  }
+  return (
+    <TipContext.Provider value={providerValue}>
+      {props.children}
+    </TipContext.Provider>
+  )
+}
+
+// Hook
+export const useTip = () => {
+  const context = useContext(TipContext)
+  return context
+}

--- a/packages/coil-extension/src/popup/context/tipContext.tsx
+++ b/packages/coil-extension/src/popup/context/tipContext.tsx
@@ -52,11 +52,7 @@ export const TipProvider: React.FC = props => {
     useState<number>(max)
 
   const updateCurrentTipAmount = (amount: number) => {
-    if (amount <= max) {
-      setCurrentTipAmount(amount)
-    } else {
-      setCurrentTipAmount(max)
-    }
+    setCurrentTipAmount(amount)
   }
 
   const providerValue = {

--- a/packages/coil-extension/src/popup/context/tipContext.tsx
+++ b/packages/coil-extension/src/popup/context/tipContext.tsx
@@ -1,12 +1,11 @@
 import React, { createContext, useContext, useState } from 'react'
 
-import { useStore } from './storeContext'
-
 //
 // Models
 //
 interface ITipContext {
   currentTipAmount: number
+  maxAllowableTipAmount: number
   setCurrentTipAmount: (amount: number) => void
 }
 
@@ -15,12 +14,55 @@ const TipContext = createContext({} as ITipContext)
 
 // Provider
 export const TipProvider: React.FC = props => {
-  const store = useStore()
-  const [currentTipAmount, setCurrentTipAmount] = useState<number>(0)
+  const storedDailyTipLimitRemaining = 100
+  const storedTipCredits = 10
+  const tippingBetaFeatureFlag = true
+  const hasStoredCreditCard = true
+
+  // this could be a util instead of storing in state if initializing with the correct values doesn't work
+  const calculateMax = () => {
+    // calculate max here
+    let newMax = 0
+    if (tippingBetaFeatureFlag == true) {
+      // if the user has a cc on file
+      // only true limit is daily limit
+      // otherwise limit is tip credits
+      if (hasStoredCreditCard) {
+        newMax = storedDailyTipLimitRemaining
+      } else {
+        newMax = storedTipCredits
+      }
+    } else {
+      // user is not in beta and can only tip with credits
+      // if credits is less than daily limit -> limit is credits
+      // if credits is greater than daily limit -> limit is daily limit
+      if (storedTipCredits < storedDailyTipLimitRemaining) {
+        newMax = storedTipCredits
+      } else {
+        newMax = storedDailyTipLimitRemaining
+      }
+    }
+    return newMax
+  }
+
+  const max = calculateMax()
+
+  const [currentTipAmount, setCurrentTipAmount] = useState<number>(12)
+  const [maxAllowableTipAmount, setMaxAllowableTipAmount] =
+    useState<number>(max)
+
+  const updateCurrentTipAmount = (amount: number) => {
+    if (amount <= max) {
+      setCurrentTipAmount(amount)
+    } else {
+      setCurrentTipAmount(max)
+    }
+  }
 
   const providerValue = {
     currentTipAmount: currentTipAmount,
-    setCurrentTipAmount: setCurrentTipAmount
+    maxAllowableTipAmount: maxAllowableTipAmount,
+    setCurrentTipAmount: updateCurrentTipAmount
   }
   return (
     <TipContext.Provider value={providerValue}>
@@ -34,3 +76,23 @@ export const useTip = () => {
   const context = useContext(TipContext)
   return context
 }
+
+// // Reducers
+// export const SOME_ACTION = 'SOME_ACTION'
+// export const UPDATE_CURRENT_TIP_AMOUNT = 'UPDATE_CURRENT_TIP_AMOUNT'
+
+// export const tipReducer = (state, action) => {
+//   switch(action.type){
+//     case UPDATE_CURRENT_TIP_AMOUNT:
+//       let updatedState = [...state]
+//       const
+//       return state
+//     default: return state
+//   }
+// }
+
+// const defaultState = {
+//   currentTipAmount: 1, // need to initialize from user.tipSettings.lastTippedAmount
+//   allowableMaximumTipAmount: 10, // need to initialize based on daily tip limit - tip credit balance - tipping-beta featrue flag
+// }
+// const [ tipState, dispatch ] = useReducer(tipReducer, defaultState)

--- a/packages/coil-extension/src/popup/context/tipContext.tsx
+++ b/packages/coil-extension/src/popup/context/tipContext.tsx
@@ -27,9 +27,9 @@ export const TipProvider: React.FC<ITipProvider> = props => {
   const {
     tipSettings: {
       lastTippedAmountUSD = 1,
-      inTippingBeta,
+      inTippingBeta = false,
       remainingDailyAmount = 0
-    },
+    } = {},
     paymentMethods,
     tipCredits = 10
   } = userObject ?? {}

--- a/packages/coil-extension/src/shared-theme/colors.ts
+++ b/packages/coil-extension/src/shared-theme/colors.ts
@@ -25,6 +25,8 @@ export const Colors = {
   Green700: '#0EB871',
   Yellow400: '#FFC559',
   Yellow700: '#F8A811',
+  Violet10: '#DFD6FF',
+  Violet200: '#9A7DFF',
   Violet400: '#815DFF',
   Orange400: '#FF8A62',
   Violet700: '#690DFF',


### PR DESCRIPTION
resolves: COIL-1640

- Updated the styles of the tipping views to match the figma
- Removed the tipping views from `TipRouter` and put each page into the `Router`
- Replaced use of local state with a `tipContext` for the tip views
- Removed tipping from legacy UI -> temporarily using `tipping-beta` feature flag

***note: Fabi has been updating the artwork assets. When they are finalized I will be updating the extension artwork***