### PR TITLE
feat: disallow fractional inputs

### DIFF
--- a/packages/coil-extension/src/popup/components/AmountInput.test.ts
+++ b/packages/coil-extension/src/popup/components/AmountInput.test.ts
@@ -1,0 +1,43 @@
+import { calculateInputWidth, normalizeAmountInput } from './AmountInput'
+
+describe('handleAmountInputChange', () => {
+  const tipContext = {
+    maxAllowableTipAmountUsd: 20
+  }
+  it('should normalize fractional inputs', () => {
+    const input = '0.1'
+    const normed = normalizeAmountInput(input, tipContext)
+    expect(normed).toStrictEqual({ displayValue: '1', value: '1' })
+  })
+  it('should ignore alphas', () => {
+    const input = 'a'
+    const normed = normalizeAmountInput(input, tipContext)
+    expect(normed).toStrictEqual({ displayValue: '', value: '1' })
+  })
+  it('should ignore spaces', () => {
+    const input = ' '
+    const normed = normalizeAmountInput(input, tipContext)
+    expect(normed).toStrictEqual({ displayValue: '', value: '1' })
+  })
+  it('should normalize 1.0 to 10', () => {
+    const input = '1.0'
+    const normed = normalizeAmountInput(input, tipContext)
+    expect(normed).toStrictEqual({ displayValue: '10', value: '10' })
+  })
+  it('should normalize 10.0 to 10', () => {
+    const input = '10.0'
+    const normed = normalizeAmountInput(input, tipContext)
+    expect(normed).toStrictEqual({ displayValue: '20', value: '20' })
+  })
+})
+
+describe('calculateInputWidth', () => {
+  it('should return a px denominated number', () => {
+    const width = calculateInputWidth('1')
+    expect(width).toBe('40px')
+  })
+  it('should return "80px" for "10"', () => {
+    const width = calculateInputWidth('10')
+    expect(width).toBe('80px')
+  })
+})

