### PR TITLE
chore(coil-extension): bump version to 0.0.63

### DIFF
--- a/packages/coil-extension/CHANGELOG.md
+++ b/packages/coil-extension/CHANGELOG.md
@@ -1,8 +1,14 @@
+- <a name="coil-extension@0.0.63"></a>
+
+# [coil-extension@0.0.63](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.62...coil-extension@0.0.63) (2021-10-04)
+
+### Bug Fixes / Enhancements
+
+- Disable Twitch.tv integration [#3379](https://github.com/coilhq/web-monetization-projects/pull/3379)
+- Remove workaround for popup not animating on non-primary monitors [#3380](https://github.com/coilhq/web-monetization-projects/pull/3380)
 - <a name="coil-extension@0.0.62"></a>
 
-# [coil-extension@0.0.61](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.61...coil-extension@0.0.62) (2021-09-21)
-
-### New Features
+# [coil-extension@0.0.62](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.61...coil-extension@0.0.62) (2021-09-21)
 
 ### Bug Fixes / Enhancements
 

--- a/packages/coil-extension/CHANGELOG.md
+++ b/packages/coil-extension/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Disable Twitch.tv integration [#3379](https://github.com/coilhq/web-monetization-projects/pull/3379)
 - Remove workaround for popup not animating on non-primary monitors [#3380](https://github.com/coilhq/web-monetization-projects/pull/3380)
+
 - <a name="coil-extension@0.0.62"></a>
 
 # [coil-extension@0.0.62](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.61...coil-extension@0.0.62) (2021-09-21)

--- a/packages/coil-extension/manifest.json
+++ b/packages/coil-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Coil",
   "description": "Support websites and creators with Web Monetization",
-  "version": "0.0.62",
+  "version": "0.0.63",
   "manifest_version": 2,
   "content_security_policy": "script-src 'self' 'sha256-POLYFILL-HASH='; object-src 'self'",
   "browser_specific_settings": {

--- a/packages/coil-extension/package.json
+++ b/packages/coil-extension/package.json
@@ -1,10 +1,10 @@
 {
   "$schema": "../coil-monorepo-upkeep/resources/package-json-schema-nested-overrides.json",
   "$overRideUpKeep": {
-    "version": "0.0.62"
+    "version": "0.0.63"
   },
   "name": "@coil/extension",
-  "version": "0.0.62",
+  "version": "0.0.63",
   "keywords": [
     "ilp",
     "web-monetization"


### PR DESCRIPTION
See [changes](https://github.com/coilhq/web-monetization-projects/compare/coil-extension@0.0.62...nd-remove-macos-workaround-2022-10-04)
- [x] Merge #3379 
  - [x] blogpost url is currently 404