### PR TITLE
chore(coil-extension): bump version to 0.0.59

### DIFF
--- a/packages/coil-extension/CHANGELOG.md
+++ b/packages/coil-extension/CHANGELOG.md
@@ -1,4 +1,18 @@
+- <a name="coil-extension@0.0.59"></a>
+
+# [coil-extension@0.0.59](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.58...coil-extension@0.0.59) (2021-05-09)
+
+### New Features
+
+- Set default view to tipping where enabled [#2717](https://github.com/coilhq/web-monetization-projects/pull/2717) [#2836](https://github.com/coilhq/web-monetization-projects/pull/2836)
+- Keyboard accessible tipping buttons [#2652](https://github.com/coilhq/web-monetization-projects/pull/2652)
+
 - <a name="coil-extension@0.0.58"></a>
+
+### Fixes
+
+- Use tabs permission on Firefox to fix logout issues [#2679](https://github.com/coilhq/web-monetization-projects/pull/2679)
+- Omit Cookies at source as well as CF from anon tokens requests [#2814](https://github.com/coilhq/web-monetization-projects/pull/2814)[#2842](https://github.com/coilhq/web-monetization-projects/pull/2842)
 
 # [coil-extension@0.0.58](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.57...coil-extension@0.0.58) (2021-02-25)
 

--- a/packages/coil-extension/docs/release-checklist.md
+++ b/packages/coil-extension/docs/release-checklist.md
@@ -35,7 +35,7 @@ When releasing, we can copy this markdown into the PR for a release.
 ## $Platform $Browser \$Version
 
 Copy below for each platform/browser/version tested, filtering steps where it
-make sense.
+makes sense.
 
 - [ ] Build for prod with release settings
 
@@ -57,34 +57,34 @@ make sense.
   - ![image](https://user-images.githubusercontent.com/525211/71150879-28d04300-2265-11ea-96da-7d720c101575.png)
     (or trial)
 
-- [ ] [example.com](http://example.com/) should say "This site isn't supported yet"
+- [ ] [example.com](http://example.com/) should say "Streaming not enabled"
 
-  - ![image](https://user-images.githubusercontent.com/525211/126276057-30b8285f-84a5-4e01-ae0e-85b7592883e6.png)
+  - ![image](https://user-images.githubusercontent.com/525211/154630950-e179eb7c-cf62-4a8c-b1b5-aa033f1ff57f.png)
 
 - [ ] [xrptipbot.com](https://www.xrptipbot.com/) should monetize
 
-  - ![image](https://user-images.githubusercontent.com/525211/126276225-62af2025-3f43-4a36-a3bc-e141c9a569de.png)
+  - ![image](https://user-images.githubusercontent.com/525211/154631133-1be5f080-858f-4984-9548-1b5b405471b7.png)
 
 -
 - [ ] [twitch.tv](https://twitch.tv/vinesauce) works
 
-  - ![image](https://user-images.githubusercontent.com/525211/126276355-63815894-47e6-4f69-8308-8ceeb43cb73b.png)
+  - <img width="355" alt="image" src="https://user-images.githubusercontent.com/525211/167336900-740809a6-4134-4f33-8f33-e3d45bd30f25.png">
 
-- [ ] [monetized youtube video](https://www.youtube.com/watch?v=-QMbZx_w2_Y)
+- [ ] [monetized youtube video](https://www.youtube.com/watch?v=8EKg_rBWZdc)
 
-  - ![image](https://user-images.githubusercontent.com/525211/126276573-a27425ab-884a-4612-99cb-ef12d452e75e.png)
+  - <img width="411" alt="image" src="https://user-images.githubusercontent.com/525211/167337147-6b8c430f-fbcc-4a34-ac42-550cb56b0632.png">
 
 - Coil welcome and welcome to explore pages
 
-  - [ ] Go to coil.com, the browser action popup should show welcome to coil
-    - ![image](https://user-images.githubusercontent.com/525211/126276719-692355e3-f571-4b08-8816-9b0715688d71.png)
+  - [ ] Go to coil.com, the browser action popup should show "Welcome, $username"
+    - <img width="336" alt="image" src="https://user-images.githubusercontent.com/525211/167337854-ba1dcb84-ec9d-434b-8e5e-1bb0b047efbc.png">
   - [ ] Should have a link to coil.com/discover page
-  - [ ] Once on explore page should show `Discover Now` with a rocket-ship graphic
+  - [ ] Once on discover page should show `Discover Now` with a rocket-ship graphic
     - ![image](https://user-images.githubusercontent.com/525211/126276807-f39ac03f-6c2b-419c-8a79-e2f2859b44a9.png)
 
 - [ ] Check the monetization animation works properly
 
-  - ![image](https://user-images.githubusercontent.com/525211/126277022-48e139b6-871a-4ed4-8d45-58e194855ff8.png)
+  - <img width="355" alt="image" src="https://user-images.githubusercontent.com/525211/167338973-a4726572-dca9-4c46-ac67-e5d8457c34f2.png">
   - Only required on desktop browsers
   - Should animate when monetized and packets received
   - Should stop animation when network disconnected
@@ -109,12 +109,6 @@ make sense.
   - Check that routed to login page
     - ![image](https://user-images.githubusercontent.com/525211/126277570-77da3644-9950-465d-bac0-4afbd33a70e4.png)
 
-- [ ] Popup icon should show if page is monetized even when logged out
-
-  - Log out from extension
-  - Go to a monetized page and check that the icon "monetized" black and in 'unavailable' state
-    - ![image](https://user-images.githubusercontent.com/525211/126277839-d482fea3-63bc-42d8-9dae-6eca318cdc63.png)
-
 - [ ] Run the puppeteer [tests](./test.sh) (look at the [circle jobs](../../../.circleci/config.yml))
 
   - export BROWSER_TYPE='chrome' # or 'firefox'
@@ -128,8 +122,9 @@ make sense.
 
 - [ ] Go to [xrptipbot.com](https://www.xrptipbot.com/) and as page
       is loading very quickly open the popup.
-      It should show "Thanks for your support" even before streaming
-      starts. Should show 'setting up payment' then 'coil is paying creator'
+      It should show "Thank you" even before streaming
+      starts. The animation should play when the streaming starts and
+      the outlined circle should become solid green in the toolbar icon.
       [#120][i120]
 
 - [ ] Open the [reloading-every-15s.html](http://localhost:4000/reloading-every-15s.html) file:
@@ -160,7 +155,7 @@ make sense.
 - [ ] Check stopped event fires with correct requestId
 
   - Open the [event-logger.html](../test/fixtures/event-logger.html) file
-  - Induce a stop/start in same js 'tick'
+  - Induce a stop/start in same js 'tick' (tack on #induce to end of url)
   - Check that the stopped event has the correct requestId
   - Issue: [#127][ni127]
   - Fix PR: [#128][np128]
@@ -168,10 +163,10 @@ make sense.
 - [ ] Check tip event fires when clicked on in the popup
 
   - Open the [event-logger.html](../test/fixtures/event-logger.html) file
-  - Open the extension popup and click on "Tip this creator \$1!"
+  - Open the extension popup and click on "Send \$1!" in the tipping tab
   - Check that the tip event occurs
 
-- [ ] Run a local web server (e.g. with `python -m http.server 4000`) serving
+- [ ] Run a local web server (with `yarn run serve:dist`) serving
       the dist folder, then open [static/popup.html](static/popup.html) in a
       normal tab and check the popup rendering in various states.
 
@@ -204,18 +199,6 @@ make sense.
   - Issue: [#313][i313]
   - Fix PR: [#332][p332]
 
-- [ ] Check SPA apps keep streaming when url changed, meta stays
-
-  - Go to e.g. https://www.wevolver.com/
-  - Change other pages which uses HTML5 history.pushState
-  - Check that streaming is maintained throughout
-
-    - if not, use browser devtools to check if meta exists
-      - `document.head.querySelector('meta[name="monetization"]')`
-
-  - Issue: [#507][i507]
-  - Fix PR: [#508][p508]
-
 - [ ] Check extension doesn't attempt to stream when unsubscribed
 
   - Log in with coil user that doesn't have active subscription
@@ -243,8 +226,8 @@ make sense.
 
 ### Iframe testing
 
-1. - [ ] Open a terminal and `cd packages/coil-extension/test/fixtures/iframes/`
-2. - [ ] Start a server (via `python -m http.server 4000` or equivalent)
+1. - [ ] Open a terminal
+2. - [ ] Start server (via `yarn serve:fixtures-iframes` )
 3. - [ ] Open http://localhost:4000/top-nested-allowed-iframe.html in browser
 4. Open developer tools and look at the structure of the dom
 

--- a/packages/coil-extension/manifest.json
+++ b/packages/coil-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Coil",
   "description": "Support websites and creators with Web Monetization",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "manifest_version": 2,
   "content_security_policy": "script-src 'self' 'sha256-ZB4S3fpmqhkYmY2fAkJhOuCiCW9xtnSo9QaJPSzPH7Q='; object-src 'self'",
   "browser_specific_settings": {

--- a/packages/coil-extension/package.json
+++ b/packages/coil-extension/package.json
@@ -1,10 +1,10 @@
 {
   "$schema": "../coil-monorepo-upkeep/resources/package-json-schema-nested-overrides.json",
   "$overRideUpKeep": {
-    "version": "0.0.58"
+    "version": "0.0.59"
   },
   "name": "@coil/extension",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "keywords": [
     "ilp",
     "web-monetization"

--- a/packages/coil-extension/six-apktool-decoded/apktool.yml
+++ b/packages/coil-extension/six-apktool-decoded/apktool.yml
@@ -18,5 +18,5 @@ usesFramework:
   tag: null
 version: 2.4.1
 versionInfo:
-  versionCode: '59'
-  versionName: 0.0.58
+  versionCode: '60'
+  versionName: 0.0.59

--- a/packages/coil-extension/test/fixtures/event-logger.html
+++ b/packages/coil-extension/test/fixtures/event-logger.html
@@ -61,12 +61,18 @@
         // For testing checklist
         const removeThenAddQuicklyToCheckStoppedEventHasCorrectRequestId =
           () => {
+            log('SETTING induce stop timeout')
             setTimeout(() => {
+              log('REMOVING tag')
               remove()
+              log('ADDING back tag')
               add()
             }, 10000)
           }
-        // removeThenAddQuicklyToCheckStoppedEventHasCorrectRequestId()
+
+        if (window.location.hash === '#induce') {
+          removeThenAddQuicklyToCheckStoppedEventHasCorrectRequestId()
+        }
 
         document.getElementById('remove').addEventListener('click', remove)
         document.getElementById('add').addEventListener('click', add)


### PR DESCRIPTION
## Chores

- [x] Make sure the manifest version was bumped but doesn't skip versions

- [x] Update the [apktool.yml](../six-apktool-decoded/apktool.yml) versionCode/versionName
      and commit it to the repository.

- [x] Update the [CHANGELOG.md](../CHANGELOG.md)

  - You can compare with latest commit before tagging via something like:
    https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.58...main
    (substitute release branch name for "main")

- [x] Review/merge in #2836 on top of main and rebase on top of main
  - [x] would mean testing again, so test with Firefox next

## MacOS Firefox 100.0.2 (64-bit)

Copy below for each platform/browser/version tested, filtering steps where it
make sense.

- [x] Build for prod with release settings

  - e.g. `yarn build-prod chrome -p --run-prod --devtool=none`
    - as per [package.sh](../package.sh)

- [x] Import unpacked/temporary extension/add-on

  - For Firefox, go to `about:debugging`
    - Enable add-on debugging
    - Load Temporary Add-on...
  - For Chrome or MS Edge, go to `chrome://extensions` (or `edge://extensions`) and `Load Unpacked`
  - Use `adb` to install Samsung Internet Extensions
    - be sure to kill the browser and delete shared settings to be sure correct addon is tested
    - see code in `scripts/reinstall-six.sh`

- [x] Ensure that you are [logged in with a user with valid subscription](https://coil.com/settings/membership)

  - ![image](https://user-images.githubusercontent.com/525211/71150879-28d04300-2265-11ea-96da-7d720c101575.png)
    (or trial)

- [x] [example.com](http://example.com/) should say "Streaming not enabled"

  - ![image](https://user-images.githubusercontent.com/525211/154630950-e179eb7c-cf62-4a8c-b1b5-aa033f1ff57f.png)

- [x] [xrptipbot.com](https://www.xrptipbot.com/) should monetize

  - ![image](https://user-images.githubusercontent.com/525211/154631133-1be5f080-858f-4984-9548-1b5b405471b7.png)

-
- [x] [twitch.tv](https://twitch.tv/vinesauce) works

  - <img width="355" alt="image" src="https://user-images.githubusercontent.com/525211/167336900-740809a6-4134-4f33-8f33-e3d45bd30f25.png">

- [x] [monetized youtube video](https://www.youtube.com/watch?v=8EKg_rBWZdc)

  - <img width="411" alt="image" src="https://user-images.githubusercontent.com/525211/167337147-6b8c430f-fbcc-4a34-ac42-550cb56b0632.png">

- Coil welcome and welcome to explore pages

  - [x] Go to coil.com, the browser action popup should show "Welcome, $username"
    - <img width="336" alt="image" src="https://user-images.githubusercontent.com/525211/167337854-ba1dcb84-ec9d-434b-8e5e-1bb0b047efbc.png">
  - [x] Should have a link to coil.com/discover page
  - [x] Once on explore page should show `Discover Now` with a rocket-ship graphic
    - ![image](https://user-images.githubusercontent.com/525211/126276807-f39ac03f-6c2b-419c-8a79-e2f2859b44a9.png)

- [x] Check the monetization animation works properly

  - <img width="355" alt="image" src="https://user-images.githubusercontent.com/525211/167338973-a4726572-dca9-4c46-ac67-e5d8457c34f2.png">
  - Only required on desktop browsers
  - Should animate when monetized and packets received
  - Should stop animation when network disconnected
    - Note that on Firefox/MacOS the popup automatically closes when the
      tab loses focus so can use something like this in terminal:
      - `sudo sleep 10 && sudo ifconfig en0 down && sleep 10 && sudo ifconfig en0 up`

- [x] Check monetization works consistently

  - In the same tab, go to http://www.travisvcrist.com/gatehub
    - refresh and make sure streaming works 10 times in a row
      - should not get 'stuck' in 'setting up payment' state
  - Issue: [coil/coilhq#3038][ci3038]
  - Fix PRs: [#242][np242]



- [x] Will route to \$coildomain.com/login rather than open popup if logged out

  - Log out from \$coildomain.com
  - Check that icon is in 'unavailable' state
    - ![image](https://user-images.githubusercontent.com/525211/126277431-a7ae73a2-14a6-41b4-90f4-69f2b9be6df5.png)
  - Click on browser action
  - Check that routed to login page
    - ![image](https://user-images.githubusercontent.com/525211/126277570-77da3644-9950-465d-bac0-4afbd33a70e4.png)

- [x] Go to a [youtube video](https://www.youtube.com/watch?v=l1btEwwRePs),
      manually skip to near end of video, and when autoplay of a video from
      another channel starts, check that monetization has stopped.

  - Issues: [#33][i33]
  - PRs: [#213][np213]

- [x] Go to [xrptipbot.com](https://www.xrptipbot.com/) and as page
      is loading very quickly open the popup.
      It should show "Thank you" even before streaming
      starts. The animation should play when the streaming starts and
      the outlined circle should become solid green in the toolbar icon.
      [#120][i120]

- [x] Open the [reloading-every-15s.html](http://localhost:4000/reloading-every-15s.html) file:

  - Use a localhost server so WM works (e.g. with `yarn serve:fixtures`)
  - Open the developer tools console undocked so can view while **PAGE IS BACKGROUNDED**
    - Note the `Reloading page` logging
  - Open the extension background page developer tools and look at the stream logging
  - SHOULD NOT initiate a stream or SPSP request
    [#144][i144]

- [x] Open the [event-logger.html](../test/fixtures/event-logger.html) file:

  - Use a localhost server so WM works (e.g. with `python -m http.server 4000`)
  - Look for unusual timings, check that pending state is emitted nearly
    immediately after page load or meta tag added
  - Issue: [#63][ni63]
  - Fix PR: [#69][np69]

- [x] Check started event fires when quickly switching between tabs

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Switch to another (non-monetized) tab. The payments stop. Quickly switch back to the first tab.
  - The payments restart. Make sure there is a monetizationstart event
  - Issue: [#105][ni105]
  - Fix PR: [#117][np117]

- [x] Check stopped event fires with correct requestId

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Induce a stop/start in same js 'tick'
  - Check that the stopped event has the correct requestId
  - Issue: [#127][ni127]
  - Fix PR: [#128][np128]

- [x] Check tip event fires when clicked on in the popup

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Open the extension popup and click on "Send \$1!" in the tipping tab
  - Check that the tip event occurs

- [x] Run a local web server (with `yarn run serve:dist`) serving
      the dist folder, then open [static/popup.html](static/popup.html) in a
      normal tab and check the popup rendering in various states.

- [x] Check that popup closes when another window is focused

  - Open two Browser windows, open the popup in one window
  - Focus on second window
  - Ensure that popup is closed

  - Issue: [#313][i313]
  - Fix PR: [#332][p332]

## MacOS Chrome Version 101.0.4951.54 (Official Build) (x86_64)

- [x] Import unpacked/temporary extension/add-on

  - For Firefox, go to `about:debugging`
    - Enable add-on debugging
    - Load Temporary Add-on...
  - For Chrome or MS Edge, go to `chrome://extensions` (or `edge://extensions`) and `Load Unpacked`
  - Use `adb` to install Samsung Internet Extensions
    - be sure to kill the browser and delete shared settings to be sure correct addon is tested
    - see code in `scripts/reinstall-six.sh`

- [x] Ensure that you are [logged in with a user with valid subscription](https://coil.com/settings/membership)

  - ![image](https://user-images.githubusercontent.com/525211/71150879-28d04300-2265-11ea-96da-7d720c101575.png)
    (or trial)

- [x] [example.com](http://example.com/) should say "Streaming not enabled"

  - ![image](https://user-images.githubusercontent.com/525211/154630950-e179eb7c-cf62-4a8c-b1b5-aa033f1ff57f.png)

- [x] [xrptipbot.com](https://www.xrptipbot.com/) should monetize

  - ![image](https://user-images.githubusercontent.com/525211/154631133-1be5f080-858f-4984-9548-1b5b405471b7.png)

-
- [x] [twitch.tv](https://twitch.tv/vinesauce) works

  - <img width="355" alt="image" src="https://user-images.githubusercontent.com/525211/167336900-740809a6-4134-4f33-8f33-e3d45bd30f25.png">

- [x] [monetized youtube video](https://www.youtube.com/watch?v=8EKg_rBWZdc)

  - <img width="411" alt="image" src="https://user-images.githubusercontent.com/525211/167337147-6b8c430f-fbcc-4a34-ac42-550cb56b0632.png">

- Coil welcome and welcome to explore pages

  - [x] Go to coil.com, the browser action popup should show "Welcome, $username"
    -  <img width="336" alt="image" src="https://user-images.githubusercontent.com/525211/167337854-ba1dcb84-ec9d-434b-8e5e-1bb0b047efbc.png">

    - **TESTERS NOTE** <img width="375" alt="image" src="https://user-images.githubusercontent.com/525211/167337369-6766ad0a-4b67-41e9-9e94-3416819b660f.png">
      - It shows the tipping view in a 'can not tip' configuration
  - [x] Should have a link to coil.com/discover page
  - [x] Once on explore page should show `Discover Now` with a rocket-ship graphic
    - <img width="346" alt="image" src="https://user-images.githubusercontent.com/525211/167338107-652ef492-2170-4765-9235-616f6ff9f2fe.png">

- [x] Check the monetization animation works properly

  - <img width="355" alt="image" src="https://user-images.githubusercontent.com/525211/167338973-a4726572-dca9-4c46-ac67-e5d8457c34f2.png">
  - Only required on desktop browsers
  - Should animate when monetized and packets received
  - Should stop animation when network disconnected
    - Note that on Firefox/MacOS the popup automatically closes when the
      tab loses focus so can use something like this in terminal:
      - `sudo sleep 10 && sudo ifconfig en0 down && sleep 10 && sudo ifconfig en0 up`

- [x] Check monetization works consistently

  - In the same tab, go to http://www.travisvcrist.com/gatehub
    - refresh and make sure streaming works 10 times in a row
      - should not get 'stuck' in 'setting up payment' state
  - Issue: [coil/coilhq#3038][ci3038]
  - Fix PRs: [#242][np242]

- [x] Will route to \$coildomain.com/login rather than open popup if logged out

  - Log out from \$coildomain.com
  - Check that icon is in 'unavailable' state
    - ![image](https://user-images.githubusercontent.com/525211/126277431-a7ae73a2-14a6-41b4-90f4-69f2b9be6df5.png)
  - Click on browser action
  - Check that routed to login page
    - ![image](https://user-images.githubusercontent.com/525211/126277570-77da3644-9950-465d-bac0-4afbd33a70e4.png)

- [x] Run the puppeteer [tests](./test.sh) (look at the [circle jobs](../../../.circleci/config.yml))

  - export BROWSER_TYPE='chrome' # or 'firefox'

- [x] Go to a [youtube video](https://www.youtube.com/watch?v=l1btEwwRePs),
      manually skip to near end of video, and when autoplay of a video from
      another channel starts, check that monetization has stopped.

  - Issues: [#33][i33]
  - PRs: [#213][np213]

- [x] Go to [xrptipbot.com](https://www.xrptipbot.com/) and as page
      is loading very quickly open the popup.
      It should show "Thank you" even before streaming
      starts. The animation should play when the streaming starts and
      the outlined circle should become solid green in the toolbar icon.
      [#120][i120]

- [x] Open the [reloading-every-15s.html](http://localhost:4000/reloading-every-15s.html) file:

  - Use a localhost server so WM works (e.g. with `yarn serve:fixtures`)
  - Open the developer tools console undocked so can view while **PAGE IS BACKGROUNDED**
    - Note the `Reloading page` logging
  - Open the extension background page developer tools and look at the stream logging
  - SHOULD NOT initiate a stream or SPSP request
    [#144][i144]

- [x] Open the [event-logger.html](../test/fixtures/event-logger.html) file:

  - Use a localhost server so WM works (e.g. with `python -m http.server 4000`)
  - Look for unusual timings, check that pending state is emitted nearly
    immediately after page load or meta tag added
  - Issue: [#63][ni63]
  - Fix PR: [#69][np69]

- [x] Check started event fires when quickly switching between tabs

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Switch to another (non-monetized) tab. The payments stop. Quickly switch back to the first tab.
  - The payments restart. Make sure there is a monetizationstart event
  - Issue: [#105][ni105]
  - Fix PR: [#117][np117]

- [x] Check stopped event fires with correct requestId

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Induce a stop/start in same js 'tick'
  - Check that the stopped event has the correct requestId
  - Issue: [#127][ni127]
  - Fix PR: [#128][np128]

- [x] Check tip event fires when clicked on in the popup

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Open the extension popup and click on "Send \$1!"
  - Check that the tip event occurs
  - **TESTERS NOTE** 

- [x] Run a local web server (e.g. with `python -m http.server 4000`) serving
      the dist folder, then open [static/popup.html](static/popup.html) in a
      normal tab and check the popup rendering in various states.

- [x] On MacOS Chromium browsers (Chrome/Edge) check that the monetized animation is working
      on non primary monitors.

  - Issue: [#312][i312]
  - Fix PR: [#317][p317]

- [x] Check that popup closes when another window is focused

  - Open two Browser windows, open the popup in one window
  - Focus on second window
  - Ensure that popup is closed

  - Issue: [#313][i313]
  - Fix PR: [#332][p332]

- [x] Check extension doesn't attempt to stream when unsubscribed

  - Log in with coil user that doesn't have active subscription
  - Open the developer tools and check the logging
  - SHOULD NOT even attempt to stream
  - ![image](https://user-images.githubusercontent.com/525211/66631124-c9840000-ec2f-11e9-95a4-3bebe7fdebd6.png)
  - Issue: [#213][i213]
  - Fix PR: [#222][p222]

- [x] Check can stream immediately after subscribing

  - Likely best to test this with staging where can use a test card
  - Log in with coil user that doesn't have active subscription
  - Add a subscription (can use [testing card](https://stripe.com/docs/testing) 4242 4242 4242 4242 )
  - Go to a monetized page and check that streaming works immediately

- [x] Check no stop event is fired when logged out

  - Open and console and set `localStorage.WM_DEBUG = true`
  - Go to a web monetized page when logged out
  - Check that no events are logged

  - Issue: [#1947][ni1947]
  - Fix PR: [#1964][np1964]

### Iframe testing

1. - [x] Open a terminal and `cd packages/coil-extension/test/fixtures/iframes/`
2. - [x] Start a server (via `python -m http.server 4000` or equivalent)
3. - [x] Open http://localhost:4000/top-nested-allowed-iframe.html in browser
4. Open developer tools and look at the structure of the dom

- Use expand recursively feature
  - ![image](https://user-images.githubusercontent.com/525211/76400168-71098800-63b2-11ea-8069-5ee7b8b0707a.png)

5. - [x] With the console set `localStorage.WM_DEBUG = true`

#### Test 1: basic monetization

1. Load the page
2. - [x] Look for 4 monetizationpending events and 4 corresponding (same requestId) monetizationstart events logged in the console.

![image](https://user-images.githubusercontent.com/525211/76397844-6a791180-63ae-11ea-8f1c-72ef3a6183fb.png)

#### Test 2: refresh page / turn off / turn on

1. - [x] [re]load the page
2. - [x] Open developer tools and turn "off" monetization via editing allow attribute of top level iframes
   - ![image](https://user-images.githubusercontent.com/525211/76398261-28040480-63af-11ea-85cb-396960ced1bb.png)
   - Popup icon (and background page logging) should show no monetization:
     - [x] ![image](https://user-images.githubusercontent.com/525211/76398281-305c3f80-63af-11ea-857c-6ab6b409daa5.png)
   - Corresponding monetization events should be logged:
     - [x] ![image](https://user-images.githubusercontent.com/525211/76398873-3999dc00-63b0-11ea-8ee6-7ca45d8b44f0.png)

3. turn "on" monetization via editing allow attribute of top level iframes
   - ![image](https://user-images.githubusercontent.com/525211/76398370-57b30c80-63af-11ea-86a8-133271e46b91.png)
   - [x] Popup icon (and background page logging) should show monetization
     - ![image](https://user-images.githubusercontent.com/525211/76398417-6d283680-63af-11ea-88e6-c4b0ed5c35f7.png)
   - [x] Corresponding monetization events should be logged:
     - ![image](https://user-images.githubusercontent.com/525211/76399026-841b5880-63b0-11ea-8b0b-c0ecbff13bee.png)

#### Test 3: refresh page / turn off / background tab / turn on / foreground tab

- As above but while the tab is backgrounded, after turning on each top level iframe a sequence of pending -> stopped events should be fired:
  - [x] ![image](https://user-images.githubusercontent.com/525211/76399956-1a03b300-63b2-11ea-9b77-671e94a1bf16.png)

#### Test 4: nested

- As per test 2
- Turn off one top level and then turn off the nested frames in top level that is allowed
- [x] allow _one_ nested iframe and check for indications of monetization

[i33]: https://github.com/coilhq/web-monetization/issues/33
[i120]: https://github.com/coilhq/web-monetization/issues/120
[i144]: https://github.com/coilhq/web-monetization/issues/144
[p166]: https://github.com/coilhq/web-monetization/pull/166
[i213]: https://github.com/coilhq/web-monetization/issues/213
[p222]: https://github.com/coilhq/web-monetization/pull/222
[p295]: https://github.com/coilhq/web-monetization/pull/295
[ci2084]: https://github.com/coilhq/coil/issues/2084
[ci3038]: https://github.com/coilhq/coil/issues/3038
[i312]: https://github.com/coilhq/web-monetization/issues/312
[p317]: https://github.com/coilhq/web-monetization/pull/317
[i313]: https://github.com/coilhq/web-monetization/issues/313
[p332]: https://github.com/coilhq/web-monetization/pull/332
[i507]: https://github.com/coilhq/web-monetization/issues/507
[p508]: https://github.com/coilhq/web-monetization/pull/508
[np28]: https://github.com/coilhq/web-monetization-projects/pull/28
[ni21]: https://github.com/coilhq/web-monetization-projects/issue/21
[ni63]: https://github.com/coilhq/web-monetization-projects/issue/63
[np69]: https://github.com/coilhq/web-monetization-projects/pull/69
[ni105]: https://github.com/coilhq/web-monetization-projects/issue/105
[np117]: https://github.com/coilhq/web-monetization-projects/pull/117
[ni127]: https://github.com/coilhq/web-monetization-projects/issue/127
[np128]: https://github.com/coilhq/web-monetization-projects/pull/128
[ni184]: https://github.com/coilhq/web-monetization-projects/issue/184
[np185]: https://github.com/coilhq/web-monetization-projects/pull/185
[np213]: https://github.com/coilhq/web-monetization-projects/pull/213
[np242]: https://github.com/coilhq/web-monetization-projects/pull/242
[np1964]: https://github.com/coilhq/web-monetization-projects/pull/1964
[ni1947]: https://github.com/coilhq/web-monetization-projects/issue/1947
