### PR TITLE
fix: query error for tip settings

### DIFF
--- a/packages/coil-client/src/queries/tipSettings.ts
+++ b/packages/coil-client/src/queries/tipSettings.ts
@@ -37,17 +37,5 @@ export async function tipSettings(this: GraphQlClient, token: string) {
     query: tipSettingsQuery,
     token
   })
-
-  if (!message.data?.whoami?.tipping) {
-    throw new Error(
-      `graphql query failed. query=\`${tipSettingsQuery}\`. could not get tipping selection`
-    )
-  }
-  if (!message.data?.minTipLimit) {
-    throw new Error(
-      `graphql query failed. query=\`${tipSettingsQuery}\`. could not get minTipLimit selection`
-    )
-  }
-
   return message
 }

--- a/packages/coil-extension/src/background/services/TippingService.ts
+++ b/packages/coil-extension/src/background/services/TippingService.ts
@@ -40,17 +40,18 @@ export class TippingService extends EventEmitter {
       // destructuring response values and setting defaults
       const {
         whoami,
-        minTipLimit: { minTipLimitAmountCentsUsd = 100 },
+        minTipLimit,
         tippingBetaFeatureFlag,
         extensionNewUiFeatureFlag
       } = resp.data ?? {}
+
       const {
-        tipping: {
-          lastTippedAmountCentsUsd = 0,
-          limitRemainingAmountCentsUsd = 0,
-          totalTipCreditAmountCentsUsd = 0
-        } = {}
-      } = whoami ?? {}
+        lastTippedAmountCentsUsd = 0,
+        limitRemainingAmountCentsUsd = 0,
+        totalTipCreditAmountCentsUsd = 0
+      } = whoami?.tipping ?? {}
+
+      const { minTipLimitAmountCentsUsd = 100 } = minTipLimit ?? {}
 
       const tipSettings = {
         totalTipCreditAmountUsd: convertCentsToDollars(


### PR DESCRIPTION
resolves: COIL-1786

Removed extension throwing error if `whaomi > tipping` returned null. Fixed nested destructures on null values