### PR TITLE
fix: update tip credit balance and final tip amount after tip

### DIFF
--- a/packages/coil-extension/src/popup/Index.tsx
+++ b/packages/coil-extension/src/popup/Index.tsx
@@ -20,7 +20,7 @@ export function Index(props: {
     <PopupHostContext.Provider value={props.host}>
       <StoreContext.Provider value={store}>
         <RouterProvider>
-          <TipProvider storage={props.storage}>
+          <TipProvider storage={props.storage} host={props.host}>
             {/* should replace ViewRouter with  NewExtension when done -> rename the NewExtension to something like App */}
             <ViewRouter />
           </TipProvider>

--- a/packages/coil-extension/src/popup/components/views/TipCompleteView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipCompleteView.tsx
@@ -33,17 +33,17 @@ const BodyWrapper = styled('div')(({ url }: { url: string }) => ({
 // Component
 //
 export const TipCompleteView = (): React.ReactElement => {
-  const { currentTipAmountUsd } = useTip()
+  const { finalTipAmountUsd } = useTip()
 
   const getBackgroundImageUrl = () => {
     let ImgUrl = '/res/Level1.gif'
-    if (currentTipAmountUsd >= 5 && currentTipAmountUsd <= 20) {
+    if (finalTipAmountUsd >= 5 && finalTipAmountUsd <= 20) {
       ImgUrl = '/res/Level2.gif'
     }
-    if (currentTipAmountUsd > 20 && currentTipAmountUsd <= 50) {
+    if (finalTipAmountUsd > 20 && finalTipAmountUsd <= 50) {
       ImgUrl = '/res/Level3.gif'
     }
-    if (currentTipAmountUsd > 50) {
+    if (finalTipAmountUsd > 50) {
       ImgUrl = '/res/Level4.gif'
     }
     // adding a random number to the url allows it re-render the animation on the same page
@@ -60,9 +60,9 @@ export const TipCompleteView = (): React.ReactElement => {
         <Box mt={5} mb={2} px={3}>
           <FitTextWrapper defaultFontSize={80}>
             $
-            {Number.isInteger(currentTipAmountUsd)
-              ? currentTipAmountUsd
-              : currentTipAmountUsd.toFixed(2)}
+            {Number.isInteger(finalTipAmountUsd)
+              ? finalTipAmountUsd
+              : finalTipAmountUsd.toFixed(2)}
           </FitTextWrapper>
         </Box>
         <Box px={3}>

--- a/packages/coil-extension/src/popup/components/views/TipConfirmView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipConfirmView.tsx
@@ -58,7 +58,7 @@ export const TipConfirmView = (): React.ReactElement => {
 
   const { runtime } = useHost()
 
-  const { currentTipAmountUsd } = useTip()
+  const { currentTipAmountUsd, setFinalTipAmountUsd } = useTip()
   const router = useRouter()
 
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
@@ -102,6 +102,9 @@ export const TipConfirmView = (): React.ReactElement => {
     setSubmitError(null)
     setIsSubmitting(true)
     try {
+      // setting the final tip amount first
+      // this is done so that the tip context can properly update when storage is updated
+      setFinalTipAmountUsd(currentTipAmountUsd)
       const { success, message } = await sendTip(currentTipAmountUsd)
 
       if (success) {

--- a/packages/coil-extension/src/popup/context/tipContext.tsx
+++ b/packages/coil-extension/src/popup/context/tipContext.tsx
@@ -1,6 +1,7 @@
-import React, { createContext, useContext, useState, useMemo } from 'react'
+import React, { createContext, useContext, useState, useEffect } from 'react'
 import { StorageService } from '@webmonetization/wext/services'
 
+import { PopupHost } from '../types'
 import { getCreditCardFromPaymentMethods } from '../../util/getCreditCardFromPaymentMethods'
 import { calculateMaxAllowableTip } from '../../util/calculateMaxAllowableTip'
 
@@ -9,13 +10,18 @@ import { calculateMaxAllowableTip } from '../../util/calculateMaxAllowableTip'
 //
 interface ITipContext {
   currentTipAmountUsd: number
+  finalTipAmountUsd: number //* only used for the TipCompleteView so it renders the proper amount after local storage updates
   maxAllowableTipAmountUsd: number //* the maxAllowableTip is primarily responsible for disabling tipping inputs
   setCurrentTipAmountUsd: (amount: number) => void
+  setFinalTipAmountUsd: (amount: number) => void
 }
 
 interface ITipProvider {
   storage: Pick<StorageService, 'get'>
+  host: PopupHost
 }
+
+type StorageEventPartial = Pick<StorageEvent, 'key' | 'newValue'>
 
 //
 // Context
@@ -26,53 +32,72 @@ const TipContext = createContext({} as ITipContext)
 // Provider
 //
 export const TipProvider: React.FC<ITipProvider> = props => {
-  const { storage, children } = props
-
-  const userObject = storage.get('user')
-  const monetized = storage.get('monetized')
-
-  const {
-    tipSettings: {
-      lastTippedAmountUsd = 0,
-      totalTipCreditAmountUsd = 0,
-      limitRemainingAmountUsd = 0,
-      minTipLimitAmountUsd = 1
-    } = {},
-    paymentMethods,
-    tippingBetaFeatureFlag
-  } = userObject ?? {}
-
-  const creditCard = getCreditCardFromPaymentMethods(paymentMethods)
-
-  const maxTipAllowedUsd = calculateMaxAllowableTip(
-    monetized,
-    tippingBetaFeatureFlag,
-    !!creditCard,
-    totalTipCreditAmountUsd,
-    limitRemainingAmountUsd
-  )
-
-  let initialTipAmountUsd = minTipLimitAmountUsd
-  if (lastTippedAmountUsd > 0) {
-    if (maxTipAllowedUsd < lastTippedAmountUsd) {
-      initialTipAmountUsd = maxTipAllowedUsd
-    } else {
-      initialTipAmountUsd = lastTippedAmountUsd
-    }
-  }
-  if (maxTipAllowedUsd === 0) {
-    initialTipAmountUsd = maxTipAllowedUsd
-  }
-
-  const [currentTipAmountUsd, setCurrentTipAmountUsd] =
-    useState<number>(initialTipAmountUsd)
+  const { storage, host, children } = props
+  const [currentTipAmountUsd, setCurrentTipAmountUsd] = useState<number>(0)
+  const [finalTipAmountUsd, setFinalTipAmountUsd] = useState<number>(0)
   const [maxAllowableTipAmountUsd, setMaxAllowableTipAmountUsd] =
-    useState<number>(maxTipAllowedUsd)
+    useState<number>(0)
+
+  // Gets the values from localstorage and updates the tipping settings based on the returned values
+  const setValuesFromStorage = () => {
+    const userObject = storage.get('user')
+    const monetized = storage.get('monetized')
+
+    const {
+      tipSettings: {
+        lastTippedAmountUsd = 0,
+        totalTipCreditAmountUsd = 0,
+        limitRemainingAmountUsd = 0,
+        minTipLimitAmountUsd = 1
+      } = {},
+      paymentMethods,
+      tippingBetaFeatureFlag
+    } = userObject ?? {}
+
+    const creditCard = getCreditCardFromPaymentMethods(paymentMethods)
+
+    const maxTipAllowedUsd = calculateMaxAllowableTip(
+      monetized,
+      tippingBetaFeatureFlag,
+      !!creditCard,
+      totalTipCreditAmountUsd,
+      limitRemainingAmountUsd
+    )
+
+    let initialTipAmountUsd = minTipLimitAmountUsd
+    if (lastTippedAmountUsd > 0) {
+      if (maxTipAllowedUsd < lastTippedAmountUsd) {
+        initialTipAmountUsd = maxTipAllowedUsd
+      } else {
+        initialTipAmountUsd = lastTippedAmountUsd
+      }
+    }
+    if (maxTipAllowedUsd === 0) {
+      initialTipAmountUsd = maxTipAllowedUsd
+    }
+
+    setCurrentTipAmountUsd(initialTipAmountUsd)
+    setMaxAllowableTipAmountUsd(maxTipAllowedUsd)
+  }
+
+  useEffect(() => {
+    setValuesFromStorage() // set the initial values
+
+    // need to update the values whenever the store user object is updated
+    const events = host.events
+    events.on('storage', (evt: StorageEventPartial) => {
+      if (evt.key === 'user') {
+        setValuesFromStorage()
+      }
+    })
+  }, [])
 
   const providerValue = {
     currentTipAmountUsd: currentTipAmountUsd,
+    finalTipAmountUsd: finalTipAmountUsd,
     maxAllowableTipAmountUsd: maxAllowableTipAmountUsd,
-    setCurrentTipAmountUsd: setCurrentTipAmountUsd
+    setCurrentTipAmountUsd: setCurrentTipAmountUsd,
+    setFinalTipAmountUsd: setFinalTipAmountUsd
   }
 
   return (


### PR DESCRIPTION
Updates the tipContext when the user object in localStorage is updated. Also added a value for the final tip amount so that the TipComplete view would not be impacted by the localStorage update. 

The user can now submit a tip with tip credits and try to tip a second time with the "Available tip credits" being properly updated without having to close the extension and reopen it. 

related to COIL-1737