### PR TITLE
chore(coil-extension): bump version to 0.0.58

### DIFF
--- a/packages/coil-extension/CHANGELOG.md
+++ b/packages/coil-extension/CHANGELOG.md
@@ -1,3 +1,11 @@
+- <a name="coil-extension@0.0.58"></a>
+
+# [coil-extension@0.0.58](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.57...coil-extension@0.0.58) (2021-02-25)
+
+### Bug Fixes
+
+-
+
 <a name="coil-extension@0.0.57"></a>
 
 # [coil-extension@0.0.57](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.56...coil-extension@0.0.57) (2022-02-08)

--- a/packages/coil-extension/CHANGELOG.md
+++ b/packages/coil-extension/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Update icon when only tipping is supported [#2635](https://github.com/coilhq/web-monetization-projects/pull/2635)
 - Disallow fractional inputs [#2636](https://github.com/coilhq/web-monetization-projects/pull/2636)
+- Updated messaging for limits [#2639](https://github.com/coilhq/web-monetization-projects/pull/2639)
 
 <a name="coil-extension@0.0.57"></a>
 

--- a/packages/coil-extension/CHANGELOG.md
+++ b/packages/coil-extension/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Bug Fixes
 
--
+- Update icon when only tipping is supported [#2635](https://github.com/coilhq/web-monetization-projects/pull/2635)
+- Disallow fractional inputs [#2636](https://github.com/coilhq/web-monetization-projects/pull/2636)
 
 <a name="coil-extension@0.0.57"></a>
 

--- a/packages/coil-extension/manifest.json
+++ b/packages/coil-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Coil",
   "description": "Support websites and creators with Web Monetization",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "manifest_version": 2,
   "content_security_policy": "script-src 'self' 'sha256-ZB4S3fpmqhkYmY2fAkJhOuCiCW9xtnSo9QaJPSzPH7Q='; object-src 'self'",
   "browser_specific_settings": {

--- a/packages/coil-extension/package.json
+++ b/packages/coil-extension/package.json
@@ -1,10 +1,10 @@
 {
   "$schema": "../coil-monorepo-upkeep/resources/package-json-schema-nested-overrides.json",
   "$overRideUpKeep": {
-    "version": "0.0.57"
+    "version": "0.0.58"
   },
   "name": "@coil/extension",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "keywords": [
     "ilp",
     "web-monetization"

--- a/packages/coil-extension/six-apktool-decoded/apktool.yml
+++ b/packages/coil-extension/six-apktool-decoded/apktool.yml
@@ -18,5 +18,5 @@ usesFramework:
   tag: null
 version: 2.4.1
 versionInfo:
-  versionCode: '58'
-  versionName: 0.0.57
+  versionCode: '59'
+  versionName: 0.0.58


### PR DESCRIPTION
## Chores

- [x] Make sure the manifest version was bumped but doesn't skip versions

- [x] Update the [apktool.yml](../six-apktool-decoded/apktool.yml) versionCode/versionName
      and commit it to the repository.

- [x] Update the [CHANGELOG.md](../CHANGELOG.md)

  - You can compare this branch against last release via:
    - https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.57...nd-bump-version-0-58-2022-02-25

- [ ] Review and merge https://github.com/coilhq/web-monetization-projects/pull/2639
