### PR TITLE
chore(coil-extension): bump version to 0.0.57

### DIFF
--- a/packages/coil-client/src/index.ts
+++ b/packages/coil-client/src/index.ts
@@ -8,3 +8,4 @@ export const tokenUtils = new CoilTokenUtils()
 
 // TODO
 export * from './queries'
+export * from './types'

--- a/packages/coil-extension/CHANGELOG.md
+++ b/packages/coil-extension/CHANGELOG.md
@@ -1,4 +1,29 @@
-<a name="coil-extension@0.0.56"></a>
+<a name="coil-extension@0.0.57"></a>
+
+# [coil-extension@0.0.57](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.56...coil-extension@0.0.57) (2022-02-08)
+
+### New Features
+
+- Add new UI & tipping closed beta
+
+  - [#2306](https://github.com/coilhq/web-monetization-projects/pull/2306)
+  - [#2484](https://github.com/coilhq/web-monetization-projects/pull/2484)
+  - [#2503](https://github.com/coilhq/web-monetization-projects/pull/2503)
+  - [#2432](https://github.com/coilhq/web-monetization-projects/pull/2432)
+  - [#2507](https://github.com/coilhq/web-monetization-projects/pull/2507)
+  - [#2508](https://github.com/coilhq/web-monetization-projects/pull/2508)
+  - [#2522](https://github.com/coilhq/web-monetization-projects/pull/2508)
+  - [#2551](https://github.com/coilhq/web-monetization-projects/pull/2551)
+  - [#2552](https://github.com/coilhq/web-monetization-projects/pull/2552)
+  - [#2535](https://github.com/coilhq/web-monetization-projects/pull/2535)
+  - [#2571](https://github.com/coilhq/web-monetization-projects/pull/2571)
+  - [#2568](https://github.com/coilhq/web-monetization-projects/pull/2568)
+  - [#2572](https://github.com/coilhq/web-monetization-projects/pull/2572)
+  - [#2578](https://github.com/coilhq/web-monetization-projects/pull/2578)
+  - [#2581](https://github.com/coilhq/web-monetization-projects/pull/2581)
+  - [#2582](https://github.com/coilhq/web-monetization-projects/pull/2582)
+
+- <a name="coil-extension@0.0.56"></a>
 
 # [coil-extension@0.0.56](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.55...coil-extension@0.0.56) (2021-07-20)
 

--- a/packages/coil-extension/docs/release-checklist.md
+++ b/packages/coil-extension/docs/release-checklist.md
@@ -19,7 +19,8 @@ When releasing, we can copy this markdown into the PR for a release.
 - [ ] Update the [CHANGELOG.md](../CHANGELOG.md)
 
   - You can compare with latest commit before tagging via something like:
-    `https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.48...8f359e45f843a4f9a01c090a02e73519413d900b`
+    `https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.56...main`
+    (substitute release branch name for "main")
 
 ### Zipping Extension Source Files
 

--- a/packages/coil-extension/docs/release-checklist.md
+++ b/packages/coil-extension/docs/release-checklist.md
@@ -55,6 +55,7 @@ make sense.
 - [ ] Ensure that you are [logged in with a user with valid subscription](https://coil.com/settings/membership)
 
   - ![image](https://user-images.githubusercontent.com/525211/71150879-28d04300-2265-11ea-96da-7d720c101575.png)
+    (or trial)
 
 - [ ] [example.com](http://example.com/) should say "This site isn't supported yet"
 

--- a/packages/coil-extension/package.json
+++ b/packages/coil-extension/package.json
@@ -1,10 +1,10 @@
 {
   "$schema": "../coil-monorepo-upkeep/resources/package-json-schema-nested-overrides.json",
   "$overRideUpKeep": {
-    "version": "0.0.56"
+    "version": "0.0.57"
   },
   "name": "@coil/extension",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "keywords": [
     "ilp",
     "web-monetization"

--- a/packages/coil-extension/six-apktool-decoded/apktool.yml
+++ b/packages/coil-extension/six-apktool-decoded/apktool.yml
@@ -18,5 +18,5 @@ usesFramework:
   tag: null
 version: 2.4.1
 versionInfo:
-  versionCode: '57'
-  versionName: 0.0.56
+  versionCode: '58'
+  versionName: 0.0.57

--- a/packages/coil-extension/src/background/services/AuthService.ts
+++ b/packages/coil-extension/src/background/services/AuthService.ts
@@ -188,20 +188,12 @@ export class AuthService extends EventEmitter {
     ])
 
     this.log('updateWhoAmi resp', resp.data)
-    if (resp.data?.whoami && tipResp.data?.whoami?.tipping) {
+    if (resp.data?.whoami && tipResp.data?.whoami) {
       this.store.user = {
         ...resp.data.whoami,
         ...formatTipSettings(tipResp.data)
       }
 
-      // Data needed for tipping
-      // tipping-beta: featureEnabled: boolean
-      // minimum tip limit: minTipLimit > minTipLimit
-      // remaining daily amount: whoami > tipping > limitRemaining
-
-      if (this.store.user) {
-        await this.tippingService.updateTipSettings(token)
-      }
       return token
     } else {
       return null
@@ -217,16 +209,12 @@ export class AuthService extends EventEmitter {
     if (
       resp.data?.refreshToken?.token &&
       resp.data?.whoami &&
-      tipResp.data?.whoami.tipping
+      tipResp.data?.whoami
     ) {
       this.store.user = {
         ...resp.data.whoami,
         ...formatTipSettings(tipResp.data)
       }
-      // Data needed for tipping
-      // tipping-beta: featureEnabled: boolean
-      // minimum tip limit: minTipLimit > minTipLimit
-      // remaining daily amount: whoami > tipping > limitRemaining
       return resp.data.refreshToken.token
     } else {
       return null

--- a/packages/coil-extension/src/background/services/TippingService.ts
+++ b/packages/coil-extension/src/background/services/TippingService.ts
@@ -7,11 +7,11 @@ import { LocalStorageProxy } from '../../types/storage'
 import * as tokens from '../../types/tokens'
 import { TipSent } from '../../types/commands'
 import { notNullOrUndef } from '../../util/nullables'
-import { convertCentsToDollars } from '../../util/convertUsdAmounts'
 
 import { logger, Logger } from './utils'
 import { Stream } from './Stream'
 import { BackgroundFramesService } from './BackgroundFramesService'
+import { formatTipSettings } from './formatTipSettings.util'
 
 @injectable()
 export class TippingService extends EventEmitter {
@@ -22,62 +22,28 @@ export class TippingService extends EventEmitter {
     @logger('TippingService')
     private log: Logger,
     private framesService: BackgroundFramesService,
-    private api = chrome
+    @inject(tokens.WextApi)
+    private api: typeof chrome
   ) {
     super()
   }
 
-  async updateTipSettings(token: string): Promise<string | null> {
-    /* 
-      updateTipSettings is responsible for fetching the data needed for the tipping views -> tipSettings 
+  async updateTipSettings(token: string): Promise<void> {
+    /*
+      updateTipSettings is responsible for fetching the data needed for the tipping views -> tipSettings
       after it fetches the data it then formats the values to make it easier for the views to consume
     */
-
     const resp = await this.client.tipSettings(token)
-
     this.log('updateTippingSettings', resp)
     if (resp.data?.whoami && resp.data?.minTipLimit) {
-      // destructuring response values and setting defaults
-      const {
-        whoami,
-        minTipLimit,
-        tippingBetaFeatureFlag,
-        extensionNewUiFeatureFlag
-      } = resp.data ?? {}
-
-      const {
-        lastTippedAmountCentsUsd = 0,
-        limitRemainingAmountCentsUsd = 0,
-        totalTipCreditAmountCentsUsd = 0
-      } = whoami?.tipping ?? {}
-
-      const { minTipLimitAmountCentsUsd = 100 } = minTipLimit ?? {}
-
-      const tipSettings = {
-        totalTipCreditAmountUsd: convertCentsToDollars(
-          totalTipCreditAmountCentsUsd
-        ),
-        minTipLimitAmountUsd: convertCentsToDollars(minTipLimitAmountCentsUsd),
-        limitRemainingAmountUsd: convertCentsToDollars(
-          limitRemainingAmountCentsUsd
-        ),
-        lastTippedAmountUsd: convertCentsToDollars(lastTippedAmountCentsUsd),
-        hotkeyTipAmountsUsd: [1, 2, 5] // not yet set by user
-      }
-
+      const formatted = formatTipSettings(resp.data)
       // update user object on local storage
       if (this.store.user) {
         this.store.user = {
           ...this.store.user,
-          tippingBetaFeatureFlag,
-          extensionNewUiFeatureFlag,
-          tipSettings
+          ...formatted
         }
       }
-
-      return token
-    } else {
-      return null
     }
   }
 

--- a/packages/coil-extension/src/background/services/formatTipSettings.util.ts
+++ b/packages/coil-extension/src/background/services/formatTipSettings.util.ts
@@ -1,0 +1,44 @@
+import { TipSettingsData } from '@coil/client'
+
+import { TipSettings } from '../../types/user'
+import { convertCentsToDollars } from '../../util/convertUsdAmounts'
+
+export function formatTipSettings(data: TipSettingsData): {
+  tipSettings: TipSettings
+  tippingBetaFeatureFlag: boolean
+  extensionNewUiFeatureFlag: boolean
+} {
+  // destructuring response values and setting defaults
+  const {
+    whoami,
+    minTipLimit,
+    tippingBetaFeatureFlag,
+    extensionNewUiFeatureFlag
+  } = data
+
+  const {
+    lastTippedAmountCentsUsd = 0,
+    limitRemainingAmountCentsUsd = 0,
+    totalTipCreditAmountCentsUsd = 0
+  } = whoami?.tipping ?? {}
+
+  const { minTipLimitAmountCentsUsd = 100 } = minTipLimit ?? {}
+
+  const tipSettings = {
+    totalTipCreditAmountUsd: convertCentsToDollars(
+      totalTipCreditAmountCentsUsd
+    ),
+    minTipLimitAmountUsd: convertCentsToDollars(minTipLimitAmountCentsUsd),
+    limitRemainingAmountUsd: convertCentsToDollars(
+      limitRemainingAmountCentsUsd
+    ),
+    lastTippedAmountUsd: convertCentsToDollars(lastTippedAmountCentsUsd),
+    hotkeyTipAmountsUsd: [1, 2, 5] // not yet set by user
+  }
+
+  return {
+    tipSettings,
+    tippingBetaFeatureFlag,
+    extensionNewUiFeatureFlag
+  }
+}

--- a/packages/coil-extension/src/content/services/ContentScript.ts
+++ b/packages/coil-extension/src/content/services/ContentScript.ts
@@ -107,7 +107,7 @@ export class ContentScript {
         // eslint-disable-next-line no-console
         console.error(
           '<iframe> (or one of its ancestors) ' +
-            'is not authorized to allow web monetization, %s',
+            'is not authorized to allow Web Monetization, %s',
           window.location.href
         )
         return

--- a/packages/coil-extension/src/popup/components/views/StreamingCoilDiscoverView.tsx
+++ b/packages/coil-extension/src/popup/components/views/StreamingCoilDiscoverView.tsx
@@ -21,7 +21,7 @@ export const StreamingCoilDiscoverView = () => {
   const theme = useTheme()
 
   return (
-    <NewHeaderFooterLayout title='Streaming Payments'>
+    <NewHeaderFooterLayout title='Stream Payments'>
       <ImgWrapper>
         <img src='/res/img-discover.svg' />
       </ImgWrapper>
@@ -35,7 +35,7 @@ export const StreamingCoilDiscoverView = () => {
       <Typography variant='subtitle1' align='center'>
         Learn all about the creators and content
         <br />
-        you can support using web monetization
+        you can support using Web Monetization
       </Typography>
     </NewHeaderFooterLayout>
   )

--- a/packages/coil-extension/src/popup/components/views/StreamingCoilView.tsx
+++ b/packages/coil-extension/src/popup/components/views/StreamingCoilView.tsx
@@ -32,7 +32,7 @@ export const StreamingCoilView = () => {
   const firstName = user?.fullName?.split(' ')[0]
 
   return (
-    <NewHeaderFooterLayout title='Streaming Payments'>
+    <NewHeaderFooterLayout title='Stream Payments'>
       <ImgWrapper>
         <img src='/res/img-discover.svg' />
       </ImgWrapper>

--- a/packages/coil-extension/src/popup/components/views/StreamingNoMembershipView.tsx
+++ b/packages/coil-extension/src/popup/components/views/StreamingNoMembershipView.tsx
@@ -42,7 +42,7 @@ export const StreamingNoMembershipView = () => {
   }, [lottieAnchor])
 
   return (
-    <NewHeaderFooterLayout title='Streaming Payments'>
+    <NewHeaderFooterLayout title='Stream Payments'>
       <LottieWrapper ref={lottieAnchor} />
       <Typography
         variant='h6'

--- a/packages/coil-extension/src/popup/components/views/StreamingNotWebMonetizedView.tsx
+++ b/packages/coil-extension/src/popup/components/views/StreamingNotWebMonetizedView.tsx
@@ -39,7 +39,7 @@ export const StreamingNotWebMonetizedView = () => {
   }, [lottieAnchor])
 
   return (
-    <NewHeaderFooterLayout title='Streaming Payments'>
+    <NewHeaderFooterLayout title='Stream Payments'>
       <LottieWrapper ref={lottieAnchor} />
       <Typography
         variant='h6'

--- a/packages/coil-extension/src/popup/components/views/StreamingWebMonitizedView.tsx
+++ b/packages/coil-extension/src/popup/components/views/StreamingWebMonitizedView.tsx
@@ -93,7 +93,7 @@ export const StreamingWebMonetizedView = () => {
   )
 
   return (
-    <NewHeaderFooterLayout title='Streaming Payments'>
+    <NewHeaderFooterLayout title='Stream Payments'>
       <LottieWrapper ref={lottieAnchor} />
       <Typography
         variant='h6'

--- a/packages/coil-extension/src/popup/components/views/StreamingWebMonitizedView.tsx
+++ b/packages/coil-extension/src/popup/components/views/StreamingWebMonitizedView.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef } from 'react'
-import lottie from 'lottie-web'
-import { Typography, styled, Theme, useTheme } from '@material-ui/core'
+import React, { useEffect, useRef, useState } from 'react'
+import lottie, { AnimationItem } from 'lottie-web'
+import { styled, Theme, Typography, useTheme } from '@material-ui/core'
 
 import { useStore } from '../../context/storeContext'
 import { NewHeaderFooterLayout } from '../NewHeaderFooterLayout'
@@ -23,7 +23,57 @@ const LottieWrapper = styled('div')(({ theme }: { theme: Theme }) => ({
 export const StreamingWebMonetizedView = () => {
   const theme = useTheme()
   const { monetizedTotal, adapted } = useStore()
+
   const lottieAnchor = useRef(null)
+  const [lastPacket, setLastPacket] = useState(0)
+  const [now, setNow] = useState(Date.now())
+  const [loaded, setLoaded] = useState(false)
+  const [lottieAnim, setLottieAnim] = useState<null | AnimationItem>(null)
+  const playAnimation =
+    typeof monetizedTotal === 'number' &&
+    monetizedTotal > 0 &&
+    now - lastPacket <= 5e3
+
+  // Update `now` every second so that recent packet check works
+  useEffect(() => {
+    const handle = window.setInterval(() => {
+      setNow(Date.now())
+    }, 1e3)
+    return () => {
+      window.clearInterval(handle)
+    }
+  })
+
+  // Set the lastPacket time whenever monetized total changes
+  useEffect(() => {
+    if (monetizedTotal && monetizedTotal > 0) {
+      setLastPacket(Date.now())
+    }
+  }, [monetizedTotal])
+
+  // Load the lottie-web animation item
+  useEffect(() => {
+    if (lottieAnchor.current && !loaded) {
+      setLottieAnim(
+        lottie.loadAnimation({
+          container: lottieAnchor.current,
+          animationData: streamingOnAnimation
+        })
+      )
+      setLoaded(true)
+    }
+  }, [lottieAnchor, loaded])
+
+  // Set the play or stopped state
+  useEffect(() => {
+    if (loaded && lottieAnim /* appease T.S. */) {
+      if (playAnimation) {
+        lottieAnim.play()
+      } else {
+        lottieAnim.stop()
+      }
+    }
+  }, [loaded, playAnimation])
 
   // site message is for standard web monetized sites
   const siteMessage = (
@@ -41,17 +91,6 @@ export const StreamingWebMonetizedView = () => {
       creator while you enjoy their content
     </>
   )
-
-  useEffect(() => {
-    const playAnimation = monetizedTotal !== 0 && monetizedTotal !== null
-    if (lottieAnchor.current) {
-      lottie.loadAnimation({
-        container: lottieAnchor.current,
-        animationData: streamingOnAnimation,
-        autoplay: playAnimation
-      })
-    }
-  }, [lottieAnchor])
 
   return (
     <NewHeaderFooterLayout title='Streaming Payments'>

--- a/packages/coil-extension/src/popup/components/views/TipNonMonetizedView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipNonMonetizedView.tsx
@@ -37,8 +37,8 @@ const Button = styled('button')(({ theme }) => ({
 export const TipNonMonetizedView: React.FC = () => {
   const theme = useTheme()
   return (
-    <NewHeaderFooterLayout title='Support This Site'>
-      <Box mt={4} mb={2}>
+    <NewHeaderFooterLayout title='Tip This Site'>
+      <Box mt={4} mb={2} height='156px'>
         <img
           src='/res/img-tipping-off.png'
           style={{ display: 'block', marginLeft: 'auto', marginRight: 'auto' }}

--- a/packages/coil-extension/src/popup/components/views/TipView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipView.tsx
@@ -43,7 +43,7 @@ export const TipView: React.FC = () => {
 
   // Render
   return (
-    <NewHeaderFooterLayout title='Support This Site'>
+    <NewHeaderFooterLayout title='Tip This Site'>
       <ComponentWrapper>
         <Box mt={6}>
           <AmountInput />

--- a/packages/coil-extension/src/types/user.ts
+++ b/packages/coil-extension/src/types/user.ts
@@ -1,32 +1,18 @@
-export interface User {
-  newUi?: boolean // todo: remove this when testing the new ui is done
-  id: string
-  fullName: string
-  shortName?: string
-  email: string
-  profilePicture?: string
-  customerId?: string
-  canTip?: boolean
-  subscription?: {
-    active: boolean
-    endDate?: string
-    trialEndDate?: string
-  }
+import { CoilUser } from '@coil/client'
+
+export interface TipSettings {
+  totalTipCreditAmountUsd: number
+  minTipLimitAmountUsd: number
+  limitRemainingAmountUsd: number
+  lastTippedAmountUsd: number
+  hotkeyTipAmountsUsd: Array<number>
+}
+
+export interface User extends CoilUser {
   invitation?: {
     usedAt: string
   }
-  currencyPreferences?: {
-    code: string
-    scale: number
-  }
-  tipSettings?: {
-    totalTipCreditAmountUsd: number
-    minTipLimitAmountUsd: number
-    limitRemainingAmountUsd: number
-    lastTippedAmountUsd: number
-    hotkeyTipAmountsUsd: Array<number>
-  }
-  paymentMethods?: Array<IUserPaymentMethod>
+  tipSettings?: TipSettings
   tippingBetaFeatureFlag?: boolean
   extensionNewUiFeatureFlag?: boolean
 }


### PR DESCRIPTION
# Release Checklist

## Chores

- [x] Make sure the manifest version was bumped but doesn't skip versions
- [ ] Update the [apktool.yml](../six-apktool-decoded/apktool.yml) versionCode/versionName
      and commit it to the repository.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md)
  - You can compare with latest commit before tagging via something like:
    `https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.56...nd-update-version-0-0-57-2022-02-08
    (substitute release branch name for "main")

### Zipping Extension Source Files

- [ ] Zip the source code for the extension

  - Some web stores will require the submission of source files.
  - So far, zipping the `coil-extension` folder (instead of zipping at the project root)
    has given us the least trouble with passing review.
    - For example, `zip -r coil-extension.zip coil-extension/`
  - `node_modules` should be deleted prior to zipping the source files.

## MacOS Chrome Version 98.0.4758.80 (Official Build) (x86_64)

Copy below for each platform/browser/version tested, filtering steps where it
make sense.

- [ ] Build for prod with release settings

  - e.g. `yarn build-prod chrome -p --run-prod --devtool=none`
    - as per [package.sh](../package.sh)

- [x] Import unpacked/temporary extension/add-on

  - For Firefox, go to `about:debugging`
    - Enable add-on debugging
    - Load Temporary Add-on...
  - For Chrome or MS Edge, go to `chrome://extensions` (or `edge://extensions`) and `Load Unpacked`
  - Use `adb` to install Samsung Internet Extensions
    - be sure to kill the browser and delete shared settings to be sure correct addon is tested
    - see code in `scripts/reinstall-six.sh`

- [x] Ensure that you are [logged in with a user with valid subscription](https://coil.com/settings/membership)

  - ![image](https://user-images.githubusercontent.com/525211/71150879-28d04300-2265-11ea-96da-7d720c101575.png)

- [ ] [example.com](http://example.com/) should say "This site isn't supported yet"

  - ![image](https://user-images.githubusercontent.com/525211/126276057-30b8285f-84a5-4e01-ae0e-85b7592883e6.png)

- [ ] [xrptipbot.com](https://www.xrptipbot.com/) should monetize

  - ![image](https://user-images.githubusercontent.com/525211/126276225-62af2025-3f43-4a36-a3bc-e141c9a569de.png)

-
- [ ] [twitch.tv](https://twitch.tv/vinesauce) works

  - ![image](https://user-images.githubusercontent.com/525211/126276355-63815894-47e6-4f69-8308-8ceeb43cb73b.png)

- [ ] [monetized youtube video](https://www.youtube.com/watch?v=-QMbZx_w2_Y)

  - ![image](https://user-images.githubusercontent.com/525211/126276573-a27425ab-884a-4612-99cb-ef12d452e75e.png)

- Coil welcome and welcome to explore pages

  - [ ] Go to coil.com, the browser action popup should show welcome to coil
    - ![image](https://user-images.githubusercontent.com/525211/126276719-692355e3-f571-4b08-8816-9b0715688d71.png)
  - [ ] Should have a link to coil.com/discover page
  - [ ] Once on explore page should show `Discover Now` with a rocket-ship graphic
    - ![image](https://user-images.githubusercontent.com/525211/126276807-f39ac03f-6c2b-419c-8a79-e2f2859b44a9.png)

- [ ] Check the monetization animation works properly

  - ![image](https://user-images.githubusercontent.com/525211/126277022-48e139b6-871a-4ed4-8d45-58e194855ff8.png)
  - Only required on desktop browsers
  - Should animate when monetized and packets received
  - Should stop animation when network disconnected
    - Note that on Firefox/MacOS the popup automatically closes when the
      tab loses focus so can use something like this in terminal:
      - `sudo sleep 10 && sudo ifconfig en0 down && sleep 10 && sudo ifconfig en0 up`

- [ ] Check monetization works consistently

  - In the same tab, go to http://www.travisvcrist.com/gatehub
    - refresh and make sure streaming works 10 times in a row
      - should not get 'stuck' in 'setting up payment' state
  - Issue: [coil/coilhq#3038][ci3038]
  - Fix PRs: [#242][np242]

- [ ] Will route to \$coildomain.com/login rather than open popup if logged out

  - Log out from \$coildomain.com
  - Check that icon is in 'unavailable' state
    - ![image](https://user-images.githubusercontent.com/525211/126277431-a7ae73a2-14a6-41b4-90f4-69f2b9be6df5.png)
  - Click on browser action
  - Check that routed to login page
    - ![image](https://user-images.githubusercontent.com/525211/126277570-77da3644-9950-465d-bac0-4afbd33a70e4.png)

- [ ] Popup icon should show if page is monetized even when logged out

  - Log out from extension
  - Go to a monetized page and check that the icon "monetized" black and in 'unavailable' state
    - ![image](https://user-images.githubusercontent.com/525211/126277839-d482fea3-63bc-42d8-9dae-6eca318cdc63.png)

- [ ] Run the puppeteer [tests](./test.sh) (look at the [circle jobs](../../../.circleci/config.yml))

  - export BROWSER_TYPE='chrome' # or 'firefox'

- [ ] Go to a [youtube video](https://www.youtube.com/watch?v=l1btEwwRePs),
      manually skip to near end of video, and when autoplay of a video from
      another channel starts, check that monetization has stopped.

  - Issues: [#33][i33]
  - PRs: [#213][np213]

- [ ] Go to [xrptipbot.com](https://www.xrptipbot.com/) and as page
      is loading very quickly open the popup.
      It should show "Thanks for your support" even before streaming
      starts. Should show 'setting up payment' then 'coil is paying creator'
      [#120][i120]

- [ ] Open the [reloading-every-15s.html](../test/fixtures/reloading-every-15s.html) file:

  - Use a localhost server so WM works (e.g. with `yarn serve:fixtures`)
  - Open the developer tools console undocked so can view while **PAGE IS BACKGROUNDED**
    - Note the `Reloading page` logging
  - Open the extension background page developer tools and look at the stream logging
  - SHOULD NOT initiate a stream or SPSP request
    [#144][i144]

- [ ] Open the [event-logger.html](../test/fixtures/event-logger.html) file:

  - Use a localhost server so WM works (e.g. with `python -m http.server 4000`)
  - Look for unusual timings, check that pending state is emitted nearly
    immediately after page load or meta tag added
  - Issue: [#63][ni63]
  - Fix PR: [#69][np69]

- [ ] Check started event fires when quickly switching between tabs

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Switch to another (non-monetized) tab. The payments stop. Quickly switch back to the first tab.
  - The payments restart. Make sure there is a monetizationstart event
  - Issue: [#105][ni105]
  - Fix PR: [#117][np117]

- [ ] Check stopped event fires with correct requestId

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Induce a stop/start in same js 'tick'
  - Check that the stopped event has the correct requestId
  - Issue: [#127][ni127]
  - Fix PR: [#128][np128]

- [ ] Check tip event fires when clicked on in the popup

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Open the extension popup and click on "Tip this creator \$1!"
  - Check that the tip event occurs

- [ ] Run a local web server (e.g. with `python -m http.server 4000`) serving
      the dist folder, then open [static/popup.html](static/popup.html) in a
      normal tab and check the popup rendering in various states.

- [ ] If the browser is running on android, check that the "popup" browser action
      simply opens settings.

  - Install android-sdk on PC and Firefox on android
  - Enable developer mode on android and enable usb debugging
  - Plug in android to PC via usb
  - `adb devices # make note of device id`
  - `adb shell pm grant org.mozilla.firefox android.permission.READ_EXTERNAL_STORAGE`
  - `adb shell pm grant org.mozilla.firefox android.permission.WRITE_EXTERNAL_STORAGE`
  - Build the extension
  - `yarn web-ext run -s $PWD/dist --target=firefox-android --android-device=WUJ01PNSVY # from adb devices step`
  - Issue: [coil/coilhq#2084][ci2084]
  - Fix PRs: [#166][p166] [#295][p295]

- [ ] On MacOS Chromium browsers (Chrome/Edge) check that the monetized animation is working
      on non primary monitors.

  - Issue: [#312][i312]
  - Fix PR: [#317][p317]

- [ ] Check that popup closes when another window is focused

  - Open two Browser windows, open the popup in one window
  - Focus on second window
  - Ensure that popup is closed

  - Issue: [#313][i313]
  - Fix PR: [#332][p332]

- [ ] Check SPA apps keep streaming when url changed, meta stays

  - Go to e.g. https://www.wevolver.com/
  - Change other pages which uses HTML5 history.pushState
  - Check that streaming is maintained throughout

    - if not, use browser devtools to check if meta exists
      - `document.head.querySelector('meta[name="monetization"]')`

  - Issue: [#507][i507]
  - Fix PR: [#508][p508]

- [ ] Check extension doesn't attempt to stream when unsubscribed

  - Log in with coil user that doesn't have active subscription
  - Open the developer tools and check the logging
  - SHOULD NOT even attempt to stream
  - ![image](https://user-images.githubusercontent.com/525211/66631124-c9840000-ec2f-11e9-95a4-3bebe7fdebd6.png)
  - Issue: [#213][i213]
  - Fix PR: [#222][p222]

- [ ] Check can stream immediately after subscribing

  - Likely best to test this with staging where can use a test card
  - Log in with coil user that doesn't have active subscription
  - Add a subscription (can use [testing card](https://stripe.com/docs/testing) 4242 4242 4242 4242 )
  - Go to a monetized page and check that streaming works immediately

- [ ] Check no stop event is fired when logged out

  - Open and console and set `localStorage.WM_DEBUG = true`
  - Go to a web monetized page when logged out
  - Check that no events are logged

  - Issue: [#1947][ni1947]
  - Fix PR: [#1964][np1964]

### Iframe testing

1. - [ ] Open a terminal and `cd packages/coil-extension/test/fixtures/iframes/`
2. - [ ] Start a server (via `python -m http.server 4000` or equivalent)
3. - [ ] Open http://localhost:4000/top-nested-allowed-iframe.html in browser
4. Open developer tools and look at the structure of the dom

- Use expand recursively feature
  - ![image](https://user-images.githubusercontent.com/525211/76400168-71098800-63b2-11ea-8069-5ee7b8b0707a.png)

5. - [ ] With the console set `localStorage.WM_DEBUG = true`

#### Test 1: basic monetization

1. Load the page
2. - [ ] Look for 4 monetizationpending events and 4 corresponding (same requestId) monetizationstart events logged in the console.

![image](https://user-images.githubusercontent.com/525211/76397844-6a791180-63ae-11ea-8f1c-72ef3a6183fb.png)

#### Test 2: refresh page / turn off / turn on

1. - [ ] [re]load the page
2. - [ ] Open developer tools and turn "off" monetization via editing allow attribute of top level iframes
   - ![image](https://user-images.githubusercontent.com/525211/76398261-28040480-63af-11ea-85cb-396960ced1bb.png)
   - Popup icon (and background page logging) should show no monetization:
     - [ ] ![image](https://user-images.githubusercontent.com/525211/76398281-305c3f80-63af-11ea-857c-6ab6b409daa5.png)
   - Corresponding monetization events should be logged:
     - [ ] ![image](https://user-images.githubusercontent.com/525211/76398873-3999dc00-63b0-11ea-8ee6-7ca45d8b44f0.png)

3. turn "on" monetization via editing allow attribute of top level iframes
   - ![image](https://user-images.githubusercontent.com/525211/76398370-57b30c80-63af-11ea-86a8-133271e46b91.png)
   - [ ] Popup icon (and background page logging) should show monetization
     - ![image](https://user-images.githubusercontent.com/525211/76398417-6d283680-63af-11ea-88e6-c4b0ed5c35f7.png)
   - [ ] Corresponding monetization events should be logged:
     - ![image](https://user-images.githubusercontent.com/525211/76399026-841b5880-63b0-11ea-8b0b-c0ecbff13bee.png)

#### Test 3: refresh page / turn off / background tab / turn on / foreground tab

- As above but while the tab is backgrounded, after turning on each top level iframe a sequence of pending -> stopped events should be fired:
  - [ ] ![image](https://user-images.githubusercontent.com/525211/76399956-1a03b300-63b2-11ea-9b77-671e94a1bf16.png)

#### Test 4: nested

- As per test 2
- Turn off one top level and then turn off the nested frames in top level that is allowed
- [ ] allow _one_ nested iframe and check for indications of monetization

[i33]: https://github.com/coilhq/web-monetization/issues/33
[i120]: https://github.com/coilhq/web-monetization/issues/120
[i144]: https://github.com/coilhq/web-monetization/issues/144
[p166]: https://github.com/coilhq/web-monetization/pull/166
[i213]: https://github.com/coilhq/web-monetization/issues/213
[p222]: https://github.com/coilhq/web-monetization/pull/222
[p295]: https://github.com/coilhq/web-monetization/pull/295
[ci2084]: https://github.com/coilhq/coil/issues/2084
[ci3038]: https://github.com/coilhq/coil/issues/3038
[i312]: https://github.com/coilhq/web-monetization/issues/312
[p317]: https://github.com/coilhq/web-monetization/pull/317
[i313]: https://github.com/coilhq/web-monetization/issues/313
[p332]: https://github.com/coilhq/web-monetization/pull/332
[i507]: https://github.com/coilhq/web-monetization/issues/507
[p508]: https://github.com/coilhq/web-monetization/pull/508
[np28]: https://github.com/coilhq/web-monetization-projects/pull/28
[ni21]: https://github.com/coilhq/web-monetization-projects/issue/21
[ni63]: https://github.com/coilhq/web-monetization-projects/issue/63
[np69]: https://github.com/coilhq/web-monetization-projects/pull/69
[ni105]: https://github.com/coilhq/web-monetization-projects/issue/105
[np117]: https://github.com/coilhq/web-monetization-projects/pull/117
[ni127]: https://github.com/coilhq/web-monetization-projects/issue/127
[np128]: https://github.com/coilhq/web-monetization-projects/pull/128
[ni184]: https://github.com/coilhq/web-monetization-projects/issue/184
[np185]: https://github.com/coilhq/web-monetization-projects/pull/185
[np213]: https://github.com/coilhq/web-monetization-projects/pull/213
[np242]: https://github.com/coilhq/web-monetization-projects/pull/242
[np1964]: https://github.com/coilhq/web-monetization-projects/pull/1964
[ni1947]: https://github.com/coilhq/web-monetization-projects/issue/1947
