### PR TITLE
feat(coil-extension): collection of fixes

### DIFF
--- a/packages/coil-client/src/index.ts
+++ b/packages/coil-client/src/index.ts
@@ -8,3 +8,4 @@ export const tokenUtils = new CoilTokenUtils()
 
 // TODO
 export * from './queries'
+export * from './types'

--- a/packages/coil-extension/docs/release-checklist.md
+++ b/packages/coil-extension/docs/release-checklist.md
@@ -54,6 +54,7 @@ make sense.
 - [ ] Ensure that you are [logged in with a user with valid subscription](https://coil.com/settings/membership)
 
   - ![image](https://user-images.githubusercontent.com/525211/71150879-28d04300-2265-11ea-96da-7d720c101575.png)
+    (or trial)
 
 - [ ] [example.com](http://example.com/) should say "This site isn't supported yet"
 

--- a/packages/coil-extension/src/background/services/AuthService.ts
+++ b/packages/coil-extension/src/background/services/AuthService.ts
@@ -188,20 +188,12 @@ export class AuthService extends EventEmitter {
     ])
 
     this.log('updateWhoAmi resp', resp.data)
-    if (resp.data?.whoami && tipResp.data?.whoami?.tipping) {
+    if (resp.data?.whoami && tipResp.data?.whoami) {
       this.store.user = {
         ...resp.data.whoami,
         ...formatTipSettings(tipResp.data)
       }
 
-      // Data needed for tipping
-      // tipping-beta: featureEnabled: boolean
-      // minimum tip limit: minTipLimit > minTipLimit
-      // remaining daily amount: whoami > tipping > limitRemaining
-
-      if (this.store.user) {
-        await this.tippingService.updateTipSettings(token)
-      }
       return token
     } else {
       return null
@@ -217,16 +209,12 @@ export class AuthService extends EventEmitter {
     if (
       resp.data?.refreshToken?.token &&
       resp.data?.whoami &&
-      tipResp.data?.whoami.tipping
+      tipResp.data?.whoami
     ) {
       this.store.user = {
         ...resp.data.whoami,
         ...formatTipSettings(tipResp.data)
       }
-      // Data needed for tipping
-      // tipping-beta: featureEnabled: boolean
-      // minimum tip limit: minTipLimit > minTipLimit
-      // remaining daily amount: whoami > tipping > limitRemaining
       return resp.data.refreshToken.token
     } else {
       return null

--- a/packages/coil-extension/src/background/services/TippingService.ts
+++ b/packages/coil-extension/src/background/services/TippingService.ts
@@ -7,11 +7,11 @@ import { LocalStorageProxy } from '../../types/storage'
 import * as tokens from '../../types/tokens'
 import { TipSent } from '../../types/commands'
 import { notNullOrUndef } from '../../util/nullables'
-import { convertCentsToDollars } from '../../util/convertUsdAmounts'
 
 import { logger, Logger } from './utils'
 import { Stream } from './Stream'
 import { BackgroundFramesService } from './BackgroundFramesService'
+import { formatTipSettings } from './formatTipSettings.util'
 
 @injectable()
 export class TippingService extends EventEmitter {
@@ -22,62 +22,28 @@ export class TippingService extends EventEmitter {
     @logger('TippingService')
     private log: Logger,
     private framesService: BackgroundFramesService,
-    private api = chrome
+    @inject(tokens.WextApi)
+    private api: typeof chrome
   ) {
     super()
   }
 
-  async updateTipSettings(token: string): Promise<string | null> {
-    /* 
-      updateTipSettings is responsible for fetching the data needed for the tipping views -> tipSettings 
+  async updateTipSettings(token: string): Promise<void> {
+    /*
+      updateTipSettings is responsible for fetching the data needed for the tipping views -> tipSettings
       after it fetches the data it then formats the values to make it easier for the views to consume
     */
-
     const resp = await this.client.tipSettings(token)
-
     this.log('updateTippingSettings', resp)
     if (resp.data?.whoami && resp.data?.minTipLimit) {
-      // destructuring response values and setting defaults
-      const {
-        whoami,
-        minTipLimit,
-        tippingBetaFeatureFlag,
-        extensionNewUiFeatureFlag
-      } = resp.data ?? {}
-
-      const {
-        lastTippedAmountCentsUsd = 0,
-        limitRemainingAmountCentsUsd = 0,
-        totalTipCreditAmountCentsUsd = 0
-      } = whoami?.tipping ?? {}
-
-      const { minTipLimitAmountCentsUsd = 100 } = minTipLimit ?? {}
-
-      const tipSettings = {
-        totalTipCreditAmountUsd: convertCentsToDollars(
-          totalTipCreditAmountCentsUsd
-        ),
-        minTipLimitAmountUsd: convertCentsToDollars(minTipLimitAmountCentsUsd),
-        limitRemainingAmountUsd: convertCentsToDollars(
-          limitRemainingAmountCentsUsd
-        ),
-        lastTippedAmountUsd: convertCentsToDollars(lastTippedAmountCentsUsd),
-        hotkeyTipAmountsUsd: [1, 2, 5] // not yet set by user
-      }
-
+      const formatted = formatTipSettings(resp.data)
       // update user object on local storage
       if (this.store.user) {
         this.store.user = {
           ...this.store.user,
-          tippingBetaFeatureFlag,
-          extensionNewUiFeatureFlag,
-          tipSettings
+          ...formatted
         }
       }
-
-      return token
-    } else {
-      return null
     }
   }
 

--- a/packages/coil-extension/src/background/services/formatTipSettings.util.ts
+++ b/packages/coil-extension/src/background/services/formatTipSettings.util.ts
@@ -1,0 +1,44 @@
+import { TipSettingsData } from '@coil/client'
+
+import { TipSettings } from '../../types/user'
+import { convertCentsToDollars } from '../../util/convertUsdAmounts'
+
+export function formatTipSettings(data: TipSettingsData): {
+  tipSettings: TipSettings
+  tippingBetaFeatureFlag: boolean
+  extensionNewUiFeatureFlag: boolean
+} {
+  // destructuring response values and setting defaults
+  const {
+    whoami,
+    minTipLimit,
+    tippingBetaFeatureFlag,
+    extensionNewUiFeatureFlag
+  } = data
+
+  const {
+    lastTippedAmountCentsUsd = 0,
+    limitRemainingAmountCentsUsd = 0,
+    totalTipCreditAmountCentsUsd = 0
+  } = whoami?.tipping ?? {}
+
+  const { minTipLimitAmountCentsUsd = 100 } = minTipLimit ?? {}
+
+  const tipSettings = {
+    totalTipCreditAmountUsd: convertCentsToDollars(
+      totalTipCreditAmountCentsUsd
+    ),
+    minTipLimitAmountUsd: convertCentsToDollars(minTipLimitAmountCentsUsd),
+    limitRemainingAmountUsd: convertCentsToDollars(
+      limitRemainingAmountCentsUsd
+    ),
+    lastTippedAmountUsd: convertCentsToDollars(lastTippedAmountCentsUsd),
+    hotkeyTipAmountsUsd: [1, 2, 5] // not yet set by user
+  }
+
+  return {
+    tipSettings,
+    tippingBetaFeatureFlag,
+    extensionNewUiFeatureFlag
+  }
+}

--- a/packages/coil-extension/src/content/services/ContentScript.ts
+++ b/packages/coil-extension/src/content/services/ContentScript.ts
@@ -107,7 +107,7 @@ export class ContentScript {
         // eslint-disable-next-line no-console
         console.error(
           '<iframe> (or one of its ancestors) ' +
-            'is not authorized to allow web monetization, %s',
+            'is not authorized to allow Web Monetization, %s',
           window.location.href
         )
         return

--- a/packages/coil-extension/src/popup/components/views/StreamingCoilDiscoverView.tsx
+++ b/packages/coil-extension/src/popup/components/views/StreamingCoilDiscoverView.tsx
@@ -21,7 +21,7 @@ export const StreamingCoilDiscoverView = () => {
   const theme = useTheme()
 
   return (
-    <NewHeaderFooterLayout title='Streaming Payments'>
+    <NewHeaderFooterLayout title='Stream Payments'>
       <ImgWrapper>
         <img src='/res/img-discover.svg' />
       </ImgWrapper>
@@ -35,7 +35,7 @@ export const StreamingCoilDiscoverView = () => {
       <Typography variant='subtitle1' align='center'>
         Learn all about the creators and content
         <br />
-        you can support using web monetization
+        you can support using Web Monetization
       </Typography>
     </NewHeaderFooterLayout>
   )

--- a/packages/coil-extension/src/popup/components/views/StreamingCoilView.tsx
+++ b/packages/coil-extension/src/popup/components/views/StreamingCoilView.tsx
@@ -32,7 +32,7 @@ export const StreamingCoilView = () => {
   const firstName = user?.fullName?.split(' ')[0]
 
   return (
-    <NewHeaderFooterLayout title='Streaming Payments'>
+    <NewHeaderFooterLayout title='Stream Payments'>
       <ImgWrapper>
         <img src='/res/img-discover.svg' />
       </ImgWrapper>

--- a/packages/coil-extension/src/popup/components/views/StreamingNoMembershipView.tsx
+++ b/packages/coil-extension/src/popup/components/views/StreamingNoMembershipView.tsx
@@ -42,7 +42,7 @@ export const StreamingNoMembershipView = () => {
   }, [lottieAnchor])
 
   return (
-    <NewHeaderFooterLayout title='Streaming Payments'>
+    <NewHeaderFooterLayout title='Stream Payments'>
       <LottieWrapper ref={lottieAnchor} />
       <Typography
         variant='h6'

--- a/packages/coil-extension/src/popup/components/views/StreamingNotWebMonetizedView.tsx
+++ b/packages/coil-extension/src/popup/components/views/StreamingNotWebMonetizedView.tsx
@@ -39,7 +39,7 @@ export const StreamingNotWebMonetizedView = () => {
   }, [lottieAnchor])
 
   return (
-    <NewHeaderFooterLayout title='Streaming Payments'>
+    <NewHeaderFooterLayout title='Stream Payments'>
       <LottieWrapper ref={lottieAnchor} />
       <Typography
         variant='h6'

--- a/packages/coil-extension/src/popup/components/views/StreamingWebMonitizedView.tsx
+++ b/packages/coil-extension/src/popup/components/views/StreamingWebMonitizedView.tsx
@@ -93,7 +93,7 @@ export const StreamingWebMonetizedView = () => {
   )
 
   return (
-    <NewHeaderFooterLayout title='Streaming Payments'>
+    <NewHeaderFooterLayout title='Stream Payments'>
       <LottieWrapper ref={lottieAnchor} />
       <Typography
         variant='h6'

--- a/packages/coil-extension/src/popup/components/views/StreamingWebMonitizedView.tsx
+++ b/packages/coil-extension/src/popup/components/views/StreamingWebMonitizedView.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef } from 'react'
-import lottie from 'lottie-web'
-import { Typography, styled, Theme, useTheme } from '@material-ui/core'
+import React, { useEffect, useRef, useState } from 'react'
+import lottie, { AnimationItem } from 'lottie-web'
+import { styled, Theme, Typography, useTheme } from '@material-ui/core'
 
 import { useStore } from '../../context/storeContext'
 import { NewHeaderFooterLayout } from '../NewHeaderFooterLayout'
@@ -23,7 +23,57 @@ const LottieWrapper = styled('div')(({ theme }: { theme: Theme }) => ({
 export const StreamingWebMonetizedView = () => {
   const theme = useTheme()
   const { monetizedTotal, adapted } = useStore()
+
   const lottieAnchor = useRef(null)
+  const [lastPacket, setLastPacket] = useState(0)
+  const [now, setNow] = useState(Date.now())
+  const [loaded, setLoaded] = useState(false)
+  const [lottieAnim, setLottieAnim] = useState<null | AnimationItem>(null)
+  const playAnimation =
+    typeof monetizedTotal === 'number' &&
+    monetizedTotal > 0 &&
+    now - lastPacket <= 5e3
+
+  // Update `now` every second so that recent packet check works
+  useEffect(() => {
+    const handle = window.setInterval(() => {
+      setNow(Date.now())
+    }, 1e3)
+    return () => {
+      window.clearInterval(handle)
+    }
+  })
+
+  // Set the lastPacket time whenever monetized total changes
+  useEffect(() => {
+    if (monetizedTotal && monetizedTotal > 0) {
+      setLastPacket(Date.now())
+    }
+  }, [monetizedTotal])
+
+  // Load the lottie-web animation item
+  useEffect(() => {
+    if (lottieAnchor.current && !loaded) {
+      setLottieAnim(
+        lottie.loadAnimation({
+          container: lottieAnchor.current,
+          animationData: streamingOnAnimation
+        })
+      )
+      setLoaded(true)
+    }
+  }, [lottieAnchor, loaded])
+
+  // Set the play or stopped state
+  useEffect(() => {
+    if (loaded && lottieAnim /* appease T.S. */) {
+      if (playAnimation) {
+        lottieAnim.play()
+      } else {
+        lottieAnim.stop()
+      }
+    }
+  }, [loaded, playAnimation])
 
   // site message is for standard web monetized sites
   const siteMessage = (
@@ -41,17 +91,6 @@ export const StreamingWebMonetizedView = () => {
       creator while you enjoy their content
     </>
   )
-
-  useEffect(() => {
-    const playAnimation = monetizedTotal !== 0 && monetizedTotal !== null
-    if (lottieAnchor.current) {
-      lottie.loadAnimation({
-        container: lottieAnchor.current,
-        animationData: streamingOnAnimation,
-        autoplay: playAnimation
-      })
-    }
-  }, [lottieAnchor])
 
   return (
     <NewHeaderFooterLayout title='Streaming Payments'>

--- a/packages/coil-extension/src/popup/components/views/TipNonMonetizedView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipNonMonetizedView.tsx
@@ -37,8 +37,8 @@ const Button = styled('button')(({ theme }) => ({
 export const TipNonMonetizedView: React.FC = () => {
   const theme = useTheme()
   return (
-    <NewHeaderFooterLayout title='Support This Site'>
-      <Box mt={4} mb={2}>
+    <NewHeaderFooterLayout title='Tip This Site'>
+      <Box mt={4} mb={2} height='156px'>
         <img
           src='/res/img-tipping-off.png'
           style={{ display: 'block', marginLeft: 'auto', marginRight: 'auto' }}

--- a/packages/coil-extension/src/popup/components/views/TipView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipView.tsx
@@ -43,7 +43,7 @@ export const TipView: React.FC = () => {
 
   // Render
   return (
-    <NewHeaderFooterLayout title='Support This Site'>
+    <NewHeaderFooterLayout title='Tip This Site'>
       <ComponentWrapper>
         <Box mt={6}>
           <AmountInput />

--- a/packages/coil-extension/src/types/user.ts
+++ b/packages/coil-extension/src/types/user.ts
@@ -1,32 +1,18 @@
-export interface User {
-  newUi?: boolean // todo: remove this when testing the new ui is done
-  id: string
-  fullName: string
-  shortName?: string
-  email: string
-  profilePicture?: string
-  customerId?: string
-  canTip?: boolean
-  subscription?: {
-    active: boolean
-    endDate?: string
-    trialEndDate?: string
-  }
+import { CoilUser } from '@coil/client'
+
+export interface TipSettings {
+  totalTipCreditAmountUsd: number
+  minTipLimitAmountUsd: number
+  limitRemainingAmountUsd: number
+  lastTippedAmountUsd: number
+  hotkeyTipAmountsUsd: Array<number>
+}
+
+export interface User extends CoilUser {
   invitation?: {
     usedAt: string
   }
-  currencyPreferences?: {
-    code: string
-    scale: number
-  }
-  tipSettings?: {
-    totalTipCreditAmountUsd: number
-    minTipLimitAmountUsd: number
-    limitRemainingAmountUsd: number
-    lastTippedAmountUsd: number
-    hotkeyTipAmountsUsd: Array<number>
-  }
-  paymentMethods?: Array<IUserPaymentMethod>
+  tipSettings?: TipSettings
   tippingBetaFeatureFlag?: boolean
   extensionNewUiFeatureFlag?: boolean
 }


### PR DESCRIPTION
* Do whoami and tipData queries in parallel from AuthService
* Only play streaming animation if have recent packet (<= 5s)
* Don't show old extension views while refreshing page (due to slow tip queries)
* Handle null tipping response in AuthService
* Update titles and copy