### PR TITLE
fix: fixed tip display to 0 and submit button

### DIFF
--- a/packages/coil-extension/src/popup/components/views/TipConfirmView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipConfirmView.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { styled, Box } from '@material-ui/core'
 
-import { Header } from '../Header'
 import { FitTextWrapper } from '../FitTextWrapper'
 import { Colors } from '../../../shared-theme/colors'
 import { TipPaymentDebits } from '../TipPaymentDebits'
@@ -100,8 +99,6 @@ export const TipConfirmView = (): React.ReactElement => {
   }
 
   const handleSubmit = async () => {
-    // router.to(ROUTES.tippingComplete)
-
     setSubmitError(null)
     setIsSubmitting(true)
     try {
@@ -130,62 +127,59 @@ export const TipConfirmView = (): React.ReactElement => {
 
   // Render
   return (
-    <>
-      <Header />
-      <ComponentWrapper>
-        <Box
-          mt='9px'
-          mb={2}
-          textAlign='center'
-          color={Colors.Grey800}
-          fontWeight='normal'
-          fontSize='18px'
-        >
-          You will send
-        </Box>
-        <FitTextWrapper defaultFontSize={64}>
-          $
-          {Number.isInteger(currentTipAmountUsd)
-            ? currentTipAmountUsd
-            : currentTipAmountUsd.toFixed(2)}
-        </FitTextWrapper>
-        <Box
-          mt={5}
-          textAlign='center'
-          color={Colors.Grey800}
-          fontWeight='normal'
-          fontSize='18px'
-        >
-          Pay with
-        </Box>
-        <Box mt={1} flex='1' display='flex'>
-          {submitError ? (
-            <Box
-              width='100%'
-              textAlign='center'
-              color={Colors.Red400}
-              alignSelf='center'
-            >
-              {submitError}
-            </Box>
-          ) : (
-            <TipPaymentDebits
-              tipCreditCharge={tipCreditCharge}
-              creditCardCharge={creditCardCharge}
-            />
-          )}
-        </Box>
-        <Box mt={1}>
-          <CtaButton onClick={handleSubmit} disabled={isSubmitting}>
-            {isSubmitting ? 'Sending...' : submitError ? 'Retry' : 'Confirm'}
-          </CtaButton>
-        </Box>
-        <Box mt={1} mb='14px'>
-          <CancelButton onClick={handleUndo} disabled={isSubmitting}>
-            Cancel
-          </CancelButton>
-        </Box>
-      </ComponentWrapper>
-    </>
+    <ComponentWrapper>
+      <Box
+        mt='59px'
+        mb={2}
+        textAlign='center'
+        color={Colors.Grey800}
+        fontWeight='normal'
+        fontSize='18px'
+      >
+        You will send
+      </Box>
+      <FitTextWrapper defaultFontSize={64}>
+        $
+        {Number.isInteger(currentTipAmountUsd)
+          ? currentTipAmountUsd
+          : currentTipAmountUsd.toFixed(2)}
+      </FitTextWrapper>
+      <Box
+        mt={5}
+        textAlign='center'
+        color={Colors.Grey800}
+        fontWeight='normal'
+        fontSize='18px'
+      >
+        Pay with
+      </Box>
+      <Box mt={1} flex='1' display='flex'>
+        {submitError ? (
+          <Box
+            width='100%'
+            textAlign='center'
+            color={Colors.Red400}
+            alignSelf='center'
+          >
+            {submitError}
+          </Box>
+        ) : (
+          <TipPaymentDebits
+            tipCreditCharge={tipCreditCharge}
+            creditCardCharge={creditCardCharge}
+          />
+        )}
+      </Box>
+      <Box mt={1}>
+        <CtaButton onClick={handleSubmit} disabled={isSubmitting}>
+          {isSubmitting ? 'Sending...' : submitError ? 'Retry' : 'Confirm'}
+        </CtaButton>
+      </Box>
+      <Box mt={1} mb='14px'>
+        <CancelButton onClick={handleUndo} disabled={isSubmitting}>
+          Cancel
+        </CancelButton>
+      </Box>
+    </ComponentWrapper>
   )
 }

--- a/packages/coil-extension/src/popup/components/views/TipView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipView.tsx
@@ -9,6 +9,7 @@ import { useRouter } from '../../context/routerContext'
 import { ROUTES } from '../../constants'
 import { TipAmountFeedback } from '../TipAmountFeedback'
 import { CtaButton } from '../CtaButton'
+import { useStore } from '../../context/storeContext'
 
 //
 // Styles
@@ -25,13 +26,17 @@ const ComponentWrapper = styled('div')({
 //
 export const TipView: React.FC = () => {
   const { currentTipAmountUsd, maxAllowableTipAmountUsd } = useTip()
+  const { user } = useStore()
   const router = useRouter()
+
+  const { tipSettings: { minTipLimitAmountUsd = 1 } = {} } = user ?? {}
 
   const handleTip = () => {
     router.to(ROUTES.tippingConfirm)
   }
 
   const buttonDisabled =
+    currentTipAmountUsd < minTipLimitAmountUsd ||
     currentTipAmountUsd > maxAllowableTipAmountUsd ||
     currentTipAmountUsd == 0 ||
     maxAllowableTipAmountUsd == 0

--- a/packages/coil-extension/src/popup/context/tipContext.tsx
+++ b/packages/coil-extension/src/popup/context/tipContext.tsx
@@ -60,6 +60,9 @@ export const TipProvider: React.FC<ITipProvider> = props => {
       initialTipAmountUsd = lastTippedAmountUsd
     }
   }
+  if (maxTipAllowedUsd === 0) {
+    initialTipAmountUsd = maxTipAllowedUsd
+  }
 
   const [currentTipAmountUsd, setCurrentTipAmountUsd] =
     useState<number>(initialTipAmountUsd)


### PR DESCRIPTION
resolves: COIL-1729

- removed the header from the tip confirm view
- The display of the initial tip amount now sets to zero if the max allowed tip is less than $1
- The submit button also checks to see if the tip amount is somehow set to a value below the minimum tip limit and will be disabled