### PR TITLE
chore(coil-extension): bump version to 0.0.60

### DIFF
--- a/packages/coil-extension/CHANGELOG.md
+++ b/packages/coil-extension/CHANGELOG.md
@@ -1,5 +1,40 @@
 - <a name="coil-extension@0.0.59"></a>
 
+# [coil-extension@0.0.60](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.59...coil-extension@0.0.60) (2021-08-11)
+
+### New Features
+
+- Add implementation of WM2
+  - [#2424](https://github.com/coilhq/web-monetization-projects/pull/2424)
+  - [#3102](https://github.com/coilhq/web-monetization-projects/pull/3102)
+  - [#3139](https://github.com/coilhq/web-monetization-projects/pull/3139)
+- Add initial support for MV3
+  - [#3048](https://github.com/coilhq/web-monetization-projects/pull/3048)
+  - [#3059](https://github.com/coilhq/web-monetization-projects/pull/3059)
+  - [#3057](https://github.com/coilhq/web-monetization-projects/pull/3057)
+  - [#3070](https://github.com/coilhq/web-monetization-projects/pull/3070)
+  - [#3072](https://github.com/coilhq/web-monetization-projects/pull/3072)
+  - [#3080](https://github.com/coilhq/web-monetization-projects/pull/3080)
+  - [#3086](https://github.com/coilhq/web-monetization-projects/pull/3086)
+  - [#3113](https://github.com/coilhq/web-monetization-projects/pull/3113)
+  - [#3116](https://github.com/coilhq/web-monetization-projects/pull/3116)
+  - [#3126](https://github.com/coilhq/web-monetization-projects/pull/3126)
+  - [#3127](https://github.com/coilhq/web-monetization-projects/pull/3127)
+  - [#3154](https://github.com/coilhq/web-monetization-projects/pull/3154)
+  - [#3168](https://github.com/coilhq/web-monetization-projects/pull/3168)
+  - [#3170](https://github.com/coilhq/web-monetization-projects/pull/3170)
+
+### Fixes
+
+- Support building without git folder [#3117](https://github.com/coilhq/web-monetization-projects/pull/3117) [#3128](https://github.com/coilhq/web-monetization-projects/pull/3128)
+- Revert workarounds for early buggy versions of Safari [#3075](https://github.com/coilhq/web-monetization-projects/pull/3075)
+- Don't open coil.com/settings for popup on Samsung Internet [#2858](<(https://github.com/coilhq/web-monetization-projects/pull/2858)>)
+- Remove old stream controls UI code [#3068](https://github.com/coilhq/web-monetization-projects/pull/3068)
+- Show popup last view if tipping shown [#3082](https://github.com/coilhq/web-monetization-projects/pull/3082)
+- Don't use localStorage directly [#2864](https://github.com/coilhq/web-monetization-projects/pull/2864)
+
+- <a name="coil-extension@0.0.59"></a>
+
 # [coil-extension@0.0.59](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.58...coil-extension@0.0.59) (2021-05-09)
 
 ### New Features

--- a/packages/coil-extension/manifest.json
+++ b/packages/coil-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Coil",
   "description": "Support websites and creators with Web Monetization",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "manifest_version": 2,
   "content_security_policy": "script-src 'self' 'sha256-POLYFILL-HASH='; object-src 'self'",
   "browser_specific_settings": {

--- a/packages/coil-extension/package.json
+++ b/packages/coil-extension/package.json
@@ -1,10 +1,10 @@
 {
   "$schema": "../coil-monorepo-upkeep/resources/package-json-schema-nested-overrides.json",
   "$overRideUpKeep": {
-    "version": "0.0.59"
+    "version": "0.0.60"
   },
   "name": "@coil/extension",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "keywords": [
     "ilp",
     "web-monetization"

--- a/packages/coil-extension/six-apktool-decoded/apktool.yml
+++ b/packages/coil-extension/six-apktool-decoded/apktool.yml
@@ -18,5 +18,5 @@ usesFramework:
   tag: null
 version: 2.4.1
 versionInfo:
-  versionCode: '60'
-  versionName: 0.0.59
+  versionCode: '61'
+  versionName: 0.0.60


### PR DESCRIPTION
## Chores

- [x] Make sure the manifest version was bumped but doesn't skip versions

- [x] Update the [apktool.yml](../six-apktool-decoded/apktool.yml) versionCode/versionName
      and commit it to the repository.

- [x] Update the [CHANGELOG.md](../CHANGELOG.md)

  - You can compare with latest commit before tagging via something like:
    - https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.59...nd-bump-version-60-2022-08-11

## MacOS Chrome Version 104.0.5112.79 (Official Build) (x86_64)

Copy below for each platform/browser/version tested, filtering steps where it
makes sense.

- [x] Build for prod with release settings

  - e.g. `yarn build-prod chrome -p --run-prod --devtool=none`
    - as per [package.sh](../package.sh)

- [x] Import unpacked/temporary extension/add-on

  - For Firefox, go to `about:debugging`
    - Enable add-on debugging
    - Load Temporary Add-on...
  - For Chrome or MS Edge, go to `chrome://extensions` (or `edge://extensions`) and `Load Unpacked`
  - Use `adb` to install Samsung Internet Extensions
    - be sure to kill the browser and delete shared settings to be sure correct addon is tested
    - see code in `scripts/reinstall-six.sh`

- [x] Ensure that you are [logged in with a user with valid subscription](https://coil.com/settings/membership)

  - ![image](https://user-images.githubusercontent.com/525211/71150879-28d04300-2265-11ea-96da-7d720c101575.png)
    (or trial)

- [x] [example.com](http://example.com/) should say "Streaming not enabled"

  - ![image](https://user-images.githubusercontent.com/525211/154630950-e179eb7c-cf62-4a8c-b1b5-aa033f1ff57f.png)

- [x] [xrptipbot.com](https://www.xrptipbot.com/) should monetize

  - ![image](https://user-images.githubusercontent.com/525211/154631133-1be5f080-858f-4984-9548-1b5b405471b7.png)

-
- [x] [twitch.tv](https://twitch.tv/vinesauce) works

  - <img width="355" alt="image" src="https://user-images.githubusercontent.com/525211/167336900-740809a6-4134-4f33-8f33-e3d45bd30f25.png">

- [x] [monetized youtube video](https://www.youtube.com/watch?v=8EKg_rBWZdc)

  - <img width="411" alt="image" src="https://user-images.githubusercontent.com/525211/167337147-6b8c430f-fbcc-4a34-ac42-550cb56b0632.png">

- Coil welcome and welcome to explore pages

  - [x] Go to coil.com, the browser action popup should show "Welcome, $username"
    - <img width="336" alt="image" src="https://user-images.githubusercontent.com/525211/167337854-ba1dcb84-ec9d-434b-8e5e-1bb0b047efbc.png">
  - [x] Should have a link to coil.com/discover page
  - [x] Once on discover page should show `Discover Now` with a rocket-ship graphic
    - ![image](https://user-images.githubusercontent.com/525211/126276807-f39ac03f-6c2b-419c-8a79-e2f2859b44a9.png)

- [x] Check the monetization animation works properly

  - <img width="355" alt="image" src="https://user-images.githubusercontent.com/525211/167338973-a4726572-dca9-4c46-ac67-e5d8457c34f2.png">
  - Only required on desktop browsers
  - Should animate when monetized and packets received
  - Should stop animation when network disconnected
    - Note that on Firefox/MacOS the popup automatically closes when the
      tab loses focus so can use something like this in terminal:
      - `sudo sleep 10 && sudo ifconfig en0 down && sleep 10 && sudo ifconfig en0 up`

- [x] Check monetization works consistently

  - In the same tab, go to http://www.travisvcrist.com/gatehub
    - refresh and make sure streaming works 10 times in a row
      - should not get 'stuck' in 'setting up payment' state
  - Issue: [coil/coilhq#3038][ci3038]
  - Fix PRs: [#242][np242]

- [x] Will route to \$coildomain.com/login rather than open popup if logged out

  - Log out from \$coildomain.com
  - Check that icon is in 'unavailable' state
    - ![image](https://user-images.githubusercontent.com/525211/126277431-a7ae73a2-14a6-41b4-90f4-69f2b9be6df5.png)
  - Click on browser action
  - Check that routed to login page
    - ![image](https://user-images.githubusercontent.com/525211/126277570-77da3644-9950-465d-bac0-4afbd33a70e4.png)

- [x] Run the puppeteer [tests](./test.sh) (look at the [circle jobs](../../../.circleci/config.yml))

  - export BROWSER_TYPE='chrome' # or 'firefox'

- [x] Go to a [youtube video](https://www.youtube.com/watch?v=l1btEwwRePs),
      manually skip to near end of video, and when autoplay of a video from
      another channel starts, check that monetization has stopped.

  - Issues: [#33][i33]
  - PRs: [#213][np213]

- [x] Go to [xrptipbot.com](https://www.xrptipbot.com/) and as page
      is loading very quickly open the popup.
      It should show "Thank you" even before streaming
      starts. The animation should play when the streaming starts and
      the outlined circle should become solid green in the toolbar icon.
      [#120][i120]

- [x] Open the [reloading-every-15s.html](http://localhost:4000/reloading-every-15s.html) file:

  - Use a localhost server so WM works (e.g. with `yarn serve:fixtures`)
  - Open the developer tools console undocked so can view while **PAGE IS BACKGROUNDED**
    - Note the `Reloading page` logging
  - Open the extension background page developer tools and look at the stream logging
  - SHOULD NOT initiate a stream or SPSP request
    [#144][i144]

- [x] Open the [event-logger.html](../test/fixtures/event-logger.html) file:

  - Use a localhost server so WM works (e.g. with `python -m http.server 4000`)
  - Look for unusual timings, check that pending state is emitted nearly
    immediately after page load or meta tag added
  - Issue: [#63][ni63]
  - Fix PR: [#69][np69]

- [x] Check started event fires when quickly switching between tabs

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Switch to another (non-monetized) tab. The payments stop. Quickly switch back to the first tab.
  - The payments restart. Make sure there is a monetizationstart event
  - Issue: [#105][ni105]
  - Fix PR: [#117][np117]

- [x] Check stopped event fires with correct requestId

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Induce a stop/start in same js 'tick' (tack on #induce to end of url)
  - Check that the stopped event has the correct requestId
  - Issue: [#127][ni127]
  - Fix PR: [#128][np128]

- [x] Check tip event fires when clicked on in the popup

  - Open the [event-logger.html](../test/fixtures/event-logger.html) file
  - Open the extension popup and click on "Send \$1!" in the tipping tab
  - Check that the tip event occurs

- [x] Run a local web server (with `yarn run serve:dist`) serving
      the dist folder, then open [static/popup.html](static/popup.html) in a
      normal tab and check the popup rendering in various states.

- [x] If the browser is running on android, check that the "popup" browser action
      simply opens settings.

  - Install android-sdk on PC and Firefox on android
  - Enable developer mode on android and enable usb debugging
  - Plug in android to PC via usb
  - `adb devices # make note of device id`
  - `adb shell pm grant org.mozilla.firefox android.permission.READ_EXTERNAL_STORAGE`
  - `adb shell pm grant org.mozilla.firefox android.permission.WRITE_EXTERNAL_STORAGE`
  - Build the extension
  - `yarn web-ext run -s $PWD/dist --target=firefox-android --android-device=WUJ01PNSVY # from adb devices step`
  - Issue: [coil/coilhq#2084][ci2084]
  - Fix PRs: [#166][p166] [#295][p295]

- [x] On MacOS Chromium browsers (Chrome/Edge) check that the monetized animation is working
      on non primary monitors.

  - Issue: [#312][i312]
  - Fix PR: [#317][p317]

- [x] Check that popup closes when another window is focused

  - Open two Browser windows, open the popup in one window
  - Focus on second window
  - Ensure that popup is closed

  - Issue: [#313][i313]
  - Fix PR: [#332][p332]

- [x] Check extension doesn't attempt to stream when unsubscribed

  - Log in with coil user that doesn't have active subscription
  - Open the developer tools and check the logging
  - SHOULD NOT even attempt to stream
  - ![image](https://user-images.githubusercontent.com/525211/66631124-c9840000-ec2f-11e9-95a4-3bebe7fdebd6.png)
  - Issue: [#213][i213]
  - Fix PR: [#222][p222]

- [x] Check can stream immediately after subscribing

  - Likely best to test this with staging where can use a test card
  - Log in with coil user that doesn't have active subscription
  - Add a subscription (can use [testing card](https://stripe.com/docs/testing) 4242 4242 4242 4242 )
  - Go to a monetized page and check that streaming works immediately

- [x] Check no stop event is fired when logged out

  - Open and console and set `localStorage.WM_DEBUG = true`
  - Go to a web monetized page when logged out
  - Check that no events are logged

  - Issue: [#1947][ni1947]
  - Fix PR: [#1964][np1964]
