### PR TITLE
fix: acount corrected to account

### DIFF
--- a/packages/coil-extension/src/popup/components/views/SettingsView.tsx
+++ b/packages/coil-extension/src/popup/components/views/SettingsView.tsx
@@ -151,7 +151,7 @@ export const SettingsView = () => {
           </div>
         </ProfileContainer>
 
-        <SettingsButton onClick={tabOpener(`${coilDomain}/settings/acount`)}>
+        <SettingsButton onClick={tabOpener(`${coilDomain}/settings/account`)}>
           <PersonIcon />
           <span className='title'>Account</span>
           <span className='icon-open'>


### PR DESCRIPTION
This PR corrects the typo in the extension that routes to `acount` instead of `account`.  It appears that it's already fixed on the backend as you can see that when you arrive at `acount` you're redirected to `account`.  This PR should make that redirection unnecessary. The GIF below illustrates what happens now, should this PR be merged, the redirect you see at present should not happen.

![acount-to-account](https://user-images.githubusercontent.com/1010525/190888664-a893148d-1cfc-48a7-b6df-23f8fca6e6ea.gif)

