### PR TITLE
fix: tip graphql error

### DIFF
--- a/packages/coil-client/src/queries/tip.ts
+++ b/packages/coil-client/src/queries/tip.ts
@@ -38,9 +38,7 @@ export async function tip(
   const code = tip?.code
   if (!success) {
     const errorMsg =
-      tip.message && tip.message !== ''
-        ? tip.message
-        : `graphql query failed. status=${code} query=\`${tipQuery}\``
+      tip.message && tip.message !== '' ? tip.message : 'Something went wrong'
     throw new Error(errorMsg)
   }
 

--- a/packages/coil-client/src/queries/tip.ts
+++ b/packages/coil-client/src/queries/tip.ts
@@ -37,9 +37,11 @@ export async function tip(
   const success = tip?.success
   const code = tip?.code
   if (!success) {
-    throw new Error(
-      `graphql query failed. status=${code} query=\`${tipQuery}\``
-    )
+    const errorMsg =
+      tip.message && tip.message !== ''
+        ? tip.message
+        : `graphql query failed. status=${code} query=\`${tipQuery}\``
+    throw new Error(errorMsg)
   }
 
   return tip


### PR DESCRIPTION
resolves: COIL-1875

the `tip` mutation was manually throwing `graphql query failed. status=${code} query=\${tipQuery}\` if the result was not a success, updated it to pass the response message as the error if it exists otherwise just a generic "Something went wrong"