### PR TITLE
feat(extension): update tip credit requests

### DIFF
--- a/packages/coil-client/src/queries/tipSettings.ts
+++ b/packages/coil-client/src/queries/tipSettings.ts
@@ -6,13 +6,11 @@ export const tipSettingsQuery = `
       tipping {
         lastTippedAmount
         limitRemaining
+        totalTipCredit
       }
     }
     minTipLimit {
       minTipLimit
-    }
-    getUserTipCredit {
-        balance
     }
     tippingBetaFeatureFlag: featureEnabled(key: "tipping-beta")
     extensionNewUiFeatureFlag: featureEnabled(key: "extension-new-ui")
@@ -24,13 +22,11 @@ export interface TipSettingsData {
     tipping: {
       lastTippedAmount: number
       limitRemaining: number
+      totalTipCredit: number
     }
   }
   minTipLimit: {
     minTipLimit: string
-  }
-  getUserTipCredit: {
-    balance: number
   }
   tippingBetaFeatureFlag: boolean
   extensionNewUiFeatureFlag: boolean

--- a/packages/coil-extension/src/background/services/TippingService.ts
+++ b/packages/coil-extension/src/background/services/TippingService.ts
@@ -44,8 +44,13 @@ export class TippingService extends EventEmitter {
         tippingBetaFeatureFlag,
         extensionNewUiFeatureFlag
       } = resp.data ?? {}
-      const { tipping: { lastTippedAmount = 0, limitRemaining = 0, totalTipCredit = 0 } = {} } =
-        whoami ?? {}
+      const {
+        tipping: {
+          lastTippedAmount = 0,
+          limitRemaining = 0,
+          totalTipCredit = 0
+        } = {}
+      } = whoami ?? {}
 
       // need to know if the user has a credit card in order to calculate the maximum allowable tip
       // getting the payment methods out of the user object in the store

--- a/packages/coil-extension/src/background/services/TippingService.ts
+++ b/packages/coil-extension/src/background/services/TippingService.ts
@@ -41,15 +41,11 @@ export class TippingService extends EventEmitter {
       const {
         whoami,
         minTipLimit: { minTipLimit = 1 },
-        getUserTipCredit,
         tippingBetaFeatureFlag,
         extensionNewUiFeatureFlag
       } = resp.data ?? {}
-      const { tipping: { lastTippedAmount = 0, limitRemaining = 0 } = {} } =
+      const { tipping: { lastTippedAmount = 0, limitRemaining = 0, totalTipCredit = 0 } = {} } =
         whoami ?? {}
-      // tipCredit will return null for users who have no tip credits -> destructuring doesn't work on null values
-      const tipCreditBalanceCents =
-        getUserTipCredit == null ? 0 : getUserTipCredit?.balance ?? 0
 
       // need to know if the user has a credit card in order to calculate the maximum allowable tip
       // getting the payment methods out of the user object in the store
@@ -74,7 +70,7 @@ export class TippingService extends EventEmitter {
         Number(limitRemaining),
         Number(lastTippedAmount),
         Number(minTipLimit),
-        Number(tipCreditBalanceCents)
+        Number(totalTipCredit)
       )
 
       // update user object on local storage


### PR DESCRIPTION
Part of the work for: COIL-1698.
* Updates GraphQL calls to use `totalTipCredit` on the `User` object as the Tip Credit balance.

note: tests will fail until the new API schema for tip credits is deployed to staging. See https://github.com/coilhq/coil/pull/5270