### PR TITLE
feat: fix max tip amount

### DIFF
--- a/packages/coil-extension/src/background/services/TippingService.ts
+++ b/packages/coil-extension/src/background/services/TippingService.ts
@@ -8,7 +8,6 @@ import * as tokens from '../../types/tokens'
 import { formatTipSettings } from '../util/formatters'
 import { TipSent } from '../../types/commands'
 import { notNullOrUndef } from '../../util/nullables'
-import { IUserPaymentMethod } from '../../types/user'
 
 import { logger, Logger } from './utils'
 import { Stream } from './Stream'
@@ -52,26 +51,8 @@ export class TippingService extends EventEmitter {
       const tipCreditBalanceCents =
         getUserTipCredit == null ? 0 : getUserTipCredit?.balance ?? 0
 
-      // need to know if the user has a credit card in order to calculate the maximum allowable tip
-      // getting the payment methods out of the user object in the store
-      const { paymentMethods = [] as Array<IUserPaymentMethod> } =
-        this.store.user ?? {}
-      const hasCreditCard =
-        paymentMethods.findIndex((paymentMethod: IUserPaymentMethod) => {
-          return paymentMethod.type === 'stripe'
-        }) > -1
-
-      // need to know if the site is monetized in order to calculate the maximum allowable tip
-      // a non monetized site should default to $0
-      const siteIsMonetized = this.store.monetized
-        ? this.store.monetized
-        : false
-
       // format the tip settings
       const formattedTipSettings = await formatTipSettings(
-        siteIsMonetized,
-        tippingBetaFeatureFlag,
-        hasCreditCard,
         Number(limitRemaining),
         Number(lastTippedAmount),
         Number(minTipLimit),

--- a/packages/coil-extension/src/background/util/formatters.ts
+++ b/packages/coil-extension/src/background/util/formatters.ts
@@ -4,45 +4,9 @@ type FormattedTipSettings = {
   lastTippedAmount: number
   tipCredits: number
   hotkeyTipAmounts: Array<number>
-  maxAllowableTipAmount: number
-}
-
-//* the maxAllowableTip is primarily responsible for disabling tipping inputs
-//* retuns max tip amount USD according to constraints
-//* a zero max tip amount will disable tip inputs
-export const calculateMaxAllowableTip = (
-  siteIsMonetized: boolean,
-  tippingBetaFeatureFlag: boolean,
-  hasCreditCard: boolean,
-  tipCredits: number,
-  remainingDailyAmount: number
-) => {
-  let newMax = 0
-  if (!siteIsMonetized) {
-    // if the site is not monetized the max amount should default to $0
-    return newMax
-  }
-  if (tippingBetaFeatureFlag && hasCreditCard) {
-    // if the user is in the beta they are allowed to use a cc
-    // if the user has a cc the only limit that matters is the max daily
-    newMax = remainingDailyAmount
-  } else {
-    // user is not in beta and can only tip with credits
-    // if credits is less than daily limit -> limit is credits
-    // if credits is greater than daily limit -> limit is daily limit
-    if (tipCredits < remainingDailyAmount) {
-      newMax = tipCredits
-    } else {
-      newMax = remainingDailyAmount
-    }
-  }
-  return newMax
 }
 
 export async function formatTipSettings(
-  siteIsMonetized: boolean,
-  tippingBetaFeatureFlag: boolean,
-  hasCreditCard: boolean,
   limitRemainingCents: number,
   lastTippedAmountCents: number,
   minimumTipLimitCents: number,
@@ -63,20 +27,11 @@ export async function formatTipSettings(
     ? Number(tipCreditBalanceCents) / 100
     : 0
 
-  const maxAllowableTipAmountUSD = calculateMaxAllowableTip(
-    siteIsMonetized,
-    tippingBetaFeatureFlag,
-    hasCreditCard,
-    tipCreditsUSD,
-    remainingDailyAmountUSD
-  )
-
   return {
     minimumTipLimit: minimumTipLimitUSD,
     remainingDailyAmount: remainingDailyAmountUSD,
     lastTippedAmount: lastTippedAmountUSD,
     tipCredits: tipCreditsUSD,
-    maxAllowableTipAmount: maxAllowableTipAmountUSD,
     hotkeyTipAmounts: [1, 2, 5] // dollar amounts - not yet set by user
   }
 }

--- a/packages/coil-extension/src/popup/components/AmountInput.tsx
+++ b/packages/coil-extension/src/popup/components/AmountInput.tsx
@@ -76,9 +76,9 @@ export const AmountInput = (): React.ReactElement => {
   const inputRef = useRef<HTMLInputElement>(null)
 
   const { user } = useStore()
-  const { minimumTipLimit = 1, maxAllowableTipAmount = 0 } =
-    user?.tipSettings || {}
-  const { currentTipAmount, setCurrentTipAmount } = useTip()
+  const { minimumTipLimit = 1 } = user?.tipSettings || {}
+  const { currentTipAmount, setCurrentTipAmount, maxAllowableTipAmount } =
+    useTip()
 
   // set focus to the input field when it loads. Cannot use 'autoFocus' because eslint-plugin-jsx-a11y
   useEffect(() => {

--- a/packages/coil-extension/src/popup/components/HotkeyAmountButtons.tsx
+++ b/packages/coil-extension/src/popup/components/HotkeyAmountButtons.tsx
@@ -54,9 +54,8 @@ const HotkeyButton = styled('button')({
 export const HotkeyAmountButtons = (): React.ReactElement => {
   const router = useRouter()
   const { user } = useStore()
-  const { hotkeyTipAmounts, maxAllowableTipAmount = 0 } =
-    user?.tipSettings || {}
-  const { setCurrentTipAmount } = useTip()
+  const { hotkeyTipAmounts } = user?.tipSettings || {}
+  const { setCurrentTipAmount, maxAllowableTipAmount } = useTip()
 
   const handleSelectAmount = (amount: number) => {
     setCurrentTipAmount(amount)

--- a/packages/coil-extension/src/popup/components/IncDecButton.tsx
+++ b/packages/coil-extension/src/popup/components/IncDecButton.tsx
@@ -145,9 +145,9 @@ export const IncDecButton = (props: IIncDecButton): React.ReactElement => {
   const { type } = props
 
   const { user } = useStore()
-  const { minimumTipLimit = 1, maxAllowableTipAmount = 0 } =
-    user?.tipSettings || {}
-  const { currentTipAmount, setCurrentTipAmount } = useTip()
+  const { minimumTipLimit = 1 } = user?.tipSettings || {}
+  const { currentTipAmount, setCurrentTipAmount, maxAllowableTipAmount } =
+    useTip()
 
   const initialVelocity = 150
   const [velocity, setVelocity] = useState<number>(initialVelocity)

--- a/packages/coil-extension/src/popup/components/views/TipConfirmView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipConfirmView.tsx
@@ -105,12 +105,13 @@ export const TipConfirmView = (): React.ReactElement => {
     setSubmitError(null)
     setIsSubmitting(true)
     try {
-      const { success } = await sendTip(currentTipAmount)
+      const { success, message } = await sendTip(currentTipAmount)
 
       if (success) {
         router.to(ROUTES.tippingComplete)
       } else {
-        throw new Error('Something went wrong')
+        const errorMsg = message ? message : 'Something went wrong'
+        throw new Error(errorMsg)
       }
     } catch (error) {
       setSubmitError(error.message)
@@ -165,7 +166,7 @@ export const TipConfirmView = (): React.ReactElement => {
               color={Colors.Red400}
               alignSelf='center'
             >
-              Something went wrong.
+              {submitError}
             </Box>
           ) : (
             <TipPaymentDebits

--- a/packages/coil-extension/src/popup/components/views/TipView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipView.tsx
@@ -4,7 +4,6 @@ import { styled, Box } from '@material-ui/core'
 import { NewHeaderFooterLayout } from '../NewHeaderFooterLayout'
 import { AmountInput } from '../AmountInput'
 import { HotkeyAmountButtons } from '../HotkeyAmountButtons'
-import { useStore } from '../../context/storeContext'
 import { useTip } from '../../context/tipContext'
 import { useRouter } from '../../context/routerContext'
 import { ROUTES } from '../../constants'
@@ -25,10 +24,8 @@ const ComponentWrapper = styled('div')({
 // Component
 //
 export const TipView: React.FC = () => {
-  const { currentTipAmount } = useTip()
+  const { currentTipAmount, maxAllowableTipAmount } = useTip()
   const router = useRouter()
-  const { user } = useStore()
-  const { maxAllowableTipAmount = 0 } = user?.tipSettings ?? {}
 
   const handleTip = () => {
     router.to(ROUTES.tippingConfirm)

--- a/packages/coil-extension/src/popup/context/tipContext.tsx
+++ b/packages/coil-extension/src/popup/context/tipContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useState, useMemo } from 'react'
 import { StorageService } from '@webmonetization/wext/services'
 
 import { getCreditCardFromPaymentMethods } from '../../util/getCreditCardFromPaymentMethods'
+import { calculateMaxAllowableTip } from '../../util/calculateMaxAllowableTip'
 
 //
 // Models
@@ -75,7 +76,7 @@ export const TipProvider: React.FC<ITipProvider> = props => {
 
   const creditCard = getCreditCardFromPaymentMethods(paymentMethods)
 
-  const maxTipAllowed = calculateMaxTipAllowed(
+  const maxTipAllowed = calculateMaxAllowableTip(
     monetized,
     tippingBetaFeatureFlag,
     !!creditCard,

--- a/packages/coil-extension/src/popup/context/tipContext.tsx
+++ b/packages/coil-extension/src/popup/context/tipContext.tsx
@@ -1,40 +1,99 @@
 import React, { createContext, useContext, useState, useMemo } from 'react'
 import { StorageService } from '@webmonetization/wext/services'
 
+import { getCreditCardFromPaymentMethods } from '../../util/getCreditCardFromPaymentMethods'
+
 //
 // Models
 //
 interface ITipContext {
   currentTipAmount: number
+  maxAllowableTipAmount: number //* the maxAllowableTip is primarily responsible for disabling tipping inputs
   setCurrentTipAmount: (amount: number) => void
 }
+
 interface ITipProvider {
   storage: Pick<StorageService, 'get'>
 }
 
+//
+// Utils
+//
+const calculateMaxTipAllowed = (
+  monetized: boolean,
+  inTippingBeta: boolean,
+  hasCreditCard: boolean,
+  tipCredits: number,
+  remainingDailyAmount: number
+) => {
+  let newMax = 0
+  if (!monetized) {
+    // if the site is not monetized, the user is not allowed to tip, therefore
+    // the max is zero
+    return newMax
+  }
+  if (inTippingBeta && hasCreditCard) {
+    // if the user is in the beta they are allowed to use a cc
+    // if the user has a cc the only limit that matters is the max daily
+    newMax = remainingDailyAmount
+  } else {
+    // user is not in beta and can only tip with credits
+    // if credits is less than daily limit -> limit is credits
+    // if credits is greater than daily limit -> limit is daily limit
+    if (tipCredits < remainingDailyAmount) {
+      newMax = tipCredits
+    } else {
+      newMax = remainingDailyAmount
+    }
+  }
+  return newMax
+}
+
+//
 // Context
+//
 const TipContext = createContext({} as ITipContext)
 
+//
 // Provider
+//
 export const TipProvider: React.FC<ITipProvider> = props => {
   const { storage, children } = props
 
   const userObject = storage.get('user')
+  const monetized = storage.get('monetized')
 
   const {
-    tipSettings: { lastTippedAmount = 1, maxAllowableTipAmount = 0 } = {}
+    tipSettings: {
+      lastTippedAmount = 1,
+      tipCredits = 0,
+      remainingDailyAmount = 0
+    } = {},
+    paymentMethods,
+    tippingBetaFeatureFlag
   } = userObject ?? {}
 
+  const creditCard = getCreditCardFromPaymentMethods(paymentMethods)
+
+  const maxTipAllowed = calculateMaxTipAllowed(
+    monetized,
+    tippingBetaFeatureFlag,
+    !!creditCard,
+    tipCredits,
+    remainingDailyAmount
+  )
+
   const initialTipAmount =
-    maxAllowableTipAmount < lastTippedAmount
-      ? maxAllowableTipAmount
-      : lastTippedAmount
+    maxTipAllowed < lastTippedAmount ? maxTipAllowed : lastTippedAmount
 
   const [currentTipAmount, setCurrentTipAmount] =
     useState<number>(initialTipAmount)
+  const [maxAllowableTipAmount, setMaxAllowableTipAmount] =
+    useState<number>(maxTipAllowed)
 
   const providerValue = {
     currentTipAmount: currentTipAmount,
+    maxAllowableTipAmount: maxAllowableTipAmount,
     setCurrentTipAmount: setCurrentTipAmount
   }
 
@@ -43,7 +102,9 @@ export const TipProvider: React.FC<ITipProvider> = props => {
   )
 }
 
+//
 // Hook
+//
 export const useTip = () => {
   const context = useContext(TipContext)
   return context

--- a/packages/coil-extension/src/popup/context/tipContext.tsx
+++ b/packages/coil-extension/src/popup/context/tipContext.tsx
@@ -18,39 +18,6 @@ interface ITipProvider {
 }
 
 //
-// Utils
-//
-const calculateMaxTipAllowed = (
-  monetized: boolean,
-  inTippingBeta: boolean,
-  hasCreditCard: boolean,
-  tipCredits: number,
-  remainingDailyAmount: number
-) => {
-  let newMax = 0
-  if (!monetized) {
-    // if the site is not monetized, the user is not allowed to tip, therefore
-    // the max is zero
-    return newMax
-  }
-  if (inTippingBeta && hasCreditCard) {
-    // if the user is in the beta they are allowed to use a cc
-    // if the user has a cc the only limit that matters is the max daily
-    newMax = remainingDailyAmount
-  } else {
-    // user is not in beta and can only tip with credits
-    // if credits is less than daily limit -> limit is credits
-    // if credits is greater than daily limit -> limit is daily limit
-    if (tipCredits < remainingDailyAmount) {
-      newMax = tipCredits
-    } else {
-      newMax = remainingDailyAmount
-    }
-  }
-  return newMax
-}
-
-//
 // Context
 //
 const TipContext = createContext({} as ITipContext)

--- a/packages/coil-extension/src/popup/mocks/loadMockedStates.tsx
+++ b/packages/coil-extension/src/popup/mocks/loadMockedStates.tsx
@@ -53,8 +53,7 @@ const tipUserNewUi = {
     remainingDailyAmount: 100,
     lastTippedAmount: 25,
     hotkeyTipAmounts: [5, 10, 50],
-    tipCredits: 20,
-    maxAllowableTipAmount: 100
+    tipCredits: 20
   },
   paymentMethods: [
     {
@@ -92,8 +91,7 @@ const tipUserNewUiCompare = {
     remainingDailyAmount: 30,
     lastTippedAmount: 25,
     hotkeyTipAmounts: [5, 10, 50],
-    tipCredits: 20,
-    maxAllowableTipAmount: 100
+    tipCredits: 20
   },
   paymentMethods: [
     {

--- a/packages/coil-extension/src/types/commands.ts
+++ b/packages/coil-extension/src/types/commands.ts
@@ -355,6 +355,7 @@ export interface Tip {
  */
 export interface TipResult {
   success: boolean
+  message?: string
 }
 
 /**

--- a/packages/coil-extension/src/types/user.ts
+++ b/packages/coil-extension/src/types/user.ts
@@ -25,7 +25,6 @@ export interface User {
     remainingDailyAmount: number
     lastTippedAmount: number
     hotkeyTipAmounts: Array<number>
-    maxAllowableTipAmount: number
   }
   paymentMethods?: Array<IUserPaymentMethod>
   tippingBetaFeatureFlag?: boolean

--- a/packages/coil-extension/src/util/calculateMaxAllowableTip.ts
+++ b/packages/coil-extension/src/util/calculateMaxAllowableTip.ts
@@ -1,0 +1,29 @@
+export const calculateMaxAllowableTip = (
+  monetized: boolean,
+  inTippingBeta: boolean,
+  hasCreditCard: boolean,
+  tipCredits: number,
+  remainingDailyAmount: number
+) => {
+  let newMax = 0
+  if (!monetized) {
+    // if the site is not monetized, the user is not allowed to tip, therefore
+    // the max is zero
+    return newMax
+  }
+  if (inTippingBeta && hasCreditCard) {
+    // if the user is in the beta they are allowed to use a cc
+    // if the user has a cc the only limit that matters is the max daily
+    newMax = remainingDailyAmount
+  } else {
+    // user is not in beta and can only tip with credits
+    // if credits is less than daily limit -> limit is credits
+    // if credits is greater than daily limit -> limit is daily limit
+    if (tipCredits < remainingDailyAmount) {
+      newMax = tipCredits
+    } else {
+      newMax = remainingDailyAmount
+    }
+  }
+  return newMax
+}

--- a/packages/coil-extension/test/jest/calculateMaxAllowableTip.test.ts
+++ b/packages/coil-extension/test/jest/calculateMaxAllowableTip.test.ts
@@ -1,4 +1,4 @@
-import { calculateMaxAllowableTip } from '../../src/background/util/formatters'
+import { calculateMaxAllowableTip } from '../../src/util/calculateMaxAllowableTip'
 
 describe('Calculate maximum allowable tip amount', () => {
   it('Non monetized sites should default to $0 max allowable tip', () => {


### PR DESCRIPTION
resolves: COIL-1712

This fixes the issue of the tipping limit not being set to $0 on when a user switches from a webmo'd tab to a non webmo'd tab.