--- a/packages/coil-extension/src/popup/components/AmountInput.tsx
+++ b/packages/coil-extension/src/popup/components/AmountInput.tsx
@@ -92,9 +92,9 @@ export const AmountInput = (): React.ReactElement => {
 
     // ensure that the input is a valid number input
     // remove any alphabet, special characters, leading zero, leading decimal
-    // const fractionalAmountRegex = new RegExp(/(^[0])|(^\.)|([a-zA-Z\s])|([!@#$%^&*()_+\-=[\]{};':"\\|,<>/?])|(?<=\..*)\.|/gm)
+    // const fractionalAmountRegex = new RegExp(/(^[0])|(^\.)|([a-zA-Z\s])|([`!@#$%^&*()_+\-=[\]{};':"\\|,<>/?])|(?<=\..*)\.|/gm)
     const amountRegex = new RegExp(
-      /(^[0])|([a-zA-Z\s])|([.!@#$%^&*()_+\-=[\]{};':"\\|,<>/?])|/gm
+      /(^[0])|([a-zA-Z\s])|([`.!@#$%^&*()_+\-=[\]{};':"\\|,<>/?])|/gm
     )
     value = value.replace(amountRegex, '')
 

--- a/packages/coil-extension/src/popup/components/AmountInput.tsx
+++ b/packages/coil-extension/src/popup/components/AmountInput.tsx
@@ -3,7 +3,8 @@ import { styled } from '@material-ui/core'
 
 import { Colors } from '../../shared-theme/colors'
 import { useStore } from '../context/storeContext'
-import { useTip } from '../context/tipContext'
+import { ITipContext, useTip } from '../context/tipContext'
+import { User } from '../../types/user'
 
 import { IncDecButton, IncDec } from './IncDecButton'
 
@@ -63,14 +64,61 @@ const Input = styled('input')({
   }
 })
 
+const defaultFontSize = 64
+const characterSpacing = 0.6
+const characterWidth = 40
+const maxAmountWidth = 160
+
+export function calculateInputWidth(value: string) {
+  const newWidth = value.length * characterWidth
+  if (newWidth < maxAmountWidth) {
+    return `${newWidth}px`
+  } else {
+    return `${maxAmountWidth}px`
+  }
+}
+
+export const normalizeAmountInput = (
+  value: string,
+  context: Pick<ITipContext, 'maxAllowableTipAmountUsd'>,
+  user?: User | null
+) => {
+  const { minTipLimitAmountUsd = 1 } = user?.tipSettings || {}
+
+  // ensure that the input is a valid number input
+  // remove any alphabet, special characters, leading zero, leading decimal
+  const amountRegex = new RegExp(
+    /(^[0])|([a-zA-Z\s])|([`.!@#$%^&*()_+\-=[\]{};':"\\|,<>/?])|/gm
+  )
+  value = value.replace(amountRegex, '')
+
+  // strip the values from the thousandths place if it exists
+  // doing this first so when the input display is set while typing it limits the user
+  if (value.includes('.')) {
+    if (value.split('.')[1].length > 2) {
+      value = value.slice(0, -1)
+    }
+  }
+
+  // set the value to max limit if input is greater
+  if (Number(value) > context.maxAllowableTipAmountUsd) {
+    value = context.maxAllowableTipAmountUsd.toString()
+  }
+
+  const displayValue = value
+
+  // set the value to min limit if input is less
+  if (Number(value) < minTipLimitAmountUsd) {
+    value = minTipLimitAmountUsd.toString()
+  }
+
+  return { displayValue, value }
+}
+
 //
 // Component
 //
 export const AmountInput = (): React.ReactElement => {
-  const defaultFontSize = 64
-  const characterSpacing = 0.6
-  const characterWidth = 40
-  const maxAmountWidth = 160
   const [displayFontSize, setDisplayFontSize] =
     useState<number>(defaultFontSize)
 
@@ -79,56 +127,29 @@ export const AmountInput = (): React.ReactElement => {
 
   const { user } = useStore()
   const { minTipLimitAmountUsd = 1 } = user?.tipSettings || {}
+  const tipContext = useTip()
   const {
     currentTipAmountUsd,
     setCurrentTipAmountUsd,
     maxAllowableTipAmountUsd
-  } = useTip()
+  } = tipContext
 
   // validates the manual input and updates the state with the current amount
   // Masks input value to ensure only value entries are displayed.
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     let value = e.target.value
 
-    // ensure that the input is a valid number input
-    // remove any alphabet, special characters, leading zero, leading decimal
-    // const fractionalAmountRegex = new RegExp(/(^[0])|(^\.)|([a-zA-Z\s])|([`!@#$%^&*()_+\-=[\]{};':"\\|,<>/?])|(?<=\..*)\.|/gm)
-    const amountRegex = new RegExp(
-      /(^[0])|([a-zA-Z\s])|([`.!@#$%^&*()_+\-=[\]{};':"\\|,<>/?])|/gm
-    )
-    value = value.replace(amountRegex, '')
-
-    // strip the values from the thousandths place if it exists
-    // doing this first so when the input display is set while typing it limits the user
-    if (value.includes('.')) {
-      if (value.split('.')[1].length > 2) {
-        value = value.slice(0, -1)
-      }
-    }
-
-    // set the value to max limit if input is greater
-    if (Number(value) > maxAllowableTipAmountUsd) {
-      value = maxAllowableTipAmountUsd.toString()
-    }
+    const normed = normalizeAmountInput(value, tipContext, user)
+    value = normed.value
 
     // set the display value on the input for while the user is typing
     // setting before the min limit so the user can clear out the first digit
     if (inputRef.current) {
-      inputRef.current.value = value
-    }
-
-    // set the value to min limit if input is less
-    if (Number(value) < minTipLimitAmountUsd) {
-      value = minTipLimitAmountUsd.toString()
+      inputRef.current.value = normed.displayValue
     }
 
     // Calculate and set the size of the input field based on the input
-    const newWidth = value.length * characterWidth
-    if (newWidth < maxAmountWidth) {
-      e.target.style.width = `${newWidth}px`
-    } else {
-      e.target.style.width = `${maxAmountWidth}px`
-    }
+    e.target.style.width = calculateInputWidth(value)
 
     // update state for the actual current tip amount
     setCurrentTipAmountUsd(Number(value))

--- a/packages/coil-extension/src/popup/components/AmountInput.tsx
+++ b/packages/coil-extension/src/popup/components/AmountInput.tsx
@@ -92,10 +92,11 @@ export const AmountInput = (): React.ReactElement => {
 
     // ensure that the input is a valid number input
     // remove any alphabet, special characters, leading zero, leading decimal
-    value = value.replace(
-      /(^[0])|(^\.)|([a-zA-Z\s])|([!@#$%^&*()_+\-=[\]{};':"\\|,<>/?])|(?<=\..*)\.|/gm,
-      ''
+    // const fractionalAmountRegex = new RegExp(/(^[0])|(^\.)|([a-zA-Z\s])|([!@#$%^&*()_+\-=[\]{};':"\\|,<>/?])|(?<=\..*)\.|/gm)
+    const amountRegex = new RegExp(
+      /(^[0])|([a-zA-Z\s])|([.!@#$%^&*()_+\-=[\]{};':"\\|,<>/?])|/gm
     )
+    value = value.replace(amountRegex, '')
 
     // strip the values from the thousandths place if it exists
     // doing this first so when the input display is set while typing it limits the user

--- a/packages/coil-extension/src/popup/components/TipAmountFeedback.tsx
+++ b/packages/coil-extension/src/popup/components/TipAmountFeedback.tsx
@@ -77,6 +77,7 @@ export const TipAmountFeedback = () => {
     return null
   }
 
+  // This formatting is here in case we choose to start allowing fractional amounts later on
   const formattedTipCreditAmountUsd = Number.isInteger(totalTipCreditAmountUsd)
     ? totalTipCreditAmountUsd
     : totalTipCreditAmountUsd.toFixed(2)

--- a/packages/coil-extension/src/popup/components/TipAmountFeedback.tsx
+++ b/packages/coil-extension/src/popup/components/TipAmountFeedback.tsx
@@ -41,6 +41,7 @@ export const TipAmountFeedback = () => {
 
   const getRestrictedMessage = () => {
     if (maxAllowableTipAmountUsd < minTipLimitAmountUsd) {
+      // happens if you have $0 dollars or less than $1 that you are allowed to spend based on your limit
       return (
         <Typography variant='subtitle1'>
           Limit below minimum tip.{' '}
@@ -76,13 +77,17 @@ export const TipAmountFeedback = () => {
     return null
   }
 
+  const formattedTipCreditAmountUsd = Number.isInteger(totalTipCreditAmountUsd)
+    ? totalTipCreditAmountUsd
+    : totalTipCreditAmountUsd.toFixed(2)
+
   return (
     <Box textAlign='center'>
       <Box>
         <Typography variant='subtitle1'>
           Available tip credits:{' '}
           <ChargeAmount iszero={totalTipCreditAmountUsd == 0}>
-            ${totalTipCreditAmountUsd.toFixed(2)}
+            ${formattedTipCreditAmountUsd}
           </ChargeAmount>
         </Typography>
       </Box>

--- a/packages/coil-extension/src/popup/context/tipContext.tsx
+++ b/packages/coil-extension/src/popup/context/tipContext.tsx
@@ -8,7 +8,7 @@ import { calculateMaxAllowableTip } from '../../util/calculateMaxAllowableTip'
 //
 // Models
 //
-interface ITipContext {
+export interface ITipContext {
   currentTipAmountUsd: number
   finalTipAmountUsd: number //* only used for the TipCompleteView so it renders the proper amount after local storage updates
   maxAllowableTipAmountUsd: number //* the maxAllowableTip is primarily responsible for disabling tipping inputs


### PR DESCRIPTION
resolves: COIL-1920

limits manual input of tips to whole numbers and does not allow users to input fractional amounts.