### PR TITLE
chore(coil-extension): bump version to 0.0.57

### DIFF
--- a/packages/coil-extension/CHANGELOG.md
+++ b/packages/coil-extension/CHANGELOG.md
@@ -1,4 +1,35 @@
-<a name="coil-extension@0.0.56"></a>
+<a name="coil-extension@0.0.57"></a>
+
+# [coil-extension@0.0.57](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.56...coil-extension@0.0.57) (2022-02-08)
+
+### New Features
+
+- Add new UI & tipping closed beta
+
+  - [#2306](https://github.com/coilhq/web-monetization-projects/pull/2306)
+  - [#2484](https://github.com/coilhq/web-monetization-projects/pull/2484)
+  - [#2503](https://github.com/coilhq/web-monetization-projects/pull/2503)
+  - [#2432](https://github.com/coilhq/web-monetization-projects/pull/2432)
+  - [#2507](https://github.com/coilhq/web-monetization-projects/pull/2507)
+  - [#2508](https://github.com/coilhq/web-monetization-projects/pull/2508)
+  - [#2522](https://github.com/coilhq/web-monetization-projects/pull/2508)
+  - [#2551](https://github.com/coilhq/web-monetization-projects/pull/2551)
+  - [#2552](https://github.com/coilhq/web-monetization-projects/pull/2552)
+  - [#2535](https://github.com/coilhq/web-monetization-projects/pull/2535)
+  - [#2571](https://github.com/coilhq/web-monetization-projects/pull/2571)
+  - [#2568](https://github.com/coilhq/web-monetization-projects/pull/2568)
+  - [#2572](https://github.com/coilhq/web-monetization-projects/pull/2572)
+  - [#2578](https://github.com/coilhq/web-monetization-projects/pull/2578)
+  - [#2581](https://github.com/coilhq/web-monetization-projects/pull/2581)
+  - [#2582](https://github.com/coilhq/web-monetization-projects/pull/2582)
+  - [#2588](https://github.com/coilhq/web-monetization-projects/pull/2588)
+  - [#2593](https://github.com/coilhq/web-monetization-projects/pull/2593)
+  - [#2596](https://github.com/coilhq/web-monetization-projects/pull/2596)
+  - [#2592](https://github.com/coilhq/web-monetization-projects/pull/2592)
+  - [#2603](https://github.com/coilhq/web-monetization-projects/pull/2603)
+  - [#2605](https://github.com/coilhq/web-monetization-projects/pull/2605)
+
+- <a name="coil-extension@0.0.56"></a>
 
 # [coil-extension@0.0.56](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.55...coil-extension@0.0.56) (2021-07-20)
 

--- a/packages/coil-extension/docs/release-checklist.md
+++ b/packages/coil-extension/docs/release-checklist.md
@@ -131,7 +131,7 @@ make sense.
       starts. Should show 'setting up payment' then 'coil is paying creator'
       [#120][i120]
 
-- [ ] Open the [reloading-every-15s.html](../test/fixtures/reloading-every-15s.html) file:
+- [ ] Open the [reloading-every-15s.html](http://localhost:4000/reloading-every-15s.html) file:
 
   - Use a localhost server so WM works (e.g. with `yarn serve:fixtures`)
   - Open the developer tools console undocked so can view while **PAGE IS BACKGROUNDED**

--- a/packages/coil-extension/docs/release-checklist.md
+++ b/packages/coil-extension/docs/release-checklist.md
@@ -19,7 +19,8 @@ When releasing, we can copy this markdown into the PR for a release.
 - [ ] Update the [CHANGELOG.md](../CHANGELOG.md)
 
   - You can compare with latest commit before tagging via something like:
-    `https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.48...8f359e45f843a4f9a01c090a02e73519413d900b`
+    `https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.56...main`
+    (substitute release branch name for "main")
 
 ### Zipping Extension Source Files
 

--- a/packages/coil-extension/package.json
+++ b/packages/coil-extension/package.json
@@ -1,10 +1,10 @@
 {
   "$schema": "../coil-monorepo-upkeep/resources/package-json-schema-nested-overrides.json",
   "$overRideUpKeep": {
-    "version": "0.0.56"
+    "version": "0.0.57"
   },
   "name": "@coil/extension",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "keywords": [
     "ilp",
     "web-monetization"

--- a/packages/coil-extension/six-apktool-decoded/apktool.yml
+++ b/packages/coil-extension/six-apktool-decoded/apktool.yml
@@ -18,5 +18,5 @@ usesFramework:
   tag: null
 version: 2.4.1
 versionInfo:
-  versionCode: '57'
-  versionName: 0.0.56
+  versionCode: '58'
+  versionName: 0.0.57

--- a/packages/coil-extension/test/fixtures/iframes/frame1.html
+++ b/packages/coil-extension/test/fixtures/iframes/frame1.html
@@ -5,7 +5,7 @@
     <meta
       id="money"
       name="monetization"
-      content="$twitter.xrptipbot.com/Coil"
+      content="$ilp.uphold.com/gRa4mXFEMYrL"
     />
   </head>
   <body>

--- a/packages/coil-extension/test/fixtures/reloading-every-15s.html
+++ b/packages/coil-extension/test/fixtures/reloading-every-15s.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="monetization" content="$twitter.xrptipbot.com/sharafian_" />
+    <meta name="monetization" content="$ilp.uphold.com/gRa4mXFEMYrL" />
 
     <script src="https://cdn.coil.com/counter.js"></script>
     <script>
@@ -19,7 +19,7 @@
   </head>
 
   <body>
-    <p>WM to $twitter.xrptipbot.com/sharafian_</p>
+    <p>WM to $ilp.uphold.com/gRa4mXFEMYrL</p>
     <p>Reloading every 15 seconds</p>
   </body>
 </html>


### PR DESCRIPTION
# Release Checklist

## Chores

- [x] Make sure the manifest version was bumped but doesn't skip versions
- [ ] Update the [apktool.yml](../six-apktool-decoded/apktool.yml) versionCode/versionName
      and commit it to the repository.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md)
  - You can compare with latest commit before tagging via something like:
  - https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.56...nd-update-version-0-0-57-2022-02-09
    (substitute release branch name for "main")

### Zipping Extension Source Files

- [ ] Zip the source code for the extension

  - Some web stores will require the submission of source files.
  - So far, zipping the `coil-extension` folder (instead of zipping at the project root)
    has given us the least trouble with passing review.
    - For example, `zip -r coil-extension.zip coil-extension/`
  - `node_modules` should be deleted prior to zipping the source files.

## MacOS Firefox 97.0.1 (64-bit)

Copy below for each platform/browser/version tested, filtering steps where it
make sense.

- [ ] Build for prod with release settings

  - e.g. `yarn build-prod chrome -p --run-prod --devtool=none`
    - as per [package.sh](../package.sh)

- [x] Import unpacked/temporary extension/add-on

  - For Firefox, go to `about:debugging`
    - Enable add-on debugging
    - Load Temporary Add-on...
  - For Chrome or MS Edge, go to `chrome://extensions` (or `edge://extensions`) and `Load Unpacked`
  - Use `adb` to install Samsung Internet Extensions
    - be sure to kill the browser and delete shared settings to be sure correct addon is tested
    - see code in `scripts/reinstall-six.sh`

- [x] Ensure that you are [logged in with a user with valid subscription](https://coil.com/settings/membership)

  - ![image](https://user-images.githubusercontent.com/525211/71150879-28d04300-2265-11ea-96da-7d720c101575.png)
    (or trial)

- [x] [example.com](http://example.com/) should say "This site isn't supported yet"

  - ![image](https://user-images.githubusercontent.com/525211/126276057-30b8285f-84a5-4e01-ae0e-85b7592883e6.png)
  - **TESTERS NOTE** <img width="341" alt="image" src="https://user-images.githubusercontent.com/525211/154630950-e179eb7c-cf62-4a8c-b1b5-aa033f1ff57f.png">

- [x] [xrptipbot.com](https://www.xrptipbot.com/) should monetize

  - ![image](https://user-images.githubusercontent.com/525211/126276225-62af2025-3f43-4a36-a3bc-e141c9a569de.png)
  -  **TESTERS NOTE** <img width="345" alt="image" src="https://user-images.githubusercontent.com/525211/154631133-1be5f080-858f-4984-9548-1b5b405471b7.png">


-
- [x] [twitch.tv](https://twitch.tv/vinesauce) works

  - ![image](https://user-images.githubusercontent.com/525211/126276355-63815894-47e6-4f69-8308-8ceeb43cb73b.png)

- [x] [monetized youtube video](https://www.youtube.com/watch?v=-QMbZx_w2_Y)

  - ![image](https://user-images.githubusercontent.com/525211/126276573-a27425ab-884a-4612-99cb-ef12d452e75e.png)
  - **TESTERS NOTE** payment pointer associated is stale
  - **TESTERS NOTE** This url works >> https://www.youtube.com/watch?v=8EKg_rBWZdc <<

- Coil welcome and welcome to explore pages

  - [x] Go to coil.com, the browser action popup should show welcome to coil
    - ![image](https://user-images.githubusercontent.com/525211/126276719-692355e3-f571-4b08-8816-9b0715688d71.png)
    - **TESTERS NOTE** <img width="361" alt="image" src="https://user-images.githubusercontent.com/525211/154645202-8b3e8ac1-d62f-4c1a-8b99-fbfd9003f262.png">
  - [x] Should have a link to coil.com/discover page
  - [x] Once on explore page should show `Discover Now` with a rocket-ship graphic
    - ![image](https://user-images.githubusercontent.com/525211/126276807-f39ac03f-6c2b-419c-8a79-e2f2859b44a9.png)

- [x] Check the monetization animation works properly

  - ![image](https://user-images.githubusercontent.com/525211/126277022-48e139b6-871a-4ed4-8d45-58e194855ff8.png)
  - Only required on desktop browsers
  - Should animate when monetized and packets received
  - Should stop animation when network disconnected
    - Note that on Firefox/MacOS the popup automatically closes when the
      tab loses focus so can use something like this in terminal:
      - `sudo sleep 10 && sudo ifconfig en0 down && sleep 10 && sudo ifconfig en0 up`
      - **TESTERS NOTE** 
        - <img width="338" alt="image" src="https://user-images.githubusercontent.com/525211/154645913-8a52148a-0dc6-416c-8b5a-e7185696d4a7.png">
        - took a really long time

- [x] Check monetization works consistently

  - In the same tab, go to http://www.travisvcrist.com/gatehub
    - refresh and make sure streaming works 10 times in a row
      - should not get 'stuck' in 'setting up payment' state
  - Issue: [coil/coilhq#3038][ci3038]
  - Fix PRs: [#242][np242]

- [x] Will route to \$coildomain.com/login rather than open popup if logged out

  - Log out from \$coildomain.com
  - Check that icon is in 'unavailable' state
    - ![image](https://user-images.githubusercontent.com/525211/126277431-a7ae73a2-14a6-41b4-90f4-69f2b9be6df5.png)
  - Click on browser action
  - Check that routed to login page
    - ![image](https://user-images.githubusercontent.com/525211/126277570-77da3644-9950-465d-bac0-4afbd33a70e4.png)

- [x] Popup icon should show if page is monetized even when logged out

  - Log out from extension
  - Go to a monetized page and check that the icon "monetized" black and in 'unavailable' state
    - ![image](https://user-images.githubusercontent.com/525211/126277839-d482fea3-63bc-42d8-9dae-6eca318cdc63.png)

- [x] Run the puppeteer [tests](./test.sh) (look at the [circle jobs](../../../.circleci/config.yml))

  - export BROWSER_TYPE='chrome' # or 'firefox'

- [x] Go to a [youtube video](https://www.youtube.com/watch?v=l1btEwwRePs),
      manually skip to near end of video, and when autoplay of a video from
      another channel starts, check that monetization has stopped.

  - Issues: [#33][i33]
  - PRs: [#213][np213]

- [x] Go to [xrptipbot.com](https://www.xrptipbot.com/) and as page
      is loading very quickly open the popup.
      It should show "Thanks for your support" even before streaming
      starts. Should show 'setting up payment' then 'coil is paying creator'
      [#120][i120]
      - **TESTERS NOTE** this test is no longer relevant with the new ui

- [x] Open the [reloading-every-15s.html](http://localhost:4000/reloading-every-15s.html) file:

  - Use a localhost server so WM works (e.g. with `yarn serve:fixtures`)
  - Open the developer tools console undocked so can view while **PAGE IS BACKGROUNDED**
    - Note the `Reloading page` logging
  - Open the extension background page developer tools and look at the stream logging
  - SHOULD NOT initiate a stream or SPSP request
    [#144][i144]

- [x] Open the [event-logger.html](../test/fixtures/event-logger.html) file:

  - Use a localhost server so WM works (e.g. with `python -m http.server 4000`)
  - Look for unusual timings, check that pending state is emitted nearly
    immediately after page load or meta tag added
  - Issue: [#63][ni63]
  - Fix PR: [#69][np69]

- [x] Check started event fires when quickly switching between tabs

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Switch to another (non-monetized) tab. The payments stop. Quickly switch back to the first tab.
  - The payments restart. Make sure there is a monetizationstart event
  - Issue: [#105][ni105]
  - Fix PR: [#117][np117]

- [x] Check stopped event fires with correct requestId

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Induce a stop/start in same js 'tick'
  - Check that the stopped event has the correct requestId
  - Issue: [#127][ni127]
  - Fix PR: [#128][np128]

- [x] Check tip event fires when clicked on in the popup

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Open the extension popup and click on "Tip this creator \$1!"
  - Check that the tip event occurs
    - **TESTERS NOTE** <img width="208" alt="image" src="https://user-images.githubusercontent.com/525211/154650115-2da25d07-7384-4b0d-8f31-cc29a563e1fb.png">


- [x] Run a local web server (e.g. with `python -m http.server 4000`) serving
      the dist folder, then open [static/popup.html](static/popup.html) in a
      normal tab and check the popup rendering in various states.
    - **TESTERS NOTE** <img width="915" alt="image" src="https://user-images.githubusercontent.com/525211/154631429-dae855c6-079b-4dac-9c59-667eb112d159.png">
 

- [ ] If the browser is running on android, check that the "popup" browser action
      simply opens settings.

  - Install android-sdk on PC and Firefox on android
  - Enable developer mode on android and enable usb debugging
  - Plug in android to PC via usb
  - `adb devices # make note of device id`
  - `adb shell pm grant org.mozilla.firefox android.permission.READ_EXTERNAL_STORAGE`
  - `adb shell pm grant org.mozilla.firefox android.permission.WRITE_EXTERNAL_STORAGE`
  - Build the extension
  - `yarn web-ext run -s $PWD/dist --target=firefox-android --android-device=WUJ01PNSVY # from adb devices step`
  - Issue: [coil/coilhq#2084][ci2084]
  - Fix PRs: [#166][p166] [#295][p295]

- [ ] On MacOS Chromium browsers (Chrome/Edge) check that the monetized animation is working
      on non primary monitors.

  - Issue: [#312][i312]
  - Fix PR: [#317][p317]

- [x] Check that popup closes when another window is focused

  - Open two Browser windows, open the popup in one window
  - Focus on second window
  - Ensure that popup is closed

  - Issue: [#313][i313]
  - Fix PR: [#332][p332]

- [x] Check SPA apps keep streaming when url changed, meta stays

  - Go to e.g. https://www.wevolver.com/
  - Change other pages which uses HTML5 history.pushState
  - Check that streaming is maintained throughout

    - if not, use browser devtools to check if meta exists
      - `document.head.querySelector('meta[name="monetization"]')`

  - Issue: [#507][i507]
  - Fix PR: [#508][p508]

- [x] Check extension doesn't attempt to stream when unsubscribed

  - Log in with coil user that doesn't have active subscription
  - Open the developer tools and check the logging
  - SHOULD NOT even attempt to stream
  - ![image](https://user-images.githubusercontent.com/525211/66631124-c9840000-ec2f-11e9-95a4-3bebe7fdebd6.png)
  - Issue: [#213][i213]
  - Fix PR: [#222][p222]
  - **TESTERS NOTE** <img width="237" alt="image" src="https://user-images.githubusercontent.com/525211/154652004-4ebbd4db-9d20-4db8-8470-ce4621a2f2a3.png">


- [x] Check can stream immediately after subscribing

  - Likely best to test this with staging where can use a test card
  - Log in with coil user that doesn't have active subscription
  - Add a subscription (can use [testing card](https://stripe.com/docs/testing) 4242 4242 4242 4242 )
  - Go to a monetized page and check that streaming works immediately
  - **TESTERS NOTE** using a trial 
  - <img width="351" alt="image" src="https://user-images.githubusercontent.com/525211/154652104-5e56652d-4ea7-4140-bb86-c03d972c008b.png">
  - **TESTERS NOTE** required 2 refreshes of the page ... not a show stopper, but need to test again

- [x] Check no stop event is fired when logged out

  - Open and console and set `localStorage.WM_DEBUG = true`
  - Go to a web monetized page when logged out
  - Check that no events are logged

  - Issue: [#1947][ni1947]
  - Fix PR: [#1964][np1964]

### Iframe testing

1. - [x] Open a terminal and `cd packages/coil-extension/test/fixtures/iframes/`
2. - [x] Start a server (via `python -m http.server 4000` or equivalent)
3. - [x] Open http://localhost:4000/top-nested-allowed-iframe.html in browser
4. Open developer tools and look at the structure of the dom
5. **TESTERS NOTE** The xrptipbot payment pointer needs updating in `frame1.html`

- Use expand recursively feature
  - ![image](https://user-images.githubusercontent.com/525211/76400168-71098800-63b2-11ea-8069-5ee7b8b0707a.png)

5. - [x] With the console set `localStorage.WM_DEBUG = true`

#### Test 1: basic monetization

1. Load the page
2. - [x] Look for 4 monetizationpending events and 4 corresponding (same requestId) monetizationstart events logged in the console.

![image](https://user-images.githubusercontent.com/525211/76397844-6a791180-63ae-11ea-8f1c-72ef3a6183fb.png)

#### Test 2: refresh page / turn off / turn on

1. - [x] [re]load the page
2. - [x] Open developer tools and turn "off" monetization via editing allow attribute of top level iframes
   - ![image](https://user-images.githubusercontent.com/525211/76398261-28040480-63af-11ea-85cb-396960ced1bb.png)
   - Popup icon (and background page logging) should show no monetization:
     - [x] ![image](https://user-images.githubusercontent.com/525211/76398281-305c3f80-63af-11ea-857c-6ab6b409daa5.png)
   - Corresponding monetization events should be logged:
     - [ ] ![image](https://user-images.githubusercontent.com/525211/76398873-3999dc00-63b0-11ea-8ee6-7ca45d8b44f0.png)

3. turn "on" monetization via editing allow attribute of top level iframes
   - ![image](https://user-images.githubusercontent.com/525211/76398370-57b30c80-63af-11ea-86a8-133271e46b91.png)
   - [x] Popup icon (and background page logging) should show monetization
     - ![image](https://user-images.githubusercontent.com/525211/76398417-6d283680-63af-11ea-88e6-c4b0ed5c35f7.png)
   - [x] Corresponding monetization events should be logged:
     - ![image](https://user-images.githubusercontent.com/525211/76399026-841b5880-63b0-11ea-8b0b-c0ecbff13bee.png)

#### Test 3: refresh page / turn off / background tab / turn on / foreground tab

- As above but while the tab is backgrounded, after turning on each top level iframe a sequence of pending -> stopped events should be fired:
  - [x] ![image](https://user-images.githubusercontent.com/525211/76399956-1a03b300-63b2-11ea-9b77-671e94a1bf16.png)

#### Test 4: nested

- As per test 2
- Turn off one top level and then turn off the nested frames in top level that is allowed
- [x] allow _one_ nested iframe and check for indications of monetization


## MacOS Chrome Version 98.0.4758.80 (Official Build) (x86_64)

Copy below for each platform/browser/version tested, filtering steps where it
make sense.

- [ ] Build for prod with release settings

  - e.g. `yarn build-prod chrome -p --run-prod --devtool=none`
    - as per [package.sh](../package.sh)

- [x] Import unpacked/temporary extension/add-on

  - For Firefox, go to `about:debugging`
    - Enable add-on debugging
    - Load Temporary Add-on...
  - For Chrome or MS Edge, go to `chrome://extensions` (or `edge://extensions`) and `Load Unpacked`
  - Use `adb` to install Samsung Internet Extensions
    - be sure to kill the browser and delete shared settings to be sure correct addon is tested
    - see code in `scripts/reinstall-six.sh`

- [x] Ensure that you are [logged in with a user with valid subscription](https://coil.com/settings/membership)

  - ![image](https://user-images.githubusercontent.com/525211/71150879-28d04300-2265-11ea-96da-7d720c101575.png)

- [x] [example.com](http://example.com/) should say "This site isn't supported yet"

  - ![image](https://user-images.githubusercontent.com/525211/126276057-30b8285f-84a5-4e01-ae0e-85b7592883e6.png)

  - **TESTERS NOTE** <img width="342" alt="image" src="https://user-images.githubusercontent.com/525211/153140042-2dcdf2a8-6b74-4682-a274-d31333be37b7.png">

- [x] [xrptipbot.com](https://www.xrptipbot.com/) should monetize

  - ![image](https://user-images.githubusercontent.com/525211/126276225-62af2025-3f43-4a36-a3bc-e141c9a569de.png)
  - **TESTERS NOTE** <img width="356" alt="image" src="https://user-images.githubusercontent.com/525211/153140346-92c9cc7d-7362-48a1-bc78-1bdc78ccb80d.png">

- [x] [twitch.tv](https://twitch.tv/vinesauce) works

  - ![image](https://user-images.githubusercontent.com/525211/126276355-63815894-47e6-4f69-8308-8ceeb43cb73b.png)
  - **TESTERS NOTE** <img width="333" alt="image" src="https://user-images.githubusercontent.com/525211/153140522-ed7bcba7-742f-49d9-83e8-88a394fd96da.png">

- [ ] [monetized youtube video](https://www.youtube.com/watch?v=-QMbZx_w2_Y)

  - ![image](https://user-images.githubusercontent.com/525211/126276573-a27425ab-884a-4612-99cb-ef12d452e75e.png)
  - **TESTER NOTE** <img width="354" alt="image" src="https://user-images.githubusercontent.com/525211/153141328-78386e3b-5e39-482a-9474-304a7c4ae8e6.png">
  - **TESTERS NOTE** There's no real indication that streaming is failing due to ... perhaps a failing payment pointer?
  - **TESTERS NOTE**  ![image](https://user-images.githubusercontent.com/525211/153141706-b3c072c1-4d10-43dc-b92c-fc7c9b32275f.png)
  - `curl -v https://twitter.xrptipbot.com/craftthreader  -H 'accept: application/spsp4+json'` returns a 525
  - `< HTTP/2 525 
< date: Wed, 09 Feb 2022 07:25:50 GMT
< content-length: 0
< cache-control: no-store, no-cache
< cf-cache-status: DYNAMIC
< expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct" `

- Coil welcome and welcome to explore pages

  - [x] Go to coil.com, the browser action popup should show welcome to coil
    - ![image](https://user-images.githubusercontent.com/525211/126276719-692355e3-f571-4b08-8816-9b0715688d71.png)
    - **TESTERS NOTE**  <img width="353" alt="image" src="https://user-images.githubusercontent.com/525211/153144285-cc2047fb-c1c3-48e6-aacd-62e917f37a7a.png">
  - [x] Should have a link to coil.com/discover page
  - [x] Once on explore page should show `Discover Now` with a rocket-ship graphic
    - ![image](https://user-images.githubusercontent.com/525211/126276807-f39ac03f-6c2b-419c-8a79-e2f2859b44a9.png)
    - **TESTERS NOTE** <img width="367" alt="image" src="https://user-images.githubusercontent.com/525211/153144653-8ad4e5c9-fdbc-4616-ac7c-9879dc7dc195.png">


- [x] Check the monetization animation works properly

  - ![image](https://user-images.githubusercontent.com/525211/126277022-48e139b6-871a-4ed4-8d45-58e194855ff8.png)
  - Only required on desktop browsers
  - Should animate when monetized and packets received
  - Should stop animation when network disconnected
    - Note that on Firefox/MacOS the popup automatically closes when the
      tab loses focus so can use something like this in terminal:
      - `sudo sleep 10 && sudo ifconfig en0 down && sleep 10 && sudo ifconfig en0 up`

- [x] Check monetization works consistently

  - In the same tab, go to http://www.travisvcrist.com/gatehub
    - refresh and make sure streaming works 10 times in a row
      - should not get 'stuck' in 'setting up payment' state
  - Issue: [coil/coilhq#3038][ci3038]
  - Fix PRs: [#242][np242]

- [x] Will route to \$coildomain.com/login rather than open popup if logged out

  - Log out from \$coildomain.com
  - Check that icon is in 'unavailable' state
    - ![image](https://user-images.githubusercontent.com/525211/126277431-a7ae73a2-14a6-41b4-90f4-69f2b9be6df5.png)
  - Click on browser action
  - Check that routed to login page
    - ![image](https://user-images.githubusercontent.com/525211/126277570-77da3644-9950-465d-bac0-4afbd33a70e4.png)

- [x] Popup icon should show if page is monetized even when logged out

  - Log out from extension
  - Go to a monetized page and check that the icon "monetized" black and in 'unavailable' state
    - ![image](https://user-images.githubusercontent.com/525211/126277839-d482fea3-63bc-42d8-9dae-6eca318cdc63.png)

- [ ] Run the puppeteer [tests](./test.sh) (look at the [circle jobs](../../../.circleci/config.yml))

  - export BROWSER_TYPE='chrome' # or 'firefox'

- [ ] Go to a [youtube video](https://www.youtube.com/watch?v=l1btEwwRePs),
      manually skip to near end of video, and when autoplay of a video from
      another channel starts, check that monetization has stopped.

  - Issues: [#33][i33]
  - PRs: [#213][np213]
  - **TESTERS NOTE** the channel is no longer configured properly it seems:
    - ![image](https://user-images.githubusercontent.com/525211/153146204-bb8fc496-c5fa-423d-8aec-bb3f092c8d48.png)


- [ ] Go to [xrptipbot.com](https://www.xrptipbot.com/) and as page
      is loading very quickly open the popup.
      It should show "Thanks for your support" even before streaming
      starts. Should show 'setting up payment' then 'coil is paying creator'
      [#120][i120]
      - **TESTERS NOTE** See: https://coiltech.slack.com/archives/C01Q12WE5MG/p1644391980680639

- [x] Open the [reloading-every-15s.html](../test/fixtures/reloading-every-15s.html) file:

  - Use a localhost server so WM works (e.g. with `yarn serve:fixtures`)
  - Open the developer tools console undocked so can view while **PAGE IS BACKGROUNDED**
    - Note the `Reloading page` logging
  - Open the extension background page developer tools and look at the stream logging
  - SHOULD NOT initiate a stream or SPSP request
    [#144][i144]
   - **TESTERS NOTE** Needed to update old @sharafian pp

- [x] Open the [event-logger.html](../test/fixtures/event-logger.html) file:

  - Use a localhost server so WM works (e.g. with `python -m http.server 4000`)
  - Look for unusual timings, check that pending state is emitted nearly
    immediately after page load or meta tag added
  - Issue: [#63][ni63]
  - Fix PR: [#69][np69]
  - **TESTERS NOTE** uphold pp some times gets stuck in pending mode for up to 10 seconds

- [x] Check started event fires when quickly switching between tabs

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Switch to another (non-monetized) tab. The payments stop. Quickly switch back to the first tab.
  - The payments restart. Make sure there is a monetizationstart event
  - Issue: [#105][ni105]
  - Fix PR: [#117][np117]

- [x] Check stopped event fires with correct requestId

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Induce a stop/start in same js 'tick'
  - Check that the stopped event has the correct requestId
  - Issue: [#127][ni127]
  - Fix PR: [#128][np128]

- [ ] Check tip event fires when clicked on in the popup

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Open the extension popup and click on "Tip this creator \$1!"
  - Check that the tip event occurs

- [x] Run a local web server (e.g. with `python -m http.server 4000`) serving
      the dist folder, then open [static/popup.html](static/popup.html) in a
      normal tab and check the popup rendering in various states.

- [ ] If the browser is running on android, check that the "popup" browser action
      simply opens settings.

  - Install android-sdk on PC and Firefox on android
  - Enable developer mode on android and enable usb debugging
  - Plug in android to PC via usb
  - `adb devices # make note of device id`
  - `adb shell pm grant org.mozilla.firefox android.permission.READ_EXTERNAL_STORAGE`
  - `adb shell pm grant org.mozilla.firefox android.permission.WRITE_EXTERNAL_STORAGE`
  - Build the extension
  - `yarn web-ext run -s $PWD/dist --target=firefox-android --android-device=WUJ01PNSVY # from adb devices step`
  - Issue: [coil/coilhq#2084][ci2084]
  - Fix PRs: [#166][p166] [#295][p295]

- [x] On MacOS Chromium browsers (Chrome/Edge) check that the monetized animation is working
      on non primary monitors.

  - Issue: [#312][i312]
  - Fix PR: [#317][p317]

- [x] Check that popup closes when another window is focused

  - Open two Browser windows, open the popup in one window
  - Focus on second window
  - Ensure that popup is closed

  - Issue: [#313][i313]
  - Fix PR: [#332][p332]

- [x] Check SPA apps keep streaming when url changed, meta stays

  - Go to e.g. https://www.wevolver.com/
  - Change other pages which uses HTML5 history.pushState
  - Check that streaming is maintained throughout

    - if not, use browser devtools to check if meta exists
      - `document.head.querySelector('meta[name="monetization"]')`

  - Issue: [#507][i507]
  - Fix PR: [#508][p508]

- [ ] Check extension doesn't attempt to stream when unsubscribed

  - Log in with coil user that doesn't have active subscription
  - Open the developer tools and check the logging
  - SHOULD NOT even attempt to stream
  - ![image](https://user-images.githubusercontent.com/525211/66631124-c9840000-ec2f-11e9-95a4-3bebe7fdebd6.png)
  - Issue: [#213][i213]
  - Fix PR: [#222][p222]

- [ ] Check can stream immediately after subscribing

  - Likely best to test this with staging where can use a test card
  - Log in with coil user that doesn't have active subscription
  - Add a subscription (can use [testing card](https://stripe.com/docs/testing) 4242 4242 4242 4242 )
  - Go to a monetized page and check that streaming works immediately

- [x] Check no stop event is fired when logged out

  - Open and console and set `localStorage.WM_DEBUG = true`
  - Go to a web monetized page when logged out
  - Check that no events are logged

  - Issue: [#1947][ni1947]
  - Fix PR: [#1964][np1964]

### Iframe testing

1. - [ ] Open a terminal and `cd packages/coil-extension/test/fixtures/iframes/`
2. - [ ] Start a server (via `python -m http.server 4000` or equivalent)
3. - [ ] Open http://localhost:4000/top-nested-allowed-iframe.html in browser
4. Open developer tools and look at the structure of the dom

- Use expand recursively feature
  - ![image](https://user-images.githubusercontent.com/525211/76400168-71098800-63b2-11ea-8069-5ee7b8b0707a.png)

5. - [ ] With the console set `localStorage.WM_DEBUG = true`

#### Test 1: basic monetization

1. Load the page
2. - [ ] Look for 4 monetizationpending events and 4 corresponding (same requestId) monetizationstart events logged in the console.

![image](https://user-images.githubusercontent.com/525211/76397844-6a791180-63ae-11ea-8f1c-72ef3a6183fb.png)

#### Test 2: refresh page / turn off / turn on

1. - [ ] [re]load the page
2. - [ ] Open developer tools and turn "off" monetization via editing allow attribute of top level iframes
   - ![image](https://user-images.githubusercontent.com/525211/76398261-28040480-63af-11ea-85cb-396960ced1bb.png)
   - Popup icon (and background page logging) should show no monetization:
     - [ ] ![image](https://user-images.githubusercontent.com/525211/76398281-305c3f80-63af-11ea-857c-6ab6b409daa5.png)
   - Corresponding monetization events should be logged:
     - [ ] ![image](https://user-images.githubusercontent.com/525211/76398873-3999dc00-63b0-11ea-8ee6-7ca45d8b44f0.png)

3. turn "on" monetization via editing allow attribute of top level iframes
   - ![image](https://user-images.githubusercontent.com/525211/76398370-57b30c80-63af-11ea-86a8-133271e46b91.png)
   - [ ] Popup icon (and background page logging) should show monetization
     - ![image](https://user-images.githubusercontent.com/525211/76398417-6d283680-63af-11ea-88e6-c4b0ed5c35f7.png)
   - [ ] Corresponding monetization events should be logged:
     - ![image](https://user-images.githubusercontent.com/525211/76399026-841b5880-63b0-11ea-8b0b-c0ecbff13bee.png)

#### Test 3: refresh page / turn off / background tab / turn on / foreground tab

- As above but while the tab is backgrounded, after turning on each top level iframe a sequence of pending -> stopped events should be fired:
  - [ ] ![image](https://user-images.githubusercontent.com/525211/76399956-1a03b300-63b2-11ea-9b77-671e94a1bf16.png)

#### Test 4: nested

- As per test 2
- Turn off one top level and then turn off the nested frames in top level that is allowed
- [ ] allow _one_ nested iframe and check for indications of monetization

[i33]: https://github.com/coilhq/web-monetization/issues/33
[i120]: https://github.com/coilhq/web-monetization/issues/120
[i144]: https://github.com/coilhq/web-monetization/issues/144
[p166]: https://github.com/coilhq/web-monetization/pull/166
[i213]: https://github.com/coilhq/web-monetization/issues/213
[p222]: https://github.com/coilhq/web-monetization/pull/222
[p295]: https://github.com/coilhq/web-monetization/pull/295
[ci2084]: https://github.com/coilhq/coil/issues/2084
[ci3038]: https://github.com/coilhq/coil/issues/3038
[i312]: https://github.com/coilhq/web-monetization/issues/312
[p317]: https://github.com/coilhq/web-monetization/pull/317
[i313]: https://github.com/coilhq/web-monetization/issues/313
[p332]: https://github.com/coilhq/web-monetization/pull/332
[i507]: https://github.com/coilhq/web-monetization/issues/507
[p508]: https://github.com/coilhq/web-monetization/pull/508
[np28]: https://github.com/coilhq/web-monetization-projects/pull/28
[ni21]: https://github.com/coilhq/web-monetization-projects/issue/21
[ni63]: https://github.com/coilhq/web-monetization-projects/issue/63
[np69]: https://github.com/coilhq/web-monetization-projects/pull/69
[ni105]: https://github.com/coilhq/web-monetization-projects/issue/105
[np117]: https://github.com/coilhq/web-monetization-projects/pull/117
[ni127]: https://github.com/coilhq/web-monetization-projects/issue/127
[np128]: https://github.com/coilhq/web-monetization-projects/pull/128
[ni184]: https://github.com/coilhq/web-monetization-projects/issue/184
[np185]: https://github.com/coilhq/web-monetization-projects/pull/185
[np213]: https://github.com/coilhq/web-monetization-projects/pull/213
[np242]: https://github.com/coilhq/web-monetization-projects/pull/242
[np1964]: https://github.com/coilhq/web-monetization-projects/pull/1964
[ni1947]: https://github.com/coilhq/web-monetization-projects/issue/1947
