### PR TITLE
test: publish staging extension for e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,23 @@ jobs:
             yarn addons-linter coilfirefoxextension@coil.com.xpi
       - *save_cache
 
+  build-extension-e2e-coil:
+    docker:
+      - image: circleci/node:16-buster-browsers
+    steps:
+      - checkout
+      - run:
+          name: Publish staging extension for coil e2e tests
+          command: |
+            yarn
+            cd packages/coil-extension
+            yarn build-staging
+            mkdir /tmp/coil-chrome-ext-e2e-staging
+            tar -cvzf /tmp/coil-chrome-ext-e2e-staging/chromeext.tar dist
+      - store_artifacts:
+          path: /tmp/coil-chrome-ext-e2e-staging/chromeext.tar
+          destination: chrome-ext-staging
+
   publish-packages:
     docker:
       - image: circleci/node:14-buster-browsers
@@ -365,3 +382,13 @@ workflows:
               # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
               ignore: /pull\/[0-9]+/
           <<: *node-version-matrix
+      - build-extension-e2e-coil:
+          requires:
+            - jest-all
+            - jest-lerna-all
+            - coil-extension-puppeteer
+            - coil-extension-puppeteer-transpile-only
+          filters:  # using regex filters requires the entire branch to match
+            branches:
+              only:  # only branches matching the below regex filters will run
+                - main


### PR DESCRIPTION
Publishing the staging chrome extension as an artifact.  This will allow the coil workflow to consume the artifact for its own e2e tests.

* builds the extension using the `build-staging` command.  e2e tests will be run in staging
* waits for tests to pass before publishing the artifact.  Don't want bad builds.
* Only builds for main

Artifacts are stored for 30 days.

Downloading the artifact is discussed in the following article:
https://circleci.com/docs/2.0/artifacts/#downloading-all-artifacts-for-a-build-on-circleci