### PR TITLE
feat: redirect back to tip view if tip preview fails

### DIFF
--- a/packages/coil-extension/src/popup/components/views/TipConfirmView.tsx
+++ b/packages/coil-extension/src/popup/components/views/TipConfirmView.tsx
@@ -79,8 +79,12 @@ export const TipConfirmView = (): React.ReactElement => {
   }
   const getTipQuote = async (tipAmount: number) => {
     const tipQuote = await getTipQuotePromise(tipAmount)
-    setTipCreditCharge(Number(tipQuote.tipCreditCharge))
-    setCreditCardCharge(Number(tipQuote.creditCardCharge))
+    if (tipQuote.success) {
+      setTipCreditCharge(Number(tipQuote.tipCreditCharge))
+      setCreditCardCharge(Number(tipQuote.creditCardCharge))
+    } else {
+      router.to(ROUTES.tipping)
+    }
   }
 
   const sendTip = async (tipAmount: number) => {


### PR DESCRIPTION
resolves: COIL-1805

redirect back to TipView if `tipPreview` errors out due to user leaving the flow